### PR TITLE
fix: update bin to fix command not found when run examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
       "default": "./dist/router/server.js"
     }
   },
-  "bin": "./dist/cli.js",
+  "bin": {
+    "waku": "./dist/cli.js"
+  },
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
# What's the issue
When clone the repo at the **first time**, can not run examples after running pnpm install.
It tells waku: command not found.
If waku link was built in the dir before, it would not warn the error.
<img width="846" alt="image" src="https://github.com/dai-shi/waku/assets/16911502/04dec248-8552-4bdf-bd2f-b593db07eec6">

# What's the platform
Run in mac OS 13.2.1 (22D68), Node v18.16.0

# How to fix
I found the bin property is corrent, but it can't work
I re-clone the repo and update the bin then run pnpm install, it fixed.
<img width="893" alt="image" src="https://github.com/dai-shi/waku/assets/16911502/1851b429-3bc0-499e-b653-1a3a0ba2d313">



