### PR TITLE
fix: support node 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 - breaking: switch to full SSR from RSC-only SSR #147
+### Changed
+- fix: support node 20 #159
 
 ## [0.16.0] - 2023-10-25
 ### Changed

--- a/packages/waku/src/lib/middleware/rsc/worker-api.ts
+++ b/packages/waku/src/lib/middleware/rsc/worker-api.ts
@@ -15,12 +15,18 @@ export type RenderRequest = {
   moduleIdCallback?: (id: string) => void;
 };
 
+const IS_NODE_18 = Number(process.versions.node.split(".")[0]) < 20;
+
 const worker = new Worker(new URL("worker-impl.js", import.meta.url), {
   execArgv: [
-    "--experimental-loader",
-    "waku/node-loader",
-    "--experimental-loader",
-    "react-server-dom-webpack/node-loader",
+    ...(IS_NODE_18
+      ? [
+          "--experimental-loader",
+          "waku/node-loader",
+          "--experimental-loader",
+          "react-server-dom-webpack/node-loader",
+        ]
+      : []),
     "--conditions",
     "react-server",
   ],

--- a/packages/waku/src/lib/middleware/rsc/worker-impl.ts
+++ b/packages/waku/src/lib/middleware/rsc/worker-impl.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import url from "node:url";
 import { parentPort } from "node:worker_threads";
 import { PassThrough, Transform, Writable } from "node:stream";
 import { finished } from "node:stream/promises";
@@ -20,6 +21,13 @@ import {
 
 const { renderToPipeableStream, decodeReply, decodeReplyFromBusboy } =
   RSDWServer;
+
+const IS_NODE_20 = Number(process.versions.node.split(".")[0]) >= 20;
+if (IS_NODE_20) {
+  const { register } = (await import("node:module")) as any;
+  register("waku/node-loader", url.pathToFileURL("./"));
+  register("react-server-dom-webpack/node-loader", url.pathToFileURL("./"));
+}
 
 type Entries = { default: ReturnType<typeof defineEntries> };
 type PipeableStream = { pipe<T extends Writable>(destination: T): T };


### PR DESCRIPTION
It looks like `--experimental-loader` doesn't work for Worker in Node 20.
https://github.com/nodejs/node/issues/47747