### PR TITLE
fix: rename getBuilder to getBuildConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- fix: rename getBuilder to getBuildConfig #75
 
 ## [0.11.3] - 2023-06-10
 ### Changed

--- a/examples/01_counter/entries.ts
+++ b/examples/01_counter/entries.ts
@@ -10,7 +10,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/examples/02_async/entries.ts
+++ b/examples/02_async/entries.ts
@@ -10,7 +10,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/examples/03_promise/entries.ts
+++ b/examples/03_promise/entries.ts
@@ -10,7 +10,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/examples/04_callserver/entries.ts
+++ b/examples/04_callserver/entries.ts
@@ -10,7 +10,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/examples/05_mutation/entries.ts
+++ b/examples/05_mutation/entries.ts
@@ -10,7 +10,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/examples/06_nesting/entries.ts
+++ b/examples/06_nesting/entries.ts
@@ -12,7 +12,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {

--- a/src/lib/middleware/rsc.ts
+++ b/src/lib/middleware/rsc.ts
@@ -54,14 +54,14 @@ export function rsc(options: {
       }
     }
     if (rscId || rsfId) {
-      const pipeable = renderRSC(
+      const readable = renderRSC(
         rsfId
           ? rscId
             ? { rsfId, args, rscId, props }
             : { rsfId, args }
           : { rscId: rscId as string, props }
       );
-      pipeable.on("error", (err) => {
+      readable.on("error", (err) => {
         console.info("Cannot render RSC", err);
         res.statusCode = 500;
         if (options.mode === "development") {
@@ -70,7 +70,7 @@ export function rsc(options: {
           res.end();
         }
       });
-      pipeable.pipe(res);
+      readable.pipe(res);
       return;
     }
     next();

--- a/src/lib/middleware/rsc/worker-impl.ts
+++ b/src/lib/middleware/rsc/worker-impl.ts
@@ -58,10 +58,12 @@ const handleRender = async (mesg: MessageReq & { type: "render" }) => {
   }
 };
 
-const handleGetBuilder = async (mesg: MessageReq & { type: "getBuilder" }) => {
+const handleGetBuildConfig = async (
+  mesg: MessageReq & { type: "getBuildConfig" }
+) => {
   const { id } = mesg;
   try {
-    const output = await getBuilderRSC();
+    const output = await getBuildConfigRSC();
     const mesg: MessageRes = { id, type: "builder", output };
     parentPort!.postMessage(mesg);
   } catch (err) {
@@ -106,8 +108,8 @@ parentPort!.on("message", (mesg: MessageReq) => {
     shutdown();
   } else if (mesg.type === "render") {
     handleRender(mesg);
-  } else if (mesg.type === "getBuilder") {
-    handleGetBuilder(mesg);
+  } else if (mesg.type === "getBuildConfig") {
+    handleGetBuildConfig(mesg);
   }
 });
 
@@ -202,22 +204,22 @@ async function renderRSC(
   throw new Error("Unexpected input");
 }
 
-async function getBuilderRSC() {
+async function getBuildConfigRSC() {
   if (!resolvedConfig) {
     resolvedConfig = await resolveConfig("build");
   }
   const config = resolvedConfig;
   const distEntriesFile = await getEntriesFile();
   const {
-    default: { getBuilder },
+    default: { getBuildConfig },
   } = await (loadServerFile(distEntriesFile) as Promise<Entries>);
-  if (!getBuilder) {
+  if (!getBuildConfig) {
     console.warn(
-      "getBuilder is undefined. It's recommended for optimization and sometimes required."
+      "getBuildConfig is undefined. It's recommended for optimization and sometimes required."
     );
     return {};
   }
 
-  const output = await getBuilder(config.root, renderRSC);
+  const output = await getBuildConfig(config.root, renderRSC);
   return output;
 }

--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -2,13 +2,13 @@ import { Writable } from "node:stream";
 import { createElement, Fragment } from "react";
 import type { FunctionComponent } from "react";
 
-import type { GetEntry, GetBuilder } from "../server.js";
+import type { GetEntry, GetBuildConfig } from "../server.js";
 import type { RouteProps, LinkProps } from "./common.js";
 import { Child as ClientChild, Link as ClientLink } from "./client.js";
 
 const collectClientModules = async (
   pathStr: string,
-  unstable_renderRSC: Parameters<GetBuilder>[1]
+  unstable_renderRSC: Parameters<GetBuildConfig>[1]
 ) => {
   const url = new URL(pathStr, "http://localhost");
   const pathItems = url.pathname.split("/").filter(Boolean);
@@ -55,7 +55,7 @@ export function defineRouter(
     id: string
   ) => Promise<FunctionComponent | { default: FunctionComponent } | null>,
   getAllPaths: (root: string) => Promise<string[]>
-): { getEntry: GetEntry; getBuilder: GetBuilder } {
+): { getEntry: GetEntry; getBuildConfig: GetBuildConfig } {
   const getEntry = async (id: string) => {
     const mod = await getComponent(id);
     const component =
@@ -78,7 +78,7 @@ export function defineRouter(
     return RouteComponent;
   };
 
-  const getBuilder: GetBuilder = async (root, unstable_renderRSC) => {
+  const getBuildConfig: GetBuildConfig = async (root, unstable_renderRSC) => {
     const paths = (await getAllPaths(root)).map((item) =>
       item === "index" ? "/" : `/${item}`
     );
@@ -103,7 +103,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (pathname, search) => {
     );
   };
 
-  return { getEntry, getBuilder };
+  return { getEntry, getBuildConfig };
 }
 
 export function Link(props: LinkProps) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ export type RenderInput =
       args: unknown[];
     };
 
-export type GetBuilder = (
+export type GetBuildConfig = (
   root: string,
   unstable_renderRSC: (
     input: RenderInput,
@@ -38,6 +38,9 @@ export type GetBuilder = (
   };
 }>;
 
-export function defineEntries(getEntry: GetEntry, getBuilder?: GetBuilder) {
-  return { getEntry, getBuilder };
+export function defineEntries(
+  getEntry: GetEntry,
+  getBuildConfig?: GetBuildConfig
+) {
+  return { getEntry, getBuildConfig };
 }

--- a/website/routes/practices/minimal.tsx
+++ b/website/routes/practices/minimal.tsx
@@ -47,7 +47,7 @@ export default defineEntries(
         return null;
     }
   },
-  // getBuilder
+  // getBuildConfig
   async () => {
     return {
       "/": {
@@ -112,14 +112,14 @@ export default function Layout() {
       <article className="mt-6">
         <div className="my-1">
           In addition to the <Code>getEntry</Code> function, you can also
-          optionally specify <Code>getBuilder</Code> function in{" "}
+          optionally specify <Code>getBuildConfig</Code> function in{" "}
           <Code>entries.ts</Code>. Here&apos;s an example:
         </div>
         <div className="my-3">
           <CodeBlock lang="tsx">{code4}</CodeBlock>
         </div>
         <div className="my-1">
-          The <Code>getBuilder</Code> function is used for build-time
+          The <Code>getBuildConfig</Code> function is used for build-time
           optimization. It renders React Server Components during the build
           process to produce the output that will be sent to the client. Note
           that rendering here means to produce RSC payload not HTML content.

--- a/website/routes/practices/router.tsx
+++ b/website/routes/practices/router.tsx
@@ -90,8 +90,8 @@ export default function Layout() {
       <article className="mt-6">
         <div className="my-1">
           In <Code>entries.ts</Code>, we use <Code>defineRouter</Code> to export{" "}
-          <Code>getEntry</Code> and <Code>getBuilder</Code> at once. Here&apos;s
-          a simple example code without builder:
+          <Code>getEntry</Code> and <Code>getBuildConfig</Code> at once.
+          Here&apos;s a simple example code without builder:
         </div>
         <div className="my-3">
           <CodeBlock lang="tsx">{code2}</CodeBlock>


### PR DESCRIPTION
It's mostly refactoring, but it's a public api name as well.
It's not breaking if we use `defineEntries`.