### PR TITLE
fix: rscPrefix config without trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix: rscPrefix config without trailing slash #50
 
 ## [0.11.0] - 2023-05-25
 ### Changed

--- a/src/lib/rsc-handler-worker.ts
+++ b/src/lib/rsc-handler-worker.ts
@@ -262,7 +262,7 @@ async function getCustomModulesRSC(): Promise<{ [name: string]: string }> {
 // FIXME this may take too much responsibility
 async function buildRSC(): Promise<void> {
   const config = await resolveConfig("build");
-  const basePath = config.base + config.framework.rscPrefix;
+  const basePrefix = config.base + config.framework.rscPrefix;
   const distEntriesFile = await getEntriesFile(config, true);
   const {
     default: { getBuilder },
@@ -302,8 +302,7 @@ async function buildRSC(): Promise<void> {
           config.root,
           config.build.outDir,
           config.framework.outPublic,
-          config.framework.rscPrefix,
-          decodeURIComponent(rscId),
+          config.framework.rscPrefix + decodeURIComponent(rscId),
           decodeURIComponent(`${searchParams}`)
         );
         fs.mkdirSync(path.dirname(destFile), { recursive: true });
@@ -359,7 +358,7 @@ async function buildRSC(): Promise<void> {
       }
       const code =
         generatePrefetchCode(
-          basePath,
+          basePrefix,
           Array.from(elements || []).flatMap(([rscId, props, skipPrefetch]) => {
             if (skipPrefetch) {
               return [];

--- a/src/lib/rsc-utils.ts
+++ b/src/lib/rsc-utils.ts
@@ -7,7 +7,7 @@ globalThis.__webpack_chunk_load__ = (id) => import(id).then((m) => globalThis.__
 globalThis.__webpack_require__ = (id) => globalThis.__waku_module_cache__.get(id);`;
 
 export const generatePrefetchCode = (
-  basePath: string,
+  basePrefix: string,
   entryItemsIterable: Iterable<readonly [rscId: string, props: unknown]>,
   moduleIds: Iterable<string>
 ) => {
@@ -29,7 +29,7 @@ ${rscIds
           const searchParams = new URLSearchParams();
           searchParams.set("props", serializedProps);
           return [
-            `'${serializedProps}': fetch('${basePath}${rscId}/${searchParams}')`,
+            `'${serializedProps}': fetch('${basePrefix}${rscId}/${searchParams}')`,
           ];
         })
         .join(",") +


### PR DESCRIPTION
To support uncommon config just in case.