### PR TITLE
chore: ignore tsbuild info files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ dist
 .env
 .devcontainer
 .vscode
-tsconfig.tsbuildinfo
+*.tsbuildinfo


### PR DESCRIPTION
After 303b33f7fd61f91ea2b2a407d8711c208d22e289, tsbuildinfo will be emitted in the base dir