### PR TITLE
website: disable --with-vercel-static for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "examples:prd:12_css": "NAME=12_css pnpm run examples:prd",
     "website:dev": "(cd packages/website && pnpm run dev)",
     "website:build": "cd packages/website && pnpm run build",
-    "website:vercel": "pnpm run website:build --with-vercel-static && mv packages/website/.vercel/output .vercel/ && (cp -r README.md packages/website/src/contents .vercel/output/functions/RSC.func/ ; true)",
+    "website:vercel": "pnpm run website:build && mv packages/website/.vercel/output .vercel/ && (cp -r README.md packages/website/src/contents .vercel/output/functions/RSC.func/ ; true)",
     "website:prd": "pnpm run website:build && (cd packages/website && pnpm start)"
   },
   "prettier": {


### PR DESCRIPTION
even #313 didn't work.

The problem is generated html that only happens Vercel production build. It doesn't happen with Vercel preview build.

[index.html.zip](https://github.com/dai-shi/waku/files/13767782/index.html.zip)

Assuming it's static only problem, disabling it for now.