### PR TITLE
chore(worker-api/impl): pass stream to parent

### DIFF
--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -21,10 +21,10 @@ export type BuildOutput = {
 
 export type MessageReq =
   | ({
-    id: number;
-    type: 'render';
-    hasModuleIdCallback: boolean;
-  } & Omit<RenderRequest, 'stream' | 'moduleIdCallback'>)
+      id: number;
+      type: 'render';
+      hasModuleIdCallback: boolean;
+    } & Omit<RenderRequest, 'stream' | 'moduleIdCallback'>)
   | { id: number; type: 'pipe'; stream: ReadableStream };
 
 export type MessageRes =
@@ -122,7 +122,7 @@ export async function renderRscWithWorker<Context>(
   const id = nextId++;
   const pipe = async () => {
     if (rr.stream) {
-      worker.postMessage({ id, type: 'pipe', stream: rr.stream } as MessageReq)
+      worker.postMessage({ id, type: 'pipe', stream: rr.stream } as MessageReq);
     }
   };
   let started = false;

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -144,7 +144,7 @@ export async function renderRscWithWorker<Context>(
             },
           });
           mesg.stream.pipeThrough(bridge);
-          resolve([bridge.readable, mesg.context as Context]);
+          resolve([mesg.stream.pipeThrough(bridge), mesg.context as Context]);
         } else {
           throw new Error('already started');
         }

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -125,8 +125,9 @@ export async function renderRscWithWorker<Context>(
   const id = nextId++;
   const pipe = async () => {
     if (rr.stream) {
+      const mesg: MessageReq = { id, type: 'pipe', stream: rr.stream };
       worker.postMessage(
-        { id, type: 'pipe', stream: rr.stream } as MessageReq,
+        mesg,
         [rr.stream as unknown as TransferListItem],
       );
     }

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -161,6 +161,9 @@ export async function renderRscWithWorker<Context>(
       ...(rr.stream ? { stream: rr.stream } : {}),
       ...copied,
     };
-    worker.postMessage(mesg, [rr.stream as unknown as TransferListItem]);
+    worker.postMessage(
+      mesg,
+      rr.stream ? [rr.stream as unknown as TransferListItem] : undefined,
+    );
   });
 }

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -163,7 +163,13 @@ export async function renderRscWithWorker<Context>(
       if (mesg.type === 'start') {
         if (!started) {
           started = true;
-          resolve([mesg.stream, mesg.context as Context]);
+          const bridge = new TransformStream({
+            flush() {
+              messageCallbacks.delete(id);
+            },
+          });
+          mesg.stream.pipeThrough(bridge);
+          resolve([bridge.readable, mesg.context as Context]);
         } else {
           throw new Error('already started');
         }

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -67,7 +67,7 @@ const getWorker = () => {
             ],
           },
         );
-        worker.on('message', async (mesg: MessageRes) => {
+        worker.on('message', (mesg: MessageRes) => {
           if ('id' in mesg) {
             messageCallbacks.get(mesg.id)?.(mesg);
           }

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -1,4 +1,7 @@
-import type { Worker as WorkerOrig } from 'node:worker_threads';
+import type {
+  TransferListItem,
+  Worker as WorkerOrig,
+} from 'node:worker_threads';
 
 import type { ResolvedConfig } from '../config.js';
 import type { ModuleImportResult } from './types.js';
@@ -122,7 +125,10 @@ export async function renderRscWithWorker<Context>(
   const id = nextId++;
   const pipe = async () => {
     if (rr.stream) {
-      worker.postMessage({ id, type: 'pipe', stream: rr.stream } as MessageReq);
+      worker.postMessage(
+        { id, type: 'pipe', stream: rr.stream } as MessageReq,
+        [rr.stream as unknown as TransferListItem],
+      );
     }
   };
   let started = false;

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -141,7 +141,7 @@ parentPort!.on('message', (mesg: MessageReq) => {
             controller.error(new Error('Unexepected buffer type'));
           }
         },
-        close: controller.close,
+        close: () => controller.close(),
       }),
     );
   }

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -1,10 +1,11 @@
 // This file can depend on Node.js
 
 import { pathToFileURL } from 'node:url';
-import { parentPort, type TransferListItem } from 'node:worker_threads';
+import { parentPort } from 'node:worker_threads';
 import { Server } from 'node:http';
 import { createServer as createViteServer } from 'vite';
 
+import type { TransferListItem } from 'node:worker_threads';
 import type { EntriesDev } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { joinPath, fileURLToFilePath } from '../utils/path.js';

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -9,7 +9,7 @@ import { createServer as createViteServer } from 'vite';
 import type { EntriesDev } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { joinPath, fileURLToFilePath } from '../utils/path.js';
-import { hasStatusCode } from '../renderers/utils.js';
+import { deepFreeze, hasStatusCode } from '../renderers/utils.js';
 import type {
   MessageReq,
   MessageRes,
@@ -65,6 +65,7 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
       stream: readable,
     };
     parentPort!.postMessage(mesg, [readable as unknown as TransferListItem]);
+    deepFreeze(rr.context);
   } catch (err) {
     const mesg: MessageRes = { id, type: 'err', err };
     if (hasStatusCode(err)) {

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -28,7 +28,10 @@ if (HAS_MODULE_REGISTER) {
   module.register('waku/node-loader', pathToFileURL('./'));
 }
 
-const handleRender = async (mesg: MessageReq & { type: 'render' }, stream: ReadableStream) => {
+const handleRender = async (
+  mesg: MessageReq & { type: 'render' },
+  stream: ReadableStream,
+) => {
   const { id, type: _removed, hasModuleIdCallback, ...rest } = mesg;
   const rr: RenderRequest = rest;
   try {
@@ -130,10 +133,10 @@ parentPort!.on('message', (mesg: MessageReq) => {
         } else {
           controller.error(new Error('Unexepected buffer type'));
         }
-      }
-    })
+      },
+    });
 
-    mesg.stream?.pipeThrough(bridge)
+    mesg.stream?.pipeThrough(bridge);
     handleRender(mesg, bridge.readable);
   }
 });

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -3,9 +3,9 @@
 import { pathToFileURL } from 'node:url';
 import { parentPort } from 'node:worker_threads';
 import { Server } from 'node:http';
+import type { TransferListItem } from 'node:worker_threads';
 import { createServer as createViteServer } from 'vite';
 
-import type { TransferListItem } from 'node:worker_threads';
 import type { EntriesDev } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { joinPath, fileURLToFilePath } from '../utils/path.js';

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -49,7 +49,7 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
       searchParams: new URLSearchParams(rr.searchParamsString),
       method: rr.method,
       context: rr.context,
-      body: rr.stream!,
+      ...(rr.stream ? { body: rr.stream } : {}),
       contentType: rr.contentType,
       ...(rr.moduleIdCallback ? { moduleIdCallback: rr.moduleIdCallback } : {}),
       isDev: true,

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -130,17 +130,19 @@ parentPort!.on('message', (mesg: MessageReq) => {
     handleRender(mesg);
   } else if (mesg.type === 'pipe') {
     const controller = controllerMap.get(mesg.id)!;
-    mesg.stream.pipeTo(new WritableStream({
-      write: (chunk) => {
-        if (chunk instanceof Uint8Array) {
-          controller.enqueue(chunk)
-        } else if (chunk instanceof ArrayBuffer) {
-          controller.enqueue(new Uint8Array(chunk, 0, chunk.byteLength))
-        } else {
-          controller.error(new Error('Unexepected buffer type'));
-        }
-      },
-      close: controller.close
-    }))
+    mesg.stream.pipeTo(
+      new WritableStream({
+        write: (chunk) => {
+          if (chunk instanceof Uint8Array) {
+            controller.enqueue(chunk);
+          } else if (chunk instanceof ArrayBuffer) {
+            controller.enqueue(new Uint8Array(chunk, 0, chunk.byteLength));
+          } else {
+            controller.error(new Error('Unexepected buffer type'));
+          }
+        },
+        close: controller.close,
+      }),
+    );
   }
 });

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -125,12 +125,12 @@ const loadEntries = async (config: ResolvedConfig) => {
   return vite.ssrLoadModule(filePath) as Promise<EntriesDev>;
 };
 
-parentPort!.on('message', (mesg: MessageReq) => {
+parentPort!.on('message', async (mesg: MessageReq) => {
   if (mesg.type === 'render') {
     handleRender(mesg);
-  } else if (mesg.type === 'pipe') {
+
     const controller = controllerMap.get(mesg.id)!;
-    mesg.stream.pipeTo(
+    mesg.stream?.pipeTo(
       new WritableStream({
         write: (chunk) => {
           if (chunk instanceof Uint8Array) {

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -125,7 +125,7 @@ const loadEntries = async (config: ResolvedConfig) => {
   return vite.ssrLoadModule(filePath) as Promise<EntriesDev>;
 };
 
-parentPort!.on('message', async (mesg: MessageReq) => {
+parentPort!.on('message', (mesg: MessageReq) => {
   if (mesg.type === 'render') {
     handleRender(mesg);
 

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -178,14 +178,11 @@ globalThis.__WAKU_PREFETCHED__ = {
             return;
           }
           headSent = true;
-          controller.enqueue(encoder.encode(modifyHead(data)));
-          data = '';
-          sendScripts(controller);
-          return;
+          data = modifyHead(data);
         }
-        const closingBodyIndex = data.indexOf('</body>');
+        const closingBodyIndex = data.lastIndexOf('</body>');
         if (closingBodyIndex === -1) {
-          controller.enqueue(chunk);
+          controller.enqueue(encoder.encode(data));
           data = '';
           sendScripts(controller);
         } else {


### PR DESCRIPTION
Resolves #308 

We implemented our messaging method, but streams are already transferrable between the worker and the main thread. The only issue is that the types are not supporting them although the implementation does support them, that's why I used `as unknown as TransferListItem`