### PR TITLE
feat: support 404 for rsc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - fix: rename getBuilder to getBuildConfig #75
+- feat: support 404 for rsc #76
 
 ## [0.11.3] - 2023-06-10
 ### Changed

--- a/examples/07_router/routes/index.tsx
+++ b/examples/07_router/routes/index.tsx
@@ -44,7 +44,7 @@ const Index = ({ children }: { children: ReactNode }) => (
         <Link href="/nested/baz">Nested / Baz</Link>
       </li>
       <li>
-        <Link href="/nested/qux">Nested / Qux</Link>
+        <Link href="/nested/qux2">Nested / Qux</Link>
       </li>
     </ul>
     <h1>Home</h1>

--- a/examples/07_router/routes/index.tsx
+++ b/examples/07_router/routes/index.tsx
@@ -44,7 +44,7 @@ const Index = ({ children }: { children: ReactNode }) => (
         <Link href="/nested/baz">Nested / Baz</Link>
       </li>
       <li>
-        <Link href="/nested/qux2">Nested / Qux</Link>
+        <Link href="/nested/qux">Nested / Qux</Link>
       </li>
     </ul>
     <h1>Home</h1>

--- a/examples/07_router/src/ErrorBoundary.tsx
+++ b/examples/07_router/src/ErrorBoundary.tsx
@@ -6,19 +6,18 @@ interface Props {
   children: ReactNode;
 }
 
-class ErrorBoundaryClass extends Component<Props, { error?: any }> {
-  constructor(props: any) {
+class ErrorBoundaryClass extends Component<Props, { error?: unknown }> {
+  constructor(props: Props) {
     super(props);
     this.state = {};
   }
 
-  static getDerivedStateFromError(error: any) {
+  static getDerivedStateFromError(error: unknown) {
     return { error };
   }
 
   render() {
     if ("error" in this.state) {
-      // You can render any custom fallback UI
       return this.props.fallback(this.state.error);
     }
     return this.props.children;

--- a/examples/07_router/src/ErrorBoundary.tsx
+++ b/examples/07_router/src/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import { Component } from "react";
+import type { ReactNode, FunctionComponent } from "react";
+
+interface Props {
+  fallback: (error: unknown) => ReactNode;
+  children: ReactNode;
+}
+
+class ErrorBoundaryClass extends Component<Props, { error?: any }> {
+  constructor(props: any) {
+    super(props);
+    this.state = {};
+  }
+
+  static getDerivedStateFromError(error: any) {
+    return { error };
+  }
+
+  render() {
+    if ("error" in this.state) {
+      // You can render any custom fallback UI
+      return this.props.fallback(this.state.error);
+    }
+    return this.props.children;
+  }
+}
+
+export const ErrorBoundary =
+  ErrorBoundaryClass as unknown as FunctionComponent<Props>;

--- a/examples/07_router/src/index.tsx
+++ b/examples/07_router/src/index.tsx
@@ -2,10 +2,14 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Router } from "waku/router/client";
 
+import { ErrorBoundary } from "./ErrorBoundary.js";
+
 const root = createRoot(document.getElementById("root")!);
 
 root.render(
   <StrictMode>
-    <Router />
+    <ErrorBoundary fallback={(error) => <h1>{String(error)}</h1>}>
+      <Router />
+    </ErrorBoundary>
   </StrictMode>
 );

--- a/src/lib/middleware/rsc.ts
+++ b/src/lib/middleware/rsc.ts
@@ -3,6 +3,7 @@ import RSDWServer from "react-server-dom-webpack/server.node.unbundled";
 import busboy from "busboy";
 
 import { resolveConfig } from "../config.js";
+import { hasStatusCode } from "./rsc/utils.js";
 import { renderRSC } from "./rsc/worker-api.js";
 
 type Middleware = (
@@ -62,8 +63,12 @@ export function rsc(options: {
           : { rscId: rscId as string, props }
       );
       readable.on("error", (err) => {
-        console.info("Cannot render RSC", err);
-        res.statusCode = 500;
+        if (hasStatusCode(err)) {
+          res.statusCode = err.statusCode;
+        } else {
+          console.info("Cannot render RSC", err);
+          res.statusCode = 500;
+        }
         if (options.mode === "development") {
           res.end(String(err));
         } else {

--- a/src/lib/middleware/rsc/utils.ts
+++ b/src/lib/middleware/rsc/utils.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import { Transform } from "node:stream";
 
+export const hasStatusCode = (x: unknown): x is { statusCode: number } =>
+  typeof (x as any)?.statusCode === "number";
+
 export const codeToInject = `
 globalThis.__waku_module_cache__ = new Map();
 globalThis.__webpack_chunk_load__ = (id) => import(id).then((m) => globalThis.__waku_module_cache__.set(id, m));

--- a/src/lib/middleware/rsc/worker-api.ts
+++ b/src/lib/middleware/rsc/worker-api.ts
@@ -28,7 +28,7 @@ export type MessageRes =
   | { id: number; type: "buf"; buf: ArrayBuffer; offset: number; len: number }
   | { id: number; type: "moduleId"; moduleId: string }
   | { id: number; type: "end" }
-  | { id: number; type: "err"; err: unknown }
+  | { id: number; type: "err"; err: unknown; statusCode?: number }
   | {
       id: number;
       type: "builder";
@@ -78,9 +78,12 @@ export function renderRSC(
       passthrough.end();
       messageCallbacks.delete(id);
     } else if (mesg.type === "err") {
-      passthrough.destroy(
-        mesg.err instanceof Error ? mesg.err : new Error(String(mesg.err))
-      );
+      const err =
+        mesg.err instanceof Error ? mesg.err : new Error(String(mesg.err));
+      if (mesg.statusCode) {
+        (err as any).statusCode = mesg.statusCode;
+      }
+      passthrough.destroy(err);
       messageCallbacks.delete(id);
     }
   });

--- a/src/router/client.ts
+++ b/src/router/client.ts
@@ -32,7 +32,10 @@ const RouterContext = createContext<{
 export function useChangeLocation() {
   const value = useContext(RouterContext);
   if (!value) {
-    throw new Error("Missing Router");
+    const dummyFn: ChangeLocation = () => {
+      throw new Error("Missing Router");
+    };
+    return dummyFn;
   }
   return value.changeLocation;
 }


### PR DESCRIPTION
It was 500 previously. Now, if `getEntry` returns `null`, it means 404.