### PR TITLE
fix: react-server condition for libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - fix: 'use client' warning #63
 - fix: collecting client modules #69
+- fix: react-server condition for libraries #71
 
 ## [0.11.2] - 2023-06-03
 ### Changed

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -47,11 +47,12 @@ const analyzeEntries = async (entriesFile: string) => {
       ),
     ],
     ssr: {
-      // FIXME Without this, waku/router isn't considered to have client
-      // entries, and "No client entry" error occurs.
-      // Unless we fix this, RSC-capable packages aren't supported.
-      // This also seems to cause problems with pnpm.
-      noExternal: ["waku"],
+      noExternal: /^(?!node:)/,
+      // FIXME this is very adhoc.
+      external: ["react", "minimatch"],
+    },
+    resolve: {
+      conditions: ["react-server"],
     },
     build: {
       write: false,
@@ -92,6 +93,9 @@ const buildServerBundle = async (
             .relative(path.join(config.root, "node_modules"), fname)
             .split("/")[0]!
       ),
+    },
+    resolve: {
+      conditions: ["react-server"],
     },
     build: {
       ssr: true,

--- a/src/lib/middleware/rsc/worker-impl.ts
+++ b/src/lib/middleware/rsc/worker-impl.ts
@@ -94,11 +94,12 @@ const vitePromise = createServer({
     }),
   ],
   ssr: {
-    // FIXME Without this, "use client" directive in waku/router/client
-    // is ignored, and some errors occur.
-    // Unless we fix this, RSC-capable packages aren't supported.
-    // This also seems to cause problems with pnpm.
-    noExternal: ["waku"],
+    noExternal: /^(?!node:)/,
+    // FIXME this is very adhoc.
+    external: ["react", "minimatch", "react-server-dom-webpack"],
+  },
+  resolve: {
+    conditions: ["react-server"],
   },
   appType: "custom",
 });


### PR DESCRIPTION
This avoids externalizing modules for rsc transforming.

With this `server-only` doesn't throw on server. (Probably a regression since #21.)
There's one issue though. It doesn't throw when building, but only when running the app.
Thanks to @lubieowoce.