### PR TITLE
breaking: server to allow fallback to static

### DIFF
--- a/e2e/fixtures/rsc-basic/src/entries.tsx
+++ b/e2e/fixtures/rsc-basic/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async () => {
     throw new Error('SSR is should not be used in this test.');

--- a/e2e/fixtures/rsc-router/src/entries.tsx
+++ b/e2e/fixtures/rsc-router/src/entries.tsx
@@ -1,10 +1,10 @@
 import { defineRouter } from 'waku/router/server';
 
+const STATIC_PATHS = ['/', '/foo'];
+
 export default defineRouter(
-  // getRoutePaths
-  async () => ({
-    static: ['/', '/foo'],
-  }),
+  // existsPath
+  async (path: string) => (STATIC_PATHS.includes(path) ? 'static' : null),
   // getComponent (id is "**/layout" or "**/page")
   async (id) => {
     switch (id) {
@@ -18,4 +18,6 @@ export default defineRouter(
         return null;
     }
   },
+  // getPathsForBuild
+  async () => STATIC_PATHS.map((path) => ({ path })),
 );

--- a/e2e/fixtures/ssr-basic/src/entries.tsx
+++ b/e2e/fixtures/ssr-basic/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/01_counter/src/components/App.tsx
+++ b/examples/01_counter/src/components/App.tsx
@@ -7,6 +7,7 @@ const App = ({ name }: { name: string }) => {
       <h1>Hello {name}!!</h1>
       <h3>This is a server component.</h3>
       <Counter />
+      <div>{new Date().toISOString()}</div>
     </div>
   );
 };

--- a/examples/01_counter/src/entries.tsx
+++ b/examples/01_counter/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/02_async/src/components/App.tsx
+++ b/examples/02_async/src/components/App.tsx
@@ -14,6 +14,7 @@ const App = ({ name }: { name: string }) => {
         <ServerMessage />
       </Suspense>
       <Counter />
+      <div>{new Date().toISOString()}</div>
     </div>
   );
 };

--- a/examples/02_async/src/entries.tsx
+++ b/examples/02_async/src/entries.tsx
@@ -13,7 +13,10 @@ export default defineEntries(
   // getBuildConfig
   async () => [{ pathname: '/', entries: [{ input: '', isStatic: true }] }],
   // getSsrConfig
-  async ({ pathname }) => {
+  async ({ pathname }, isBuild) => {
+    if (!isBuild) {
+      return null;
+    }
     switch (pathname) {
       case '/':
         return {

--- a/examples/02_async/src/entries.tsx
+++ b/examples/02_async/src/entries.tsx
@@ -13,8 +13,8 @@ export default defineEntries(
   // getBuildConfig
   async () => [{ pathname: '/', entries: [{ input: '', isStatic: true }] }],
   // getSsrConfig
-  async ({ pathname }, isBuild) => {
-    if (!isBuild) {
+  async ({ pathname }, isPrd) => {
+    if (isPrd) {
       return null;
     }
     switch (pathname) {

--- a/examples/02_async/src/entries.tsx
+++ b/examples/02_async/src/entries.tsx
@@ -11,12 +11,9 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '', isStatic: true }] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
-  async ({ pathname }, isPrd) => {
-    if (isPrd) {
-      return null;
-    }
+  async ({ pathname }) => {
     switch (pathname) {
       case '/':
         return {

--- a/examples/02_async/src/entries.tsx
+++ b/examples/02_async/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '', isStatic: true }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/03_promise/src/entries.tsx
+++ b/examples/03_promise/src/entries.tsx
@@ -16,7 +16,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/04_callserver/src/components/App.tsx
+++ b/examples/04_callserver/src/components/App.tsx
@@ -12,6 +12,7 @@ const App = ({ name }: { name: string }) => {
       <h1>Hello {name}!!</h1>
       <h3>This is a server component.</h3>
       <Counter greet={greet as unknown as ServerFunction<typeof greet>} />
+      <div>{new Date().toISOString()}</div>
     </div>
   );
 };

--- a/examples/04_callserver/src/entries.tsx
+++ b/examples/04_callserver/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/04_callserver/src/entries.tsx
+++ b/examples/04_callserver/src/entries.tsx
@@ -11,9 +11,12 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ input: '', isStatic: true }] }],
   // getSsrConfig
-  async ({ pathname }) => {
+  async ({ pathname }, isPrd) => {
+    if (isPrd) {
+      return null;
+    }
     switch (pathname) {
       case '/':
         return {

--- a/examples/05_mutation/src/entries.tsx
+++ b/examples/05_mutation/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/06_nesting/src/entries.tsx
+++ b/examples/06_nesting/src/entries.tsx
@@ -23,12 +23,12 @@ export default defineEntries(
     {
       pathname: '/',
       entries: [
-        [''],
-        ['InnerApp=1', true],
-        ['InnerApp=2', true],
-        ['InnerApp=3', true],
-        ['InnerApp=4', true],
-        ['InnerApp=5', true],
+        { input: '' },
+        { input: 'InnerApp=1', skipPrefetch: true },
+        { input: 'InnerApp=2', skipPrefetch: true },
+        { input: 'InnerApp=3', skipPrefetch: true },
+        { input: 'InnerApp=4', skipPrefetch: true },
+        { input: 'InnerApp=5', skipPrefetch: true },
       ],
     },
   ],

--- a/examples/07_router/src/entries.tsx
+++ b/examples/07_router/src/entries.tsx
@@ -1,10 +1,10 @@
 import { defineRouter } from 'waku/router/server';
 
+const STATIC_PATHS = ['/', '/foo', '/bar', '/nested/baz', '/nested/qux'];
+
 export default defineRouter(
-  // getRoutePaths
-  async () => ({
-    static: ['/', '/foo', '/bar', '/nested/baz', '/nested/qux'],
-  }),
+  // existsPath
+  async (path: string) => (STATIC_PATHS.includes(path) ? 'static' : null),
   // getComponent (id is "**/layout" or "**/page")
   async (id) => {
     switch (id) {
@@ -26,4 +26,6 @@ export default defineRouter(
         return null;
     }
   },
+  // getPathsForBuild
+  async () => STATIC_PATHS.map((path) => ({ path })),
 );

--- a/examples/07_router/src/entries.tsx
+++ b/examples/07_router/src/entries.tsx
@@ -6,7 +6,8 @@ export default defineRouter(
   // existsPath
   async (path: string) => (STATIC_PATHS.includes(path) ? 'static' : null),
   // getComponent (id is "**/layout" or "**/page")
-  async (id) => {
+  async (id, unstable_setShouldSkip) => {
+    unstable_setShouldSkip({}); // always skip if possible
     switch (id) {
       case 'layout':
         return import('./routes/layout.js');

--- a/examples/07_router/src/main.tsx
+++ b/examples/07_router/src/main.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from './components/ErrorBoundary.js';
 const rootElement = (
   <StrictMode>
     <ErrorBoundary fallback={(error) => <h1>{String(error)}</h1>}>
-      <Router shouldSkip={() => true} />
+      <Router />
     </ErrorBoundary>
   </StrictMode>
 );

--- a/examples/08_cookies/src/entries.tsx
+++ b/examples/08_cookies/src/entries.tsx
@@ -25,7 +25,9 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']], context: { count: 0 } }],
+  async () => [
+    { pathname: '/', entries: [{ input: '' }], context: { count: 0 } },
+  ],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/09_cssmodules/src/entries.tsx
+++ b/examples/09_cssmodules/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/10_dynamicroute/src/entries.tsx
+++ b/examples/10_dynamicroute/src/entries.tsx
@@ -54,21 +54,23 @@ const getMappingAndItems = async (id: string) => {
   return { mapping, items };
 };
 
+const getStaticPaths = async () => {
+  const files = await glob('**/page.{tsx,js}', { cwd: routesDir });
+  return files
+    .filter((file) => !/(^|\/)(\[\w+\]|_\w+_)\//.test(file))
+    .map((file) => '/' + file.slice(0, Math.max(0, file.lastIndexOf('/'))));
+};
+
 export default defineRouter(
-  // getRoutePaths
-  async () => {
-    const files = await glob('**/page.{tsx,js}', { cwd: routesDir });
-    const staticRoutes = files
-      .filter((file) => !/(^|\/)(\[\w+\]|_\w+_)\//.test(file))
-      .map((file) => '/' + file.slice(0, Math.max(0, file.lastIndexOf('/'))));
-    const dynamicRoutes = async (path: string) => {
-      const result = await getMappingAndItems(path + '/page');
-      return result !== null;
-    };
-    return {
-      static: staticRoutes,
-      dynamic: dynamicRoutes,
-    };
+  // existsPath
+  async (path: string) => {
+    if ((await getStaticPaths()).includes(path)) {
+      return 'static';
+    }
+    if ((await getMappingAndItems(path + '/page')) !== null) {
+      return 'dynamic';
+    }
+    return null;
   },
   // getComponent (id is "**/layout" or "**/page")
   async (id) => {
@@ -83,4 +85,6 @@ export default defineRouter(
     );
     return Component;
   },
+  // getPathsForBuild
+  async () => (await getStaticPaths()).map((path) => ({ path })),
 );

--- a/examples/10_dynamicroute/src/entries.tsx
+++ b/examples/10_dynamicroute/src/entries.tsx
@@ -73,7 +73,8 @@ export default defineRouter(
     return null;
   },
   // getComponent (id is "**/layout" or "**/page")
-  async (id) => {
+  async (id, unstable_setShouldSkip) => {
+    unstable_setShouldSkip({}); // always skip if possible
     const result = await getMappingAndItems(id);
     if (result === null) {
       return null;

--- a/examples/10_dynamicroute/src/main.tsx
+++ b/examples/10_dynamicroute/src/main.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from './components/ErrorBoundary.js';
 const rootElement = (
   <StrictMode>
     <ErrorBoundary fallback={(error) => <h1>{String(error)}</h1>}>
-      <Router shouldSkip={() => true} />
+      <Router />
     </ErrorBoundary>
   </StrictMode>
 );

--- a/examples/11_form/src/entries.tsx
+++ b/examples/11_form/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/examples/12_css/src/entries.tsx
+++ b/examples/12_css/src/entries.tsx
@@ -11,7 +11,7 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [['']] }],
+  async () => [{ pathname: '/', entries: [{ input: '' }] }],
   // getSsrConfig
   async ({ pathname }) => {
     switch (pathname) {

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -314,9 +314,13 @@ const emitRscFiles = async (
     return Array.from(idSet || []);
   };
   const rscFileSet = new Set<string>(); // XXX could be implemented better
+  const staticInputSet = new Set<string>();
   await Promise.all(
     Array.from(buildConfig).map(async ({ entries, context }) => {
-      for (const [input] of entries || []) {
+      for (const { input, isStatic } of entries || []) {
+        if (isStatic) {
+          staticInputSet.add(input);
+        }
         const destRscFile = joinPath(
           rootDir,
           config.distDir,
@@ -347,6 +351,13 @@ const emitRscFiles = async (
       }
     }),
   );
+  const skipRenderRscCode = `
+const staticInputSet = new Set(${JSON.stringify(Array.from(staticInputSet))});
+export function skipRenderRsc(input) {
+  return staticInputSet.has(input);
+}
+`;
+  await appendFile(distEntriesFile, skipRenderRscCode);
   return { buildConfig, getClientModules, rscFiles: Array.from(rscFileSet) };
 };
 
@@ -388,7 +399,7 @@ const emitHtmlFiles = async (
         );
         const inputsForPrefetch = new Set<string>();
         const moduleIdsForPrefetch = new Set<string>();
-        for (const [input, skipPrefetch] of entries || []) {
+        for (const { input, skipPrefetch } of entries || []) {
           if (!skipPrefetch) {
             inputsForPrefetch.add(input);
             for (const id of getClientModules(input)) {

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -439,6 +439,7 @@ const emitHtmlFiles = async (
               }),
             isDev: false,
             entries: distEntries,
+            isBuild: true,
           }));
         await mkdir(joinPath(destHtmlFile, '..'), { recursive: true });
         if (htmlReadable) {

--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -63,8 +63,9 @@ import { connectMiddleware } from 'waku';
 const entries = import(path.resolve('${config.distDir}', '${config.entriesJs}'));
 export default function handler(req, res) {
   connectMiddleware({ entries, ssr: ${ssr} })(req, res, () => {
-    const fname = path.resolve('${config.distDir}', '${config.publicDir}', req.url);
-    console.log('req', req, 'fname', fname);
+    const fname = path.join('${config.distDir}', '${config.publicDir}', req.url);
+    console.log('req.url', req.url, 'fname', fname);
+    /*
     if (fs.existsSync(fname)) {
       if (fname.endsWith('.html')) {
         res.setHeader('content-type', 'text/html; charset=utf-8');
@@ -74,6 +75,7 @@ export default function handler(req, res) {
       fs.createReadStream(fname).pipe(res);
       return;
     }
+    */
     res.statusCode = 404;
     res.end();
   });

--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -63,8 +63,12 @@ import { connectMiddleware } from 'waku';
 const entries = import(path.resolve('${config.distDir}', '${config.entriesJs}'));
 export default function handler(req, res) {
   connectMiddleware({ entries, ssr: ${ssr} })(req, res, () => {
-    const fname = path.join('${config.distDir}', '${config.publicDir}', req.url);
+    let fname = path.join('${config.distDir}', '${config.publicDir}', req.url);
+    if (fname.endsWith('/')) {
+      fname += '${config.indexHtml}';
+    }
     console.log('req.url', req.url, 'fname', fname);
+    console.log('exists', fs.existsSync(fname));
     /*
     if (fs.existsSync(fname)) {
       if (fname.endsWith('.html')) {

--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -67,7 +67,7 @@ export default function handler(req, res) {
       '${config.distDir}',
       '${config.publicDir}',
       req.url,
-      extname(req.url) ? '' : '${config.indexHtml}',
+      path.extname(req.url) ? '' : '${config.indexHtml}',
     );
     console.log('req.url', req.url, 'fname', fname);
     console.log('exists', fs.existsSync(fname));

--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -63,13 +63,14 @@ import { connectMiddleware } from 'waku';
 const entries = import(path.resolve('${config.distDir}', '${config.entriesJs}'));
 export default function handler(req, res) {
   connectMiddleware({ entries, ssr: ${ssr} })(req, res, () => {
-    let fname = path.join('${config.distDir}', '${config.publicDir}', req.url);
-    if (fname.endsWith('/')) {
-      fname += '${config.indexHtml}';
-    }
+    const fname = path.join(
+      '${config.distDir}',
+      '${config.publicDir}',
+      req.url,
+      extname(req.url) ? '' : '${config.indexHtml}',
+    );
     console.log('req.url', req.url, 'fname', fname);
     console.log('exists', fs.existsSync(fname));
-    /*
     if (fs.existsSync(fname)) {
       if (fname.endsWith('.html')) {
         res.setHeader('content-type', 'text/html; charset=utf-8');
@@ -79,7 +80,6 @@ export default function handler(req, res) {
       fs.createReadStream(fname).pipe(res);
       return;
     }
-    */
     res.statusCode = 404;
     res.end();
   });

--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -69,8 +69,6 @@ export default function handler(req, res) {
       req.url,
       path.extname(req.url) ? '' : '${config.indexHtml}',
     );
-    console.log('req.url', req.url, 'fname', fname);
-    console.log('exists', fs.existsSync(fname));
     if (fs.existsSync(fname)) {
       if (fname.endsWith('.html')) {
         res.setHeader('content-type', 'text/html; charset=utf-8');

--- a/packages/waku/src/lib/handlers/handler-prd.ts
+++ b/packages/waku/src/lib/handlers/handler-prd.ts
@@ -23,10 +23,6 @@ export function createHandler<
     throw new Error('prehook is required if posthook is provided');
   }
   const configPromise = resolveConfig(config || {});
-  const loadHtmlHeadPromise = entries.then(({ loadHtmlHead }) => loadHtmlHead);
-  const skipRenderRscPromise = entries.then(
-    ({ skipRenderRsc }) => skipRenderRsc,
-  );
 
   return async (req, res, next) => {
     const config = await configPromise;
@@ -49,8 +45,8 @@ export function createHandler<
     }
     if (ssr) {
       try {
-        const loadHtmlHead = await loadHtmlHeadPromise;
         const resolvedEntries = await entries;
+        const { loadHtmlHead } = resolvedEntries;
         const readable = await renderHtml({
           config,
           reqUrl: req.url,
@@ -85,7 +81,7 @@ export function createHandler<
       if (method !== 'GET' && method !== 'POST') {
         throw new Error(`Unsupported method '${method}'`);
       }
-      const skipRenderRsc = await skipRenderRscPromise;
+      const { skipRenderRsc } = await entries;
       try {
         const input = decodeInput(
           req.url.toString().slice(req.url.origin.length + basePrefix.length),

--- a/packages/waku/src/lib/handlers/handler-prd.ts
+++ b/packages/waku/src/lib/handlers/handler-prd.ts
@@ -66,6 +66,7 @@ export function createHandler<
             }),
           isDev: false,
           entries: resolvedEntries,
+          isBuild: false,
         });
         if (readable) {
           unstable_posthook?.(req, res, context as Context);

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -270,7 +270,7 @@ export const renderHtml = async (
       ? import(WAKU_CLIENT_MODULE_VALUE)
       : loadModule!('public/' + WAKU_CLIENT_MODULE),
   ]);
-  const ssrConfig = await getSsrConfig?.(reqUrl, !isDev && opts.isBuild);
+  const ssrConfig = await getSsrConfig?.(reqUrl, !isDev && !opts.isBuild);
   if (!ssrConfig) {
     return null;
   }

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -241,7 +241,7 @@ export const renderHtml = async (
     htmlHead: string;
     renderRscForHtml: (input: string) => Promise<ReadableStream>;
   } & (
-    | { isDev: false; entries: EntriesPrd }
+    | { isDev: false; entries: EntriesPrd; isBuild: boolean }
     | { isDev: true; entries: EntriesDev }
   ),
 ): Promise<ReadableStream | null> => {
@@ -270,7 +270,7 @@ export const renderHtml = async (
       ? import(WAKU_CLIENT_MODULE_VALUE)
       : loadModule!('public/' + WAKU_CLIENT_MODULE),
   ]);
-  const ssrConfig = await getSsrConfig?.(reqUrl);
+  const ssrConfig = await getSsrConfig?.(reqUrl, !isDev && opts.isBuild);
   if (!ssrConfig) {
     return null;
   }

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -252,7 +252,7 @@ export const renderHtml = async (
     loadModule,
   } = entries as (EntriesDev & { loadModule: undefined }) | EntriesPrd;
   const [
-    { createElement },
+    { createElement, Fragment },
     { renderToReadableStream },
     { createFromReadableStream },
     { ServerRoot, Slot },
@@ -374,7 +374,7 @@ export const renderHtml = async (
             Omit<ComponentProps<typeof ServerRoot>, 'children'>
           >,
           { elements },
-          ssrConfig.unstable_render({ createElement, Slot }),
+          ssrConfig.unstable_render({ createElement, Fragment, Slot }),
         ),
       ),
       {

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -1,19 +1,23 @@
 // This file should not include Node specific code.
 
+// TODO This might be too naive.
+// Should we use pathname and searchParams instead of input string?
+
 export const encodeInput = (input: string) => {
   if (input === '') {
     return 'index.txt';
-  } else if (!input.endsWith('/')) {
-    return input + '.txt';
   }
-  throw new Error("Input must not ends with '/'");
+  const [first, second] = input.split('?', 2);
+  return first + '.txt' + (second ? '?' + second : '');
 };
 
 export const decodeInput = (encodedInput: string) => {
   if (encodedInput === 'index.txt') {
     return '';
-  } else if (encodedInput.endsWith('.txt')) {
-    return encodedInput.slice(0, -'.txt'.length);
+  }
+  const [first, second] = encodedInput.split('?', 2);
+  if (first?.endsWith('.txt')) {
+    return first.slice(0, -'.txt'.length) + (second ? '?' + second : '');
   }
   const err = new Error('Invalid encoded input');
   (err as any).statusCode = 400;

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -2,18 +2,18 @@
 
 export const encodeInput = (input: string) => {
   if (input === '') {
-    return '_';
-  } else if (!input.startsWith('_')) {
-    return input;
+    return 'index.txt';
+  } else if (!input.endsWith('/')) {
+    return input + '.txt';
   }
-  throw new Error("Input must not start with '_'");
+  throw new Error("Input must not ends with '/'");
 };
 
 export const decodeInput = (encodedInput: string) => {
-  if (encodedInput === '_') {
+  if (encodedInput === 'index.txt') {
     return '';
-  } else if (!encodedInput.startsWith('_')) {
-    return encodedInput;
+  } else if (encodedInput.endsWith('.txt')) {
+    return encodedInput.slice(0, -'.txt'.length);
   }
   const err = new Error('Invalid encoded input');
   (err as any).statusCode = 400;

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -109,44 +109,38 @@ export function Link({
   return ele;
 }
 
-let shouldSkip: ShouldSkip | undefined;
 const getSkipList = (
   componentIds: readonly string[],
   props: RouteProps,
   cached: Record<string, RouteProps>,
 ): string[] => {
-  if (!shouldSkip) {
-    const ele = document.getElementById('__WAKU_ROUTER_SHOULD_SKIP__');
-    if (!ele) {
-      return [];
-    }
-    shouldSkip = JSON.parse(ele.textContent!);
+  const ele: any = document.querySelector('meta[name="waku-should-skip"]')
+  if (!ele) {
+    return [];
   }
-  return [
-    ...componentIds.filter((id) => {
-      const prevProps = cached[id];
-      if (!prevProps) {
-        return false;
-      }
-      const shouldCheck = shouldSkip?.[id];
-      if (!shouldCheck) {
-        return false;
-      }
-      if (shouldCheck.path && props.path !== prevProps.path) {
-        return false;
-      }
-      if (
-        shouldCheck.keys?.some(
-          (key) =>
-            props.searchParams.get(key) !== prevProps.searchParams.get(key),
-        )
-      ) {
-        return false;
-      }
-      return true;
-    }),
-    SHOULD_SKIP_ID,
-  ];
+  const shouldSkip: ShouldSkip = JSON.parse(ele.content);
+  return componentIds.filter((id) => {
+    const prevProps = cached[id];
+    if (!prevProps) {
+      return false;
+    }
+    const shouldCheck = shouldSkip?.[id];
+    if (!shouldCheck) {
+      return false;
+    }
+    if (shouldCheck.path && props.path !== prevProps.path) {
+      return false;
+    }
+    if (
+      shouldCheck.keys?.some(
+        (key) =>
+          props.searchParams.get(key) !== prevProps.searchParams.get(key),
+      )
+    ) {
+      return false;
+    }
+    return true;
+  });
 };
 
 function InnerRouter({ basePath }: { basePath: string }) {

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -114,7 +114,7 @@ const getSkipList = (
   props: RouteProps,
   cached: Record<string, RouteProps>,
 ): string[] => {
-  const ele: any = document.querySelector('meta[name="waku-should-skip"]')
+  const ele: any = document.querySelector('meta[name="waku-should-skip"]');
   if (!ele) {
     return [];
   }

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -62,3 +62,12 @@ export function parseInputString(input: string): {
     throw err;
   }
 }
+
+// the key is componentId
+export type ShouldSkip = Record<
+  string,
+  {
+    path: boolean; // if we compare path
+    keys?: string[]; // searchParams keys to compare
+  }
+>;

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -28,7 +28,7 @@ export function getInputString(
   let input = search
     ? '=' + path.replace(/\/$/, '/__INDEX__') + '/' + search
     : '-' + path.replace(/\/$/, '/__INDEX__');
-  if (skip) {
+  if (skip && skip.length) {
     const params = new URLSearchParams();
     skip.forEach((id) => params.append('skip', id));
     input += '?' + params;
@@ -62,6 +62,8 @@ export function parseInputString(input: string): {
     throw err;
   }
 }
+
+export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
 
 // the key is componentId
 export type ShouldSkip = Record<

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -63,9 +63,10 @@ export function parseInputString(input: string): {
   }
 }
 
+// It starts with "/" to avoid conflicing with normal component ids.
 export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
 
-// the key is componentId
+// The key is componentId
 export type ShouldSkip = Record<
   string,
   {

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -69,7 +69,7 @@ export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
 export type ShouldSkip = Record<
   string,
   {
-    path: boolean; // if we compare path
+    path?: boolean; // if we compare path
     keys?: string[]; // searchParams keys to compare
   }
 >;

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -16,9 +16,9 @@ const prefetcher = (
   path: string,
   searchParamsList: Iterable<URLSearchParams> | undefined,
 ) =>
-  Array.from(searchParamsList || []).map(
-    (searchParams) => [getInputString(path, searchParams)] as const,
-  );
+  Array.from(searchParamsList || []).map((searchParams) => ({
+    input: getInputString(path, searchParams),
+  }));
 
 const Default = ({ children }: { children: ReactNode }) => children;
 

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -11,7 +11,7 @@ import {
   parseInputString,
   SHOULD_SKIP_ID,
 } from './common.js';
-import type { RouteProps } from './common.js';
+import type { RouteProps, ShouldSkip } from './common.js';
 
 // eslint-disable-next-line import/no-named-as-default-member
 const { createElement } = ReactExports;
@@ -19,12 +19,11 @@ const { createElement } = ReactExports;
 const Default = ({ children }: { children: ReactNode }) => children;
 
 // TODO implement
-const ShoudSkipComponent = () =>
+const ShoudSkipComponent = ({ shouldSkip }: { shouldSkip: ShouldSkip }) =>
   createElement(
     'script',
     { id: '__WAKU_ROUTER_SHOULD_SKIP__', type: 'application/json' },
-    `
-{ "layout": {} }`,
+    JSON.stringify(shouldSkip),
   );
 
 export function defineRouter<P>(
@@ -61,8 +60,13 @@ export function defineRouter<P>(
         }),
       )
     ).flat();
-    // TODO should we skip this for the second time?
-    entries.push([SHOULD_SKIP_ID, createElement(ShoudSkipComponent)]);
+    if (!skip?.includes(SHOULD_SKIP_ID)) {
+      const shouldSkip: ShouldSkip = { layout: {}, page: {} };
+      entries.push([
+        SHOULD_SKIP_ID,
+        createElement(ShoudSkipComponent, { shouldSkip }) as any,
+      ]);
+    }
     return Object.fromEntries(entries);
   };
 

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -25,7 +25,7 @@ export function defineRouter<P>(
   existsPath: (path: string) => Promise<'static' | 'dynamic' | null>,
   getComponent: (
     componentId: string, // "**/layout" or "**/page"
-    unstable_setShouldSkip: (val: ShouldSkip[string]) => void,
+    unstable_setShouldSkip: (val?: ShouldSkip[string]) => void,
   ) => Promise<FunctionComponent<P> | { default: FunctionComponent<P> } | null>,
   getPathsForBuild?: () => Promise<
     Iterable<{ path: string; searchParams?: URLSearchParams }>
@@ -47,7 +47,11 @@ export function defineRouter<P>(
             return [];
           }
           const mod = await getComponent(id, (val) => {
-            shouldSkip[id] = val;
+            if (val) {
+              shouldSkip[id] = val;
+            } else {
+              delete shouldSkip[id];
+            }
           });
           const component =
             typeof mod === 'function' ? mod : mod?.default || Default;

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -13,6 +13,17 @@ const { createElement } = ReactExports;
 
 const Default = ({ children }: { children: ReactNode }) => children;
 
+// TODO implement
+const ShoudSkipComponent = () =>
+  createElement(
+    'script',
+    null,
+    `
+globalThis.__WAKU_ROUTER_SHOULD_SKIP__ = {
+  'layout': { path: true },
+};`,
+  );
+
 export function defineRouter<P>(
   existsPath: (path: string) => Promise<'static' | 'dynamic' | null>,
   getComponent: (
@@ -47,6 +58,8 @@ export function defineRouter<P>(
         }),
       )
     ).flat();
+    // TODO should we skip this for the second time?
+    entries.push(['/SHOULD_SKIP', createElement(ShoudSkipComponent)]);
     return Object.fromEntries(entries);
   };
 
@@ -97,10 +110,9 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path, searchParams) => {
     );
   };
 
-  const getSsrConfig: GetSsrConfig = async (reqUrl, isBuild) => {
-    if (
-      (await existsPath(reqUrl.pathname)) !== (isBuild ? 'static' : 'dynamic')
-    ) {
+  // TODO this API is not very understandable and not consistent with RSC
+  const getSsrConfig: GetSsrConfig = async (reqUrl, isPrd) => {
+    if ((await existsPath(reqUrl.pathname)) !== (isPrd ? 'dynamic' : null)) {
       return null;
     }
     const componentIds = getComponentIds(reqUrl.pathname);

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,4 +1,4 @@
-import type { createElement, ReactNode } from 'react';
+import type { createElement, Fragment, ReactNode } from 'react';
 
 import type { Slot } from './client.js';
 
@@ -36,6 +36,7 @@ export type GetSsrConfig = (
   input: string;
   unstable_render: (opts: {
     createElement: typeof createElement;
+    Fragment: typeof Fragment;
     Slot: typeof Slot;
   }) => ReactNode;
 } | null>;

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -19,7 +19,11 @@ export type GetBuildConfig = (
 ) => Promise<
   Iterable<{
     pathname: string;
-    entries?: Iterable<readonly [input: string, skipPrefetch?: boolean]>;
+    entries?: Iterable<{
+      input: string;
+      skipPrefetch?: boolean;
+      isStatic?: boolean;
+    }>;
     customCode?: string; // optional code to inject TODO hope to remove this
     context?: unknown;
   }>
@@ -48,4 +52,5 @@ export type EntriesDev = {
 export type EntriesPrd = EntriesDev & {
   loadModule: (id: string) => Promise<unknown>;
   loadHtmlHead: (pathname: string) => string;
+  skipRenderRsc: (input: string) => boolean;
 };

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -29,7 +29,10 @@ export type GetBuildConfig = (
   }>
 >;
 
-export type GetSsrConfig = (reqUrl: URL) => Promise<{
+export type GetSsrConfig = (
+  reqUrl: URL,
+  isBuild: boolean,
+) => Promise<{
   input: string;
   unstable_render: (opts: {
     createElement: typeof createElement;

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -31,7 +31,7 @@ export type GetBuildConfig = (
 
 export type GetSsrConfig = (
   reqUrl: URL,
-  isBuild: boolean,
+  isPrd: boolean,
 ) => Promise<{
   input: string;
   unstable_render: (opts: {

--- a/packages/website/src/entries.tsx
+++ b/packages/website/src/entries.tsx
@@ -1,10 +1,10 @@
 import { defineRouter } from 'waku/router/server';
 
+const STATIC_PATHS = ['/', '/blog/introducing-waku'];
+
 export default defineRouter(
-  // getRoutePaths
-  async () => ({
-    static: ['/', '/blog/introducing-waku'],
-  }),
+  // existsPath
+  async (path: string) => (STATIC_PATHS.includes(path) ? 'static' : null),
   // getComponent (id is "**/layout" or "**/page")
   async (id) => {
     switch (id) {
@@ -18,4 +18,6 @@ export default defineRouter(
         return null;
     }
   },
+  // getPathsForBuild
+  async () => STATIC_PATHS.map((path) => ({ path })),
 );

--- a/packages/website/src/entries.tsx
+++ b/packages/website/src/entries.tsx
@@ -6,7 +6,8 @@ export default defineRouter(
   // existsPath
   async (path: string) => (STATIC_PATHS.includes(path) ? 'static' : null),
   // getComponent (id is "**/layout" or "**/page")
-  async (id) => {
+  async (id, unstable_setShouldSkip) => {
+    unstable_setShouldSkip({}); // always skip if possible
     switch (id) {
       case 'layout':
         return import('./routes/layout.js');

--- a/packages/website/src/main.tsx
+++ b/packages/website/src/main.tsx
@@ -4,7 +4,7 @@ import { Router } from 'waku/router/client';
 
 const rootElement = (
   <StrictMode>
-    <Router shouldSkip={() => true} />
+    <Router />
   </StrictMode>
 );
 

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -4,6 +4,11 @@ export default defineConfig(({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
   if (mode === 'development') {
     return {
+      optimizeDeps: {
+        include: [
+          // '@uidotdev/usehooks',
+        ],
+      },
       ssr: {
         external: ['next-mdx-remote'],
       },


### PR DESCRIPTION
This is something I wanted for some time.
Now, we can skip rendering RSC and/or HTML on the server.
In addition to it, with router, we can let the client to skip requesting for some/all route components.

It's working as expected, but now I fee the API and the core implementation is full of hacks. It's not easy to understand and thus not very maintainable for the future.

We should revisit it after getting some feedbacks.