### PR TITLE
refactor: use web stream internally (step 3)

### DIFF
--- a/examples/06_nesting/src/components/Counter.tsx
+++ b/examples/06_nesting/src/components/Counter.tsx
@@ -23,7 +23,9 @@ export const Counter = ({ enableInnerApp }: { enableInnerApp?: boolean }) => {
   return (
     <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
       <p>Count: {count}</p>
-      <button onClick={handleClick}>Increment</button>{' '}
+      <button onClick={handleClick} disabled={isPending}>
+        Increment
+      </button>{' '}
       {isPending && 'Pending...'}
       <h3>This is a client component.</h3>
       {enableInnerApp && <Slot id="InnerApp" />}

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -64,9 +64,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "dependencies": {
-    "busboy": "^1.6.0"
-  },
   "devDependencies": {
     "@hono/node-server": "^1.2.2",
     "@swc/cli": "^0.1.62",

--- a/packages/waku/src/lib/middleware/rsc/utils.ts
+++ b/packages/waku/src/lib/middleware/rsc/utils.ts
@@ -77,3 +77,37 @@ export const concatUint8Arrays = (arrs: Uint8Array[]): Uint8Array => {
   }
   return array;
 };
+
+// TODO is this correct? better to use a library?
+export const parseFormData = (body: string, contentType: string) => {
+  const boundary = contentType.split('boundary=')[1];
+  const parts = body.split(`--${boundary}`);
+  const formData = new FormData();
+  for (const part of parts) {
+    if (part.trim() === '' || part === '--') continue;
+    const [rawHeaders, content] = part.split('\r\n\r\n', 2);
+    const headers = rawHeaders!.split('\r\n').reduce(
+      (acc, currentHeader) => {
+        const [key, value] = currentHeader.split(': ');
+        acc[key!.toLowerCase()] = value!;
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+    const contentDisposition = headers['content-disposition'];
+    const nameMatch = /name="([^"]+)"/.exec(contentDisposition!);
+    const filenameMatch = /filename="([^"]+)"/.exec(contentDisposition!);
+    if (nameMatch) {
+      const name = nameMatch[1];
+      if (filenameMatch) {
+        const filename = filenameMatch[1];
+        const type = headers['content-type'] || 'application/octet-stream';
+        const blob = new Blob([content!], { type });
+        formData.append(name!, blob, filename);
+      } else {
+        formData.append(name!, content!.trim());
+      }
+    }
+  }
+  return formData;
+};

--- a/packages/waku/src/lib/middleware/rsc/worker-impl.ts
+++ b/packages/waku/src/lib/middleware/rsc/worker-impl.ts
@@ -1,35 +1,21 @@
 import path from 'node:path';
 import url from 'node:url';
 import { parentPort } from 'node:worker_threads';
-import { PassThrough, Readable, Transform, Writable } from 'node:stream';
-import { finished } from 'node:stream/promises';
 import { Server } from 'node:http';
-import { Buffer } from 'node:buffer';
 
 import type { ReactNode } from 'react';
-import RSDWServer from 'react-server-dom-webpack/server.node.unbundled';
-import busboy from 'busboy';
+import RSDWServer from 'react-server-dom-webpack/server.edge';
 import type { ViteDevServer } from 'vite';
 
 import { resolveConfig, viteInlineConfig } from '../../config.js';
-import { hasStatusCode, deepFreeze } from './utils.js';
-import type {
-  MessageReq,
-  MessageRes,
-  RenderRequest as RenderRequestOrig,
-} from './worker-api.js';
+import { hasStatusCode, deepFreeze, parseFormData } from './utils.js';
+import type { MessageReq, MessageRes, RenderRequest } from './worker-api.js';
 import {
   defineEntries,
   runWithAsyncLocalStorage as runWithAsyncLocalStorageOrig,
 } from '../../../server.js';
 
-// TODO this is a temporary solution
-type RenderRequest = Omit<RenderRequestOrig, 'stream'> & {
-  stream?: Readable;
-};
-
-const { renderToPipeableStream, decodeReply, decodeReplyFromBusboy } =
-  RSDWServer;
+const { renderToReadableStream, decodeReply } = RSDWServer;
 
 const IS_NODE_20 = Number(process.versions.node.split('.')[0]) >= 20;
 if (IS_NODE_20) {
@@ -46,17 +32,18 @@ type Entries = {
     invert?: boolean,
   ) => string | undefined;
 };
-type PipeableStream = { pipe<T extends Writable>(destination: T): T };
-
-const streamMap = new Map<number, Writable>();
+const controllerMap = new Map<number, ReadableStreamDefaultController>();
 
 const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { id, type, hasModuleIdCallback, ...rest } = mesg;
   const rr: RenderRequest = rest;
   try {
-    const stream = new PassThrough();
-    streamMap.set(id, stream);
+    const stream = new ReadableStream({
+      start(controller) {
+        controllerMap.set(id, controller);
+      },
+    });
     rr.stream = stream;
     if (hasModuleIdCallback) {
       rr.moduleIdCallback = (moduleId: string) => {
@@ -64,33 +51,30 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
         parentPort!.postMessage(mesg);
       };
     }
-    const pipeable = await renderRSC(rr);
+    const readable = await renderRSC(rr);
     const mesg: MessageRes = { id, type: 'start', context: rr.context };
     parentPort!.postMessage(mesg);
     deepFreeze(rr.context);
-    const writable = new Writable({
-      write(chunk, encoding, callback) {
-        if (encoding !== ('buffer' as any)) {
-          throw new Error('Unknown encoding');
+    const writable = new WritableStream({
+      write(chunk) {
+        if (!(chunk instanceof Uint8Array)) {
+          throw new Error('Unknown chunk type');
         }
-        const buffer: Buffer = chunk;
         const mesg: MessageRes = {
           id,
           type: 'buf',
-          buf: buffer.buffer,
-          offset: buffer.byteOffset,
-          len: buffer.length,
+          buf: chunk.buffer,
+          offset: chunk.byteOffset,
+          len: chunk.byteLength,
         };
         parentPort!.postMessage(mesg, [mesg.buf]);
-        callback();
       },
-      final(callback) {
+      close() {
         const mesg: MessageRes = { id, type: 'end' };
         parentPort!.postMessage(mesg);
-        callback();
       },
     });
-    pipeable.pipe(writable);
+    readable.pipeTo(writable);
   } catch (err) {
     const mesg: MessageRes = { id, type: 'err', err };
     if (hasStatusCode(err)) {
@@ -186,16 +170,16 @@ parentPort!.on('message', (mesg: MessageReq) => {
   } else if (mesg.type === 'getBuildConfig') {
     handleGetBuildConfig(mesg);
   } else if (mesg.type === 'buf') {
-    const stream = streamMap.get(mesg.id)!;
-    stream.write(Buffer.from(mesg.buf, mesg.offset, mesg.len));
+    const controller = controllerMap.get(mesg.id)!;
+    controller.enqueue(new Uint8Array(mesg.buf, mesg.offset, mesg.len));
   } else if (mesg.type === 'end') {
-    const stream = streamMap.get(mesg.id)!;
-    stream.end();
+    const controller = controllerMap.get(mesg.id)!;
+    controller.close();
   } else if (mesg.type === 'err') {
-    const stream = streamMap.get(mesg.id)!;
+    const controller = controllerMap.get(mesg.id)!;
     const err =
       mesg.err instanceof Error ? mesg.err : new Error(String(mesg.err));
-    stream.destroy(err);
+    controller.error(err);
   }
 });
 
@@ -246,17 +230,19 @@ const resolveClientEntry = (
 };
 
 // HACK Patching stream is very fragile.
-const transformRsfId = (prefixToRemove: string) =>
-  new Transform({
-    transform(chunk, encoding, callback) {
-      if (encoding !== ('buffer' as any)) {
-        throw new Error('Unknown encoding');
+const transformRsfId = (prefixToRemove: string) => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (!(chunk instanceof Uint8Array)) {
+        throw new Error('Unknown chunk type');
       }
-      const data = chunk.toString();
+      const data = decoder.decode(chunk);
       const lines = data.split('\n');
       let changed = false;
       for (let i = 0; i < lines.length; ++i) {
-        const match = lines[i].match(
+        const match = lines[i]!.match(
           new RegExp(
             `^([0-9]+):{"id":"(?:file://)?${prefixToRemove}(.*?)"(.*)$`,
           ),
@@ -266,11 +252,12 @@ const transformRsfId = (prefixToRemove: string) =>
           changed = true;
         }
       }
-      callback(null, changed ? Buffer.from(lines.join('\n')) : chunk);
+      controller.enqueue(changed ? encoder.encode(lines.join('\n')) : chunk);
     },
   });
+};
 
-async function renderRSC(rr: RenderRequest): Promise<PipeableStream> {
+async function renderRSC(rr: RenderRequest): Promise<ReadableStream> {
   const config = await resolveConfig();
 
   const { runWithAsyncLocalStorage } = await (loadServerFile(
@@ -320,22 +307,30 @@ async function renderRSC(rr: RenderRequest): Promise<PipeableStream> {
     const actionId = decodeURIComponent(rr.input);
     let args: unknown[] = [];
     const contentType = rr.headers['content-type'];
+    let body = '';
+    if (rr.stream) {
+      const decoder = new TextDecoder();
+      const reader = rr.stream.getReader();
+      let result: ReadableStreamReadResult<unknown>;
+      do {
+        result = await reader.read();
+        if (result.value) {
+          if (!(result.value instanceof Uint8Array)) {
+            throw new Error('Unexepected buffer type');
+          }
+          body += decoder.decode(result.value);
+        }
+      } while (!result.done);
+    }
     if (
       typeof contentType === 'string' &&
       contentType.startsWith('multipart/form-data')
     ) {
-      const bb = busboy({ headers: rr.headers });
-      const reply = decodeReplyFromBusboy(bb);
-      rr.stream?.pipe(bb);
-      args = await reply;
-    } else {
-      let body = '';
-      for await (const chunk of rr.stream || []) {
-        body += chunk;
-      }
-      if (body) {
-        args = await decodeReply(body);
-      }
+      // XXX This doesn't support streaming unlike busboy
+      const formData = parseFormData(body, contentType);
+      args = await decodeReply(formData);
+    } else if (body) {
+      args = await decodeReply(body);
     }
     const [fileId, name] = actionId.split('#');
     const filePath = path.join(config.rootDir, fileId!);
@@ -355,10 +350,10 @@ async function renderRSC(rr: RenderRequest): Promise<PipeableStream> {
       },
       async () => {
         const data = await (mod[name!] || mod)(...args);
-        return renderToPipeableStream(
+        return renderToReadableStream(
           elements.then((resolved) => ({ ...resolved, _value: data })),
           bundlerConfig,
-        ).pipe(transformRsfId(config.rootDir));
+        ).pipeThrough(transformRsfId(config.rootDir));
       },
     );
   }
@@ -372,7 +367,7 @@ async function renderRSC(rr: RenderRequest): Promise<PipeableStream> {
     },
     async () => {
       const elements = await render(rr.input);
-      return renderToPipeableStream(elements, bundlerConfig).pipe(
+      return renderToReadableStream(elements, bundlerConfig).pipeThrough(
         transformRsfId(config.rootDir),
       );
     },
@@ -397,7 +392,7 @@ async function getBuildConfigRSC() {
     input: string,
   ): Promise<string[]> => {
     const idSet = new Set<string>();
-    const pipeable = await renderRSC({
+    const readable = await renderRSC({
       input,
       method: 'GET',
       headers: {},
@@ -405,13 +400,17 @@ async function getBuildConfigRSC() {
       context: null,
       moduleIdCallback: (id) => idSet.add(id),
     });
-    const stream = new Writable({
-      write(_chunk, _encoding, callback) {
-        callback();
-      },
+    await new Promise<void>((resolve, reject) => {
+      const writable = new WritableStream({
+        close() {
+          resolve();
+        },
+        abort(reason) {
+          reject(reason);
+        },
+      });
+      readable.pipeTo(writable);
     });
-    pipeable.pipe(stream);
-    await finished(stream);
     return Array.from(idSet);
   };
 

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -1,5 +1,3 @@
-type ReactServerValue = any; // any serializable value
-
 type ImportManifestEntry = {
   id: string;
   chunks: string[];
@@ -22,8 +20,27 @@ type SSRManifest = {
   moduleLoading: ModuleLoading;
 };
 
+type ServerManifest = {
+  [id: string]: ImportManifestEntry;
+};
+
+type ClientManifest = {
+  [id: string]: ImportManifestEntry;
+};
+
 declare module 'react-server-dom-webpack/node-loader';
-declare module 'react-server-dom-webpack/server.node.unbundled'; // TODO
+
+declare module 'react-server-dom-webpack/server.edge' {
+  export function renderToReadableStream(
+    model: ReactClientValue,
+    webpackMap: ClientManifest,
+    options?: Options,
+  ): ReadableStream;
+  export function decodeReply<T>(
+    body: string | FormData,
+    webpackMap?: ServerManifest,
+  ): Promise<T>;
+}
 
 declare module 'react-server-dom-webpack/client' {
   export function createFromFetch<T>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,9 +585,6 @@ importers:
 
   packages/waku:
     dependencies:
-      busboy:
-        specifier: ^1.6.0
-        version: 1.6.0
       react:
         specifier: 18.3.0-canary-6c7b41da3-20231123
         version: 18.3.0-canary-6c7b41da3-20231123
@@ -2301,13 +2298,6 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: false
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -5554,11 +5544,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: false
-
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
     dev: false
 
   /string-width@4.2.3:


### PR DESCRIPTION
Previous PRs: #190, #196

This converts mainly `worker-impl.ts`.