### PR TITLE
refactor: use tsconfig monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.2.0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run typecheck
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
-  type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8.2.0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run typecheck
-
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/examples/01_counter/tsconfig.json
+++ b/examples/01_counter/tsconfig.json
@@ -11,5 +11,5 @@
     "jsx": "react-jsx",
     "outDir": "./dist",
     "rootDir": "./src"
-  },
+  }
 }

--- a/examples/01_counter/tsconfig.json
+++ b/examples/01_counter/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
-  }
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
 }

--- a/examples/02_async/src/components/App.tsx
+++ b/examples/02_async/src/components/App.tsx
@@ -1,3 +1,5 @@
+/// Async Server Component
+/// <reference types="react/experimental" />
 import { Suspense } from "react";
 
 import { Counter } from "./Counter.js";

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -12,13 +12,9 @@
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "composite": true,
-    "types": [
-      "react/experimental"
-    ]
+    "types": ["react/experimental"]
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -12,7 +12,10 @@
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "composite": true,
-    "types": ["react/experimental"]
+    "types": [
+      // React Server Async Component type
+      "react/experimental"
+    ]
   },
   "include": ["./src"],
   "references": [

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -8,6 +8,20 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
-  }
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "composite": true,
+    "types": [
+      "react/experimental"
+    ]
+  },
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -11,11 +11,7 @@
     "jsx": "react-jsx",
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "composite": true,
-    "types": [
-      // React Server Async Component type
-      "react/experimental"
-    ]
+    "composite": true
   },
   "include": ["./src"],
   "references": [

--- a/examples/02_async/tsconfig.node.json
+++ b/examples/02_async/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/node",
+    "tsBuildInfoFile": "./dist/node/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/03_promise/tsconfig.json
+++ b/examples/03_promise/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/04_callserver/tsconfig.json
+++ b/examples/04_callserver/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/05_mutation/tsconfig.json
+++ b/examples/05_mutation/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/06_nesting/tsconfig.json
+++ b/examples/06_nesting/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/07_router/tsconfig.json
+++ b/examples/07_router/tsconfig.json
@@ -8,6 +8,17 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
-  }
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "composite": true
+  },
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/examples/07_router/tsconfig.json
+++ b/examples/07_router/tsconfig.json
@@ -13,9 +13,7 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "composite": true
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/examples/07_router/tsconfig.node.json
+++ b/examples/07_router/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/node",
+    "tsBuildInfoFile": "./dist/node/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/08_cookies/tsconfig.json
+++ b/examples/08_cookies/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/09_cssmodules/tsconfig.json
+++ b/examples/09_cssmodules/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -10,6 +10,14 @@
     "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx",
     "outDir": "./dist",
-    "rootDir": "./src"
-  }
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "composite": true,
+    "types": ["react/experimental"]
+  },
+  "include": ["./src"],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -11,8 +11,7 @@
     "jsx": "react-jsx",
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "composite": true,
-    "types": ["react/experimental"]
+    "composite": true
   },
   "include": ["./src"],
   "references": [

--- a/examples/10_dynamicroute/tsconfig.node.json
+++ b/examples/10_dynamicroute/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/node",
+    "tsBuildInfoFile": "./dist/node/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/11_form/tsconfig.json
+++ b/examples/11_form/tsconfig.json
@@ -8,6 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile": "pnpm -r --filter='./packages/*' run compile",
     "csb-install-FIXME": "pnpm install --no-frozen-lockfile",
     "postinstall": "test -d ./packages/waku/dist || (pnpm -r --filter='./packages/waku' run compile && pnpm install)",
-    "test": "prettier -c . && eslint . && tsc -b tsconfig.json --diagnostics",
+    "test": "prettier -c . && eslint . && tsc -b --diagnostics",
     "e2e": "playwright test",
     "examples:dev": "(cd ./examples/${NAME} && pnpm run dev)",
     "examples:dev:01_counter": "NAME=01_counter pnpm run examples:dev",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "typecheck": "tsc -b tsconfig.json --diagnostics",
     "dev": "pnpm -r --filter='./packages/*' run dev",
     "compile": "pnpm -r --filter='./packages/*' run compile",
     "csb-install-FIXME": "pnpm install --no-frozen-lockfile",
     "postinstall": "test -d ./packages/waku/dist || (pnpm -r --filter='./packages/waku' run compile && pnpm install)",
-    "test": "prettier -c . && eslint . && tsc --project . --noEmit",
+    "test": "prettier -c . && eslint . && tsc -b tsconfig.json --diagnostics",
     "e2e": "playwright test",
     "examples:dev": "(cd ./examples/${NAME} && pnpm run dev)",
     "examples:dev:01_counter": "NAME=01_counter pnpm run examples:dev",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "typecheck": "tsc -b tsconfig.json --diagnostics",
     "dev": "pnpm -r --filter='./packages/*' run dev",
     "compile": "pnpm -r --filter='./packages/*' run compile",
     "csb-install-FIXME": "pnpm install --no-frozen-lockfile",

--- a/packages/create-waku/src/cli.ts
+++ b/packages/create-waku/src/cli.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { default as prompts } from "prompts";
 import { red, green, bold } from "kolorist";
-import fse from "fs-extra/esm";
+import fse from "fs-extra";
 
 function isValidPackageName(projectName: string) {
   return /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(

--- a/packages/create-waku/src/cli.ts
+++ b/packages/create-waku/src/cli.ts
@@ -2,7 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import prompts from "prompts";
+import { default as prompts } from "prompts";
 import { red, green, bold } from "kolorist";
 import fse from "fs-extra/esm";
 

--- a/packages/create-waku/src/cli.ts
+++ b/packages/create-waku/src/cli.ts
@@ -2,13 +2,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-// FIXME what's the proper fix?
-// eslint-disable-next-line import/no-named-as-default
 import prompts from "prompts";
 import { red, green, bold } from "kolorist";
-// FIXME why @types/fs-extra doesn't work?
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import fse from "fs-extra/esm";
 
 function isValidPackageName(projectName: string) {

--- a/packages/create-waku/tsconfig.json
+++ b/packages/create-waku/tsconfig.json
@@ -8,7 +8,8 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["src"],
+  "include": ["./src"],
+  "exclude": ["./template"],
   "references": [
     {
       "path": "../waku"

--- a/packages/create-waku/tsconfig.json
+++ b/packages/create-waku/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },

--- a/packages/create-waku/tsconfig.json
+++ b/packages/create-waku/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "emitDeclarationOnly": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "module": "ESNext",

--- a/packages/create-waku/tsconfig.json
+++ b/packages/create-waku/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../waku"
+    }
+  ]
+}

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -58,7 +58,7 @@
     "dev": "swc src -d dist -w",
     "compile": "rm -rf dist && pnpm run compile:code && pnpm run compile:types",
     "compile:code": "swc src -d dist && swc src -d dist/cjs -C module.type=commonjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
-    "compile:types": "tsc --project tsconfig.build.json",
+    "compile:types": "tsc --project tsconfig.json",
     "postinstall": "(cd node_modules/vite && patch -p1 -i ../../patches/vite@4.4.10.patch) || (cd ../vite && patch -p1 -i ../waku/patches/vite@4.4.10.patch) || true"
   },
   "license": "MIT",

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -1,5 +1,3 @@
-/// <reference types="react/canary" />
-
 "use client";
 
 import {

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -1,3 +1,4 @@
+/// <reference types="react/canary" />
 "use client";
 
 import {

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -1,5 +1,3 @@
-/// <reference types="react/canary" />
-
 "use client";
 
 import {

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -3,11 +3,3 @@ declare module "react-server-dom-webpack/server";
 declare module "react-server-dom-webpack/server.node.unbundled";
 declare module "react-server-dom-webpack/client";
 declare module "react-server-dom-webpack/client.node.unbundled";
-
-// FIXME Is this too naive? How can we avoid the eslint warning?
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace JSX {
-  export type ElementType =
-    | string
-    | ((props: any) => React.ReactNode | Promise<React.ReactNode>);
-}

--- a/packages/waku/tsconfig.build.json
+++ b/packages/waku/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "outDir": "dist"
-  },
-  "include": ["src"]
-}

--- a/packages/waku/tsconfig.json
+++ b/packages/waku/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "emitDeclarationOnly": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "types": ["react/experimental"],

--- a/packages/waku/tsconfig.json
+++ b/packages/waku/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": [
+      "react/experimental"
+    ],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/waku/tsconfig.json
+++ b/packages/waku/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "types": ["react/experimental"],
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },

--- a/packages/waku/tsconfig.json
+++ b/packages/waku/tsconfig.json
@@ -5,9 +5,7 @@
     "emitDeclarationOnly": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "types": [
-      "react/experimental"
-    ],
+    "types": ["react/experimental"],
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
   },
   "include": ["src"],
   "references": [

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../waku"
+    }
+  ]
+}

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/e2e",
+    "types": ["node"]
+  },
+  "include": ["playwright.config.base.ts", "playwright.config.ts", "./e2e"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
     "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "composite": true,
     "incremental": true,
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,57 @@
     "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
+    "composite": true,
+    "incremental": true,
     "paths": {
       "waku": ["./packages/waku/src/main.ts"],
       "waku/*": ["./packages/waku/src/*.ts"]
     }
-  }
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    // Packages
+    {
+      "path": "./packages/waku"
+    },
+    {
+      "path": "./packages/create-waku"
+    },
+    {
+      "path": "./packages/website"
+    },
+    // Examples
+    {
+      "path": "./examples/01_counter"
+    },
+    {
+      "path": "./examples/02_async"
+    },
+    {
+      "path": "./examples/03_promise"
+    },
+    {
+      "path": "./examples/04_callserver"
+    },
+    {
+      "path": "./examples/05_mutation"
+    },
+    {
+      "path": "./examples/06_nesting"
+    },
+    {
+      "path": "./examples/07_router"
+    },
+    {
+      "path": "./examples/08_cookies"
+    },
+    {
+      "path": "./examples/09_cssmodules"
+    },
+    // E2E
+    {
+      "path": "./tsconfig.e2e.json"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,12 @@
     {
       "path": "./examples/09_cssmodules"
     },
+    {
+      "path": "./examples/10_dynamicroute"
+    },
+    {
+      "path": "./examples/11_form"
+    },
     // E2E
     {
       "path": "./tsconfig.e2e.json"


### PR DESCRIPTION
Add top-level ts config that includes all submodules, which restricts the type and isolated type context. If some files are missing or wrong-typed, it will throw the error.