### PR TITLE
feat: css hmr

### DIFF
--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -1,7 +1,7 @@
 import type { Worker as WorkerOrig } from 'node:worker_threads';
 
 import type { ResolvedConfig } from '../config.js';
-import type { TransformResult } from 'vite';
+import type { ModuleImportResult } from './types.js';
 
 export type RenderRequest = {
   input: string;
@@ -32,7 +32,7 @@ export type MessageReq =
 export type MessageRes =
   | { type: 'full-reload' }
   | { type: 'hot-import'; source: string }
-  | { type: 'module-import'; result: TransformResult }
+  | { type: 'module-import'; result: ModuleImportResult }
   | { id: number; type: 'start'; context: unknown }
   | { id: number; type: 'buf'; buf: ArrayBuffer; offset: number; len: number }
   | { id: number; type: 'end' }
@@ -105,7 +105,7 @@ export async function registerImportCallback(fn: (source: string) => void) {
 }
 
 export async function registerModuleCallback(
-  fn: (result: TransformResult) => void,
+  fn: (result: ModuleImportResult) => void,
 ) {
   const worker = await getWorker();
   const listener = (mesg: MessageRes) => {

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -91,15 +91,17 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
 
 const dummyServer = new Server(); // FIXME we hope to avoid this hack
 
+const moduleImports: Set<string> = new Set();
+
 const mergedViteConfig = await mergeUserViteConfig({
   plugins: [
     nonjsResolvePlugin(),
     rscTransformPlugin(false),
-    rscReloadPlugin((type) => {
+    rscReloadPlugin(moduleImports, (type) => {
       const mesg: MessageRes = { type };
       parentPort!.postMessage(mesg);
     }),
-    rscDelegatePlugin((resultOrSource) => {
+    rscDelegatePlugin(moduleImports, (resultOrSource) => {
       const mesg: MessageRes =
         typeof resultOrSource === 'object'
           ? { type: 'module-import', result: resultOrSource }

--- a/packages/waku/src/lib/handlers/types.ts
+++ b/packages/waku/src/lib/handlers/types.ts
@@ -1,3 +1,5 @@
+import type { TransformResult } from 'vite';
+
 export type BaseReq = {
   stream: ReadableStream;
   url: URL;
@@ -16,3 +18,7 @@ export type Handler<Req extends BaseReq, Res extends BaseRes> = (
   res: Res,
   next: (err?: unknown) => void,
 ) => void;
+
+export type ModuleImportResult = TransformResult & {
+  id: string;
+};

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-delegate.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-delegate.ts
@@ -8,12 +8,12 @@ const CSS_LANGS_RE =
   /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
 
 export function rscDelegatePlugin(
+  moduleImports: Set<string>,
   importCallback: (source: string | ModuleImportResult) => void,
 ): Plugin {
   let mode = 'development';
   let base = '/';
   let server: ViteDevServer;
-  const moduleImports: Set<string> = new Set();
   return {
     name: 'rsc-delegate-plugin',
     configResolved(config) {
@@ -27,7 +27,6 @@ export function rscDelegatePlugin(
       if (moduleImports.has(file)) {
         // re-inject
         const transformedResult = await server.transformRequest(file);
-        console.log('re-inject');
         transformedResult && importCallback({ ...transformedResult, id: file });
       }
     },
@@ -53,7 +52,6 @@ export function rscDelegatePlugin(
                 id,
                 { ssr: true },
               );
-              console.log('resolved id', resolvedSource?.id);
               if (resolvedSource?.id) {
                 const transformedResult = await server.transformRequest(
                   resolvedSource.id,

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -1,4 +1,5 @@
-import type { Plugin, TransformResult, ViteDevServer } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
+import type { ModuleImportResult } from '../handlers/types.js';
 
 const customCode = `
 import { createHotContext as __vite__createHotContext } from "/@vite/client";
@@ -8,10 +9,17 @@ if (import.meta.hot && !globalThis.__WAKU_HMR_CONFIGURED__) {
   globalThis.__WAKU_HMR_CONFIGURED__ = true;
   import.meta.hot.on('hot-import', (data) => import(/* @vite-ignore */ data));
   import.meta.hot.on('module', (data) => {
+    // remove elment with the same 'waku-module-id'
+    let script = document.querySelector(
+      'script[waku-module-id="' + data.id + '"]',
+    );
+    script?.remove()
+
     const code = data.code;
-    const script = document.createElement('script');
+    script = document.createElement('script');
     script.type = 'module';
     script.text = code;
+    script.setAttribute('waku-module-id', data.id)
     document.head.appendChild(script);
   });
 }
@@ -51,11 +59,11 @@ export function hotImport(vite: ViteDevServer, source: string) {
   vite.ws.send({ type: 'custom', event: 'hot-import', data: source });
 }
 
-const modulePendingMap = new WeakMap<ViteDevServer, Set<TransformResult>>();
+const modulePendingMap = new WeakMap<ViteDevServer, Set<ModuleImportResult>>();
 
 export function moduleImport(
   viteServer: ViteDevServer,
-  result: TransformResult,
+  result: ModuleImportResult,
 ) {
   let sourceSet = modulePendingMap.get(viteServer);
   if (!sourceSet) {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -9,7 +9,7 @@ if (import.meta.hot && !globalThis.__WAKU_HMR_CONFIGURED__) {
   globalThis.__WAKU_HMR_CONFIGURED__ = true;
   import.meta.hot.on('hot-import', (data) => import(/* @vite-ignore */ data));
   import.meta.hot.on('module', (data) => {
-    // remove elment with the same 'waku-module-id'
+    // remove element with the same 'waku-module-id'
     let script = document.querySelector(
       'script[waku-module-id="' + data.id + '"]',
     );

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -13,13 +13,13 @@ if (import.meta.hot && !globalThis.__WAKU_HMR_CONFIGURED__) {
     let script = document.querySelector(
       'script[waku-module-id="' + data.id + '"]',
     );
-    script?.remove()
+    script?.remove();
 
     const code = data.code;
     script = document.createElement('script');
     script.type = 'module';
     script.text = code;
-    script.setAttribute('waku-module-id', data.id)
+    script.setAttribute('waku-module-id', data.id);
     document.head.appendChild(script);
   });
 }

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-reload.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-reload.ts
@@ -31,14 +31,14 @@ export function rscReloadPlugin(fn: (type: 'full-reload') => void): Plugin {
       }
     },
     async handleHotUpdate(ctx) {
-      if (!enabled) {
-        return [];
-      }
-      if (ctx.modules.length && !isClientEntry(ctx.file, await ctx.read())) {
-        fn('full-reload');
-      } else {
-        return [];
-      }
+      // if (!enabled) {
+      //   return [];
+      // }
+      // if (ctx.modules.length && !isClientEntry(ctx.file, await ctx.read())) {
+      //   fn('full-reload');
+      // } else {
+      //   return [];
+      // }
     },
   };
 }

--- a/packages/website/src/style.css
+++ b/packages/website/src/style.css
@@ -2,6 +2,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=block');
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=block');
 @tailwind base;
+
 :root {
   @apply bg-black;
 }

--- a/packages/website/src/style.css
+++ b/packages/website/src/style.css
@@ -2,7 +2,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&display=block');
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=block');
 @tailwind base;
-
 :root {
   @apply bg-black;
 }


### PR DESCRIPTION
In `handleHotUpdate` we re-inject/re-transform the module and send an update to the hmr listener (`import.meta.hot.on('module', ...)`). 

To avoid multiple hmr script tags, we add an `id` to the `TransformResult` (now `ModuleImportResult`) so we can identify any script tag with the same `waku-module-id` so we remove it from the DOM and replace it with a new one that has the new content.  