### PR TITLE
fix: `update-check` not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r --filter="./packages/create-waku" run compile
+      # cleanup node_modules for testing
+      - run: rm -rf packages/create-waku/node_modules
       - uses: actions/upload-artifact@v4
         with:
           name: create-waku

--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -2,11 +2,12 @@
 import { existsSync, readdirSync } from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { default as prompts } from 'prompts';
 import { red, green, bold } from 'kolorist';
 import fse from 'fs-extra/esm';
+import checkForUpdate from 'update-check';
+import packageJson from '../package.json';
 
 function isValidPackageName(projectName: string) {
   return /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(
@@ -29,10 +30,6 @@ function canSafelyOverwrite(dir: string) {
 }
 
 async function notifyUpdate() {
-  const nodeRequire = createRequire(import.meta.url);
-  // `update-check` is a CSJ module.
-  const checkForUpdate = nodeRequire('update-check');
-  const packageJson = nodeRequire('../package.json');
   const result = await checkForUpdate(packageJson).catch(() => null);
   if (result?.latest) {
     console.log(`A new version of 'create-waku' is available!`);

--- a/packages/create-waku/tsconfig.json
+++ b/packages/create-waku/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
     "rootDir": "./src",
     "outDir": "./dist",
     "lib": ["esnext"],
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "moduleResolution": "bundler"
   },
   "include": ["./src"],
   "exclude": ["./template"],


### PR DESCRIPTION
Fixes: https://github.com/dai-shi/waku/issues/346

Just noticed that we are using `@vercel/ncc` which is a bundler, so we can mix cjs and esm