### PR TITLE
fix(cli): scan template error

### DIFF
--- a/packages/create-waku/src/cli.ts
+++ b/packages/create-waku/src/cli.ts
@@ -35,7 +35,8 @@ async function init() {
   let targetDir = "";
   const defaultProjectName = "waku-project";
 
-  const CHOICES = fs.readdirSync("template");
+  const templateRoot = path.join(__dirname, "../template");
+  const CHOICES = fs.readdirSync(templateRoot);
   let result: {
     packageName: string;
     shouldOverwrite: string;
@@ -116,7 +117,6 @@ async function init() {
 
   console.log("Setting up project...");
 
-  const templateRoot = path.join(__dirname, "../template");
   const templateDir = path.resolve(templateRoot, chooseProject);
 
   // Read existing package.json from the root directory

--- a/packages/create-waku/src/cli.ts
+++ b/packages/create-waku/src/cli.ts
@@ -117,7 +117,7 @@ async function init() {
 
   console.log("Setting up project...");
 
-  const templateDir = path.resolve(templateRoot, chooseProject);
+  const templateDir = path.join(templateRoot, chooseProject);
 
   // Read existing package.json from the root directory
   const packageJsonPath = path.join(root, "package.json");


### PR DESCRIPTION
Running `npx create-waku` resulting the error,
```
Error: ENOENT: no such file or directory, scandir 'template'
```

Changing the code manually in `node_modules` on my system in the package `create-waku/dist/cli.js` works,
```diff
- const CHOICES = fs.readdirSync("template");
+ const templateRoot = path.join(__dirname, "../template");
+ const CHOICES = fs.readdirSync(templateRoot);
```

Because it checks the template folder in `cwd` on our system rather than in `create-waku` package we have to change this.
