### PR TITLE
chore: lock pnpm version in `package.json`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.2.0
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.2.0
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -25,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.2.0
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "waku-monorepo",
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@8.9.2",
   "private": true,
   "scripts": {
     "dev": "pnpm -r --filter='./packages/*' run dev",


### PR DESCRIPTION
`packageVersion` is a new built-in API from node.js that could lock the package manager and its version from the top level.