### PR TITLE
Add empty postcss config to make examples runnable

### DIFF
--- a/examples/postcss.config.js
+++ b/examples/postcss.config.js
@@ -1,0 +1,1 @@
+export default { }


### PR DESCRIPTION
Trying to run the 01_counter example straight out of the example folder I got this error message in my terminal

![image](https://github.com/dai-shi/waku/assets/30793/87608d4a-9492-484d-88ca-c42943f2c93a)
```
[vite] Internal server error: [postcss] Cannot read properties of undefined (reading 'config')
  Plugin: vite:css
  File: /Users/tobbe/dev/waku/examples/01_counter/index.html?html-proxy&direct&index=0.css
      at getTailwindConfig (/Users/tobbe/dev/waku/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:87:62)
      at /Users/tobbe/dev/waku/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:99:92
      at /Users/tobbe/dev/waku/node_modules/tailwindcss/lib/processTailwindFeatures.js:48:11
      at plugins (/Users/tobbe/dev/waku/node_modules/tailwindcss/lib/plugin.js:38:63)
      at LazyResult.runOnRoot (/Users/tobbe/dev/waku/examples/01_counter/node_modules/postcss/lib/lazy-result.js:339:16)
      at LazyResult.runAsync (/Users/tobbe/dev/waku/examples/01_counter/node_modules/postcss/lib/lazy-result.js:393:26)
      at LazyResult.async (/Users/tobbe/dev/waku/examples/01_counter/node_modules/postcss/lib/lazy-result.js:221:30)
      at LazyResult.then (/Users/tobbe/dev/waku/examples/01_counter/node_modules/postcss/lib/lazy-result.js:206:17)
```

As you can see PostCSS is trying to load Tailwind. This is because it's picking up on the `postcss.config.js` file in the root of the project, that has this config
```
export default {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  }
}
```

Adding a config file in the `/examples` directory stops PostCSS from traversing further up the directory tree, and because the config is empty it doesn't try to load Tailwind.

So with this change you can go in to the 01_counter example directory and run `yarn install` and then `yarn dev` and successfully run the example.