### PR TITLE
fix: package deps to run examples from root

### DIFF
--- a/examples/01_counter/package.json
+++ b/examples/01_counter/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/02_async/package.json
+++ b/examples/02_async/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/03_promise/package.json
+++ b/examples/03_promise/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/04_callserver/package.json
+++ b/examples/04_callserver/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/05_mutation/package.json
+++ b/examples/05_mutation/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/06_nesting/package.json
+++ b/examples/06_nesting/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/07_router/package.json
+++ b/examples/07_router/package.json
@@ -14,7 +14,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/08_cookies/package.json
+++ b/examples/08_cookies/package.json
@@ -14,7 +14,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/examples/09_cssmodules/package.json
+++ b/examples/09_cssmodules/package.json
@@ -13,7 +13,8 @@
     "react": "18.3.0-canary-7118f5dd7-20230705",
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
-    "waku": "0.14.0"
+    "webpack": "^5.59.0",
+    "waku": "workspace:0.14.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.8",

--- a/package.json
+++ b/package.json
@@ -123,9 +123,11 @@
     "react-dom": "18.3.0-canary-7118f5dd7-20230705",
     "react-server-dom-webpack": "18.3.0-canary-7118f5dd7-20230705",
     "rollup": "^3.26.3",
+    "postcss": "^8.1.0",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.1.6",
-    "waku": "link:."
+    "waku": "link:.",
+    "webpack": "^5.59.0"
   },
   "peerDependencies": {
     "express": "^4.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       glob:
         specifier: ^10.3.3
         version: 10.3.3
+      postcss:
+        specifier: ^8.1.0
+        version: 8.4.27
       prettier:
         specifier: ^3.0.0
         version: 3.0.0
@@ -101,6 +104,9 @@ importers:
       waku:
         specifier: link:.
         version: 'link:'
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2(@swc/core@1.3.71)
 
   examples/01_counter:
     dependencies:
@@ -117,8 +123,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -145,8 +154,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -173,8 +185,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -201,8 +216,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -229,8 +247,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -257,8 +278,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -288,8 +312,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -319,8 +346,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -347,8 +377,11 @@ importers:
         specifier: 18.3.0-canary-7118f5dd7-20230705
         version: 18.3.0-canary-7118f5dd7-20230705(react-dom@18.3.0-canary-7118f5dd7-20230705)(react@18.3.0-canary-7118f5dd7-20230705)(webpack@5.88.2)
       waku:
-        specifier: 0.14.0
+        specifier: workspace:0.14.0
         version: link:../..
+      webpack:
+        specifier: ^5.59.0
+        version: 5.88.2
     devDependencies:
       '@types/react':
         specifier: ^18.2.8
@@ -1161,11 +1194,11 @@ packages:
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
-      '@types/eslint': 8.44.1
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
 
-  /@types/eslint@8.44.1:
-    resolution: {integrity: sha512-XpNDc4Z5Tb4x+SW1MriMVeIsMoONHCkWFMkR/aPJbzEsxqHy+4Glu/BqTdPrApfDeMaXbtNh6bseNgl5KaWrSg==}
+  /@types/eslint@8.44.2:
+    resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
@@ -2317,7 +2350,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.45.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.2.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.2.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
       eslint-plugin-import: 2.28.0(@typescript-eslint/parser@6.2.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
@@ -2356,6 +2389,35 @@ packages:
       debug: 3.2.7
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.2.0)(eslint-plugin-import@2.28.0)(eslint@8.45.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.2.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.2.0(eslint@8.45.0)(typescript@5.1.6)
+      debug: 3.2.7
+      eslint: 8.45.0
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.2.0)(eslint-plugin-import@2.28.0)(eslint@8.45.0)
     transitivePeerDependencies:
       - supports-color
@@ -4494,6 +4556,30 @@ packages:
       terser: 5.19.2
       webpack: 5.88.2(@swc/core@1.3.71)
 
+  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.19.2
+      webpack: 5.88.2
+    dev: false
+
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
     engines: {node: '>=10'}
@@ -4736,6 +4822,46 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+
+  /webpack@5.88.2:
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      browserslist: 4.21.9
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: false
 
   /webpack@5.88.2(@swc/core@1.3.71):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}


### PR DESCRIPTION
running pnpm install and running the examples I ran into 

<img width="1116" alt="Screenshot 2023-08-17 at 2 45 35 PM" src="https://github.com/dai-shi/waku/assets/1854811/1815690b-2877-45a3-b174-4d8cda2f36de">

Fixing the deps and running pnpm install I get a clean pnpm install and working demo

<img width="596" alt="Screenshot 2023-08-17 at 2 48 15 PM" src="https://github.com/dai-shi/waku/assets/1854811/29b3cd8b-6e55-4c93-8181-d88a5c92f9eb">
<img width="1052" alt="Screenshot 2023-08-17 at 2 48 27 PM" src="https://github.com/dai-shi/waku/assets/1854811/1cf78cdb-5aac-477c-b1ee-3fa101a858f3">
<img width="1452" alt="Screenshot 2023-08-17 at 2 50 31 PM" src="https://github.com/dai-shi/waku/assets/1854811/be975e42-2de5-4509-afae-5a4564a55ee9">
