### PR TITLE
docs: npm install to pnpm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ the following commands:
 ```sh
 git clone https://github.com/dai-shi/waku.git
 cd waku
-npm install
+pnpm install
 npm run examples:dev:07_router
 ```
 


### PR DESCRIPTION
Hi. I'm interested in waku. So I've forked and played with some examples.
When I install the dependencies using `npm`, it had an error below:

<img width="945" alt="스크린샷 2023-12-17 23 13 15" src="https://github.com/dai-shi/waku/assets/33178048/79a83208-505e-4615-bb5b-61dda3c0e76d">

So I revised README.md [here](https://github.com/dai-shi/waku?tab=readme-ov-file#how-to-try-it-1) (Need to install dependencies using `pnpm`)
