### PR TITLE
refactor: use web stream internally (step 2)

### DIFF
--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -12,7 +12,7 @@ import {
   startTransition,
 } from 'react';
 import type { ReactNode } from 'react';
-import RSDWClient from 'react-server-dom-webpack/client.browser';
+import RSDWClient from 'react-server-dom-webpack/client';
 import { encodeInput } from './lib/middleware/rsc/utils.js';
 
 const { createFromFetch, encodeReply } = RSDWClient;

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -12,7 +12,7 @@ import {
   startTransition,
 } from 'react';
 import type { ReactNode } from 'react';
-import RSDWClient from 'react-server-dom-webpack/client';
+import RSDWClient from 'react-server-dom-webpack/client.browser';
 import { encodeInput } from './lib/middleware/rsc/utils.js';
 
 const { createFromFetch, encodeReply } = RSDWClient;
@@ -56,7 +56,10 @@ export const fetchRSC = cache(
             body: await encodeReply(args),
           },
         );
-        const data = createFromFetch(checkStatus(response), options);
+        const data = createFromFetch<Awaited<Elements>>(
+          checkStatus(response),
+          options,
+        );
         startTransition(() => {
           // FIXME this causes rerenders even if data is empty
           rerender((prev) => mergeElements(prev, data));
@@ -67,7 +70,10 @@ export const fetchRSC = cache(
     const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
     const response = prefetched[input] || fetch(basePath + encodeInput(input));
     delete prefetched[input];
-    const data = createFromFetch(checkStatus(response), options);
+    const data = createFromFetch<Awaited<Elements>>(
+      checkStatus(response),
+      options,
+    );
     return data;
   },
 );

--- a/packages/waku/src/lib/middleware/rsc/ssr.ts
+++ b/packages/waku/src/lib/middleware/rsc/ssr.ts
@@ -222,15 +222,17 @@ globalThis.__WAKU_SSR_ENABLED__ = true;
           throw new Error('preamble not yet sent');
         }
         if (!closed) {
-          notify = () => {
-            controller.enqueue(encoder.encode(getScripts()));
-            if (closed) {
-              controller.enqueue(encoder.encode(postamble));
-            }
-          };
-        } else {
-          controller.enqueue(encoder.encode(postamble));
+          return new Promise<void>((resolve) => {
+            notify = () => {
+              controller.enqueue(encoder.encode(getScripts()));
+              if (closed) {
+                controller.enqueue(encoder.encode(postamble));
+                resolve();
+              }
+            };
+          });
         }
+        controller.enqueue(encoder.encode(postamble));
       },
     });
   };

--- a/packages/waku/src/lib/middleware/rsc/ssr.ts
+++ b/packages/waku/src/lib/middleware/rsc/ssr.ts
@@ -222,11 +222,15 @@ globalThis.__WAKU_SSR_ENABLED__ = true;
           throw new Error('preamble not yet sent');
         }
         if (!closed) {
-          notify = undefined;
-          closed = true;
-          controller.enqueue(encoder.encode(getScripts()));
+          notify = () => {
+            controller.enqueue(encoder.encode(getScripts()));
+            if (closed) {
+              controller.enqueue(encoder.encode(postamble));
+            }
+          };
+        } else {
+          controller.enqueue(encoder.encode(postamble));
         }
-        controller.enqueue(encoder.encode(postamble));
       },
     });
   };

--- a/packages/waku/src/lib/middleware/rsc/ssr.ts
+++ b/packages/waku/src/lib/middleware/rsc/ssr.ts
@@ -199,11 +199,18 @@ globalThis.__WAKU_SSR_ENABLED__ = true;
     let preambleSent = false;
     return new TransformStream({
       transform(chunk, controller) {
+        if (!(chunk instanceof Uint8Array)) {
+          throw new Error('Unknown chunk type');
+        }
         if (!preambleSent) {
           preambleSent = true;
-          controller.enqueue(encoder.encode(modifyHead(preamble)));
-          controller.enqueue(chunk);
-          controller.enqueue(encoder.encode(intermediate));
+          controller.enqueue(
+            concatUint8Arrays([
+              encoder.encode(modifyHead(preamble)),
+              chunk,
+              encoder.encode(intermediate),
+            ]),
+          );
           notify = () => controller.enqueue(encoder.encode(getScripts()));
           notify();
           return;

--- a/packages/waku/src/lib/middleware/rsc/ssr.ts
+++ b/packages/waku/src/lib/middleware/rsc/ssr.ts
@@ -222,8 +222,6 @@ globalThis.__WAKU_SSR_ENABLED__ = true;
           controller.enqueue(encoder.encode(intermediate));
         }
         if (!closedSent) {
-          throw new Error('we missed to send closed');
-          /*
           const notifyOrig = notify;
           notify = () => {
             notifyOrig?.();
@@ -231,7 +229,6 @@ globalThis.__WAKU_SSR_ENABLED__ = true;
               controller.enqueue(encoder.encode(postamble));
             }
           };
-          */
         } else {
           controller.enqueue(encoder.encode(postamble));
         }

--- a/packages/waku/src/lib/middleware/rsc/utils.ts
+++ b/packages/waku/src/lib/middleware/rsc/utils.ts
@@ -66,3 +66,14 @@ export const endStream = (stream: WritableStream, message?: string) => {
   }
   writer.ready.then(() => writer.close());
 };
+
+export const concatUint8Arrays = (arrs: Uint8Array[]): Uint8Array => {
+  const len = arrs.reduce((acc, arr) => acc + arr.length, 0);
+  const array = new Uint8Array(len);
+  let offset = 0;
+  for (const arr of arrs) {
+    array.set(arr, offset);
+    offset += arr.length;
+  }
+  return array;
+};

--- a/packages/waku/src/lib/middleware/rsc/worker-impl.ts
+++ b/packages/waku/src/lib/middleware/rsc/worker-impl.ts
@@ -7,7 +7,7 @@ import { Server } from 'node:http';
 import { Buffer } from 'node:buffer';
 
 import type { ReactNode } from 'react';
-import RSDWServer from 'react-server-dom-webpack/server';
+import RSDWServer from 'react-server-dom-webpack/server.node.unbundled';
 import busboy from 'busboy';
 import type { ViteDevServer } from 'vite';
 

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -23,7 +23,6 @@ type SSRManifest = {
 };
 
 declare module 'react-server-dom-webpack/node-loader';
-declare module 'react-server-dom-webpack/server'; // TODO
 declare module 'react-server-dom-webpack/server.node.unbundled'; // TODO
 
 declare module 'react-server-dom-webpack/client' {

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -52,6 +52,6 @@ declare module 'react-dom/server.edge' {
   }
   export function renderToReadableStream(
     children: ReactNode,
-    options?: RenderToReadableStreamOptions,
+    options?: Options,
   ): Promise<ReactDOMServerReadableStream>;
 }

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -26,7 +26,7 @@ declare module 'react-server-dom-webpack/node-loader';
 declare module 'react-server-dom-webpack/server'; // TODO
 declare module 'react-server-dom-webpack/server.node.unbundled'; // TODO
 
-declare module 'react-server-dom-webpack/client.browser' {
+declare module 'react-server-dom-webpack/client' {
   export function createFromFetch<T>(
     promiseForResponse: Promise<Response>,
     options?: Options,

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -1,5 +1,58 @@
+type ReactServerValue = any; // any serializable value
+
+type ImportManifestEntry = {
+  id: string;
+  chunks: string[];
+  name: string;
+};
+
+type ModuleLoading = null | {
+  prefix: string;
+  crossOrigin?: 'use-credentials' | '';
+};
+
+type SSRModuleMap = null | {
+  [clientId: string]: {
+    [clientExportName: string]: ImportManifestEntry;
+  };
+};
+
+type SSRManifest = {
+  moduleMap: SSRModuleMap;
+  moduleLoading: ModuleLoading;
+};
+
 declare module 'react-server-dom-webpack/node-loader';
-declare module 'react-server-dom-webpack/server';
-declare module 'react-server-dom-webpack/server.node.unbundled';
-declare module 'react-server-dom-webpack/client';
-declare module 'react-server-dom-webpack/client.node.unbundled';
+declare module 'react-server-dom-webpack/server'; // TODO
+declare module 'react-server-dom-webpack/server.node.unbundled'; // TODO
+
+declare module 'react-server-dom-webpack/client.browser' {
+  export function createFromFetch<T>(
+    promiseForResponse: Promise<Response>,
+    options?: Options,
+  ): Promise<T>;
+  export function encodeReply(
+    value: ReactServerValue,
+  ): Promise<string | URLSearchParams | FormData>;
+}
+
+declare module 'react-server-dom-webpack/client.edge' {
+  export type Options = {
+    ssrManifest: SSRManifest;
+    nonce?: string;
+  };
+  export function createFromReadableStream<T>(
+    stream: ReadableStream,
+    options: Options,
+  ): Promise<T>;
+}
+
+declare module 'react-dom/server.edge' {
+  export interface ReactDOMServerReadableStream extends ReadableStream {
+    allReady: Promise<void>;
+  }
+  export function renderToReadableStream(
+    children: ReactNode,
+    options?: RenderToReadableStreamOptions,
+  ): Promise<ReactDOMServerReadableStream>;
+}

--- a/packages/website/src/main.tsx
+++ b/packages/website/src/main.tsx
@@ -10,17 +10,8 @@ const rootElement = (
   </StrictMode>
 );
 
-// FIXME temporary fix, doesn't feel ideal.
-function init() {
-  const root = document.getElementById('root');
-  if (!root) {
-    setTimeout(init);
-    return;
-  }
-  if ((globalThis as any).__WAKU_SSR_ENABLED__) {
-    hydrateRoot(root, rootElement);
-  } else {
-    createRoot(root).render(rootElement);
-  }
+if ((globalThis as any).__WAKU_SSR_ENABLED__) {
+  hydrateRoot(document.getElementById('root')!, rootElement);
+} else {
+  createRoot(document.getElementById('root')!).render(rootElement);
 }
-init();

--- a/packages/website/src/main.tsx
+++ b/packages/website/src/main.tsx
@@ -10,8 +10,17 @@ const rootElement = (
   </StrictMode>
 );
 
-if ((globalThis as any).__WAKU_SSR_ENABLED__) {
-  hydrateRoot(document.getElementById('root')!, rootElement);
-} else {
-  createRoot(document.getElementById('root')!).render(rootElement);
+// FIXME temporary fix, doesn't feel ideal.
+function init() {
+  const root = document.getElementById('root');
+  if (!root) {
+    setTimeout(init);
+    return;
+  }
+  if ((globalThis as any).__WAKU_SSR_ENABLED__) {
+    hydrateRoot(root, rootElement);
+  } else {
+    createRoot(root).render(rootElement);
+  }
 }
+init();


### PR DESCRIPTION
Continuing from #190.

This converts mainly `ssr.ts`.