### PR TITLE
chore: fix build output disappear

### DIFF
--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "start": "node dist/cli.js",
-    "compile": "rm -rf template dist && pnpm run template && pnpm run build",
+    "compile": "rm -rf template dist tsconfig.tsbuildinfo && pnpm run template && pnpm run build",
     "template": "cp -r ../../examples template/",
     "build": "tsc -b"
   },

--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "start": "node dist/cli.js",
-    "compile": "rm -rf template dist tsconfig.tsbuildinfo && pnpm run template && pnpm run build",
+    "compile": "rm -rf template dist *.tsbuildinfo && pnpm run template && pnpm run build",
     "template": "cp -r ../../examples template/",
     "build": "tsc -b"
   },

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "dev": "swc src -d dist -w",
-    "compile": "rm -rf dist && pnpm run compile:code && pnpm run compile:types && cp ../../README.md .",
+    "compile": "rm -rf dist *.tsbuildinfo && pnpm run compile:code && pnpm run compile:types && cp ../../README.md .",
     "compile:code": "swc src -d dist && swc src -d dist/cjs -C module.type=commonjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "compile:types": "tsc --project tsconfig.json"
   },


### PR DESCRIPTION
`.tsbuildinfo` is a cache file, if you didn't remove it correctly. tsc will treat the output still remain in this case.

Fixes: https://github.com/dai-shi/waku/issues/167
Fixes: https://github.com/dai-shi/waku/issues/168