### PR TITLE
fix: resolve multiple port occupancy conflict

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { parseArgs } from "node:util";
 import { createRequire } from "node:module";
 
+import type { Express } from "express";
+
 const require = createRequire(new URL(".", import.meta.url));
 
 const { values, positionals } = parseArgs({
@@ -74,10 +76,8 @@ async function runDev(options?: { ssr?: boolean }) {
     app.use(ssr({ command: "dev" }));
   }
   app.use(devServer());
-  const port = process.env.PORT || 3000;
-  app.listen(port, () => {
-    console.info("Listening on", port);
-  });
+  const port = parseInt(process.env.PORT || "3000", 10)
+  startServer(app, port)
 }
 
 async function runBuild() {
@@ -106,9 +106,22 @@ async function runStart(options?: { ssr?: boolean }) {
     ),
   );
   (express.static.mime as any).default_type = "";
-  const port = process.env.PORT || 8080;
-  app.listen(port, () => {
-    console.info("Listening on", port);
+  const port = parseInt(process.env.PORT || "8080", 10)
+  startServer(app, port)
+}
+
+function startServer(app: Express, port: number) {
+  const server = app.listen(port, () => {
+    console.log(`ready: Listening on http://localhost:${port}/`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.log(`warn: Port ${port} is in use, trying ${port + 1} instead.`)
+      startServer(app, port + 1);
+    } else {
+      console.error('Failed to start server');
+    }
   });
 }
 

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -76,8 +76,8 @@ async function runDev(options?: { ssr?: boolean }) {
     app.use(ssr({ command: "dev" }));
   }
   app.use(devServer());
-  const port = parseInt(process.env.PORT || "3000", 10)
-  startServer(app, port)
+  const port = parseInt(process.env.PORT || "3000", 10);
+  startServer(app, port);
 }
 
 async function runBuild() {
@@ -106,8 +106,8 @@ async function runStart(options?: { ssr?: boolean }) {
     ),
   );
   (express.static.mime as any).default_type = "";
-  const port = parseInt(process.env.PORT || "8080", 10)
-  startServer(app, port)
+  const port = parseInt(process.env.PORT || "8080", 10);
+  startServer(app, port);
 }
 
 function startServer(app: Express, port: number) {
@@ -115,12 +115,12 @@ function startServer(app: Express, port: number) {
     console.log(`ready: Listening on http://localhost:${port}/`);
   });
 
-  server.on('error', (err: NodeJS.ErrnoException) => {
-    if (err.code === 'EADDRINUSE') {
-      console.log(`warn: Port ${port} is in use, trying ${port + 1} instead.`)
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.log(`warn: Port ${port} is in use, trying ${port + 1} instead.`);
       startServer(app, port + 1);
     } else {
-      console.error('Failed to start server');
+      console.error("Failed to start server");
     }
   });
 }


### PR DESCRIPTION
When I start multiple services in `/examples`, I notice that the server only uses port 3000. There seems to be a better option, to choose the next port number when the current one is occupied. 

