### PR TITLE
Node compatible `process.env`

### DIFF
--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -68,8 +68,12 @@ const getWorker = () => {
         throw e;
       }),
     ])
-      .then(([{ Worker }, { default: module }]) => {
+      .then(([{ Worker, setEnvironmentData }, { default: module }]) => {
         const HAS_MODULE_REGISTER = typeof module.register === 'function';
+        setEnvironmentData(
+          '__WAKU_PRIVATE_ENV__',
+          (globalThis as any).__WAKU_PRIVATE_ENV__,
+        );
         const worker = new Worker(
           new URL('dev-worker-impl.js', import.meta.url),
           {
@@ -81,11 +85,6 @@ const getWorker = () => {
               'react-server',
               'workerd',
             ],
-            env: {
-              __WAKU_PRIVATE_ENV__: JSON.stringify(
-                (globalThis as any).__WAKU_PRIVATE_ENV__,
-              ),
-            },
           },
         );
         worker.on('message', (mesg: MessageRes) => {

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -1,7 +1,7 @@
 // This file can depend on Node.js
 
 import { pathToFileURL } from 'node:url';
-import { parentPort } from 'node:worker_threads';
+import { parentPort, getEnvironmentData } from 'node:worker_threads';
 import { Server } from 'node:http';
 import type { TransferListItem } from 'node:worker_threads';
 import { createServer as createViteServer } from 'vite';
@@ -29,8 +29,8 @@ if (HAS_MODULE_REGISTER) {
   module.register('waku/node-loader', pathToFileURL('./'));
 }
 
-(globalThis as any).__WAKU_PRIVATE_ENV__ = JSON.parse(
-  process.env.__WAKU_PRIVATE_ENV__!,
+(globalThis as any).__WAKU_PRIVATE_ENV__ = getEnvironmentData(
+  '__WAKU_PRIVATE_ENV__',
 );
 
 const handleRender = async (mesg: MessageReq & { type: 'render' }) => {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
@@ -16,12 +16,6 @@ export function rscEnvPlugin({
       viteConfig.define = {
         ...viteConfig.define,
         ...Object.fromEntries([
-          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
-            ([k, v]) =>
-              k.startsWith('WAKU_PUBLIC_')
-                ? [[`import.meta.env.${k}`, JSON.stringify(v)]]
-                : [],
-          ),
           ...(config
             ? [
                 [
@@ -37,6 +31,19 @@ export function rscEnvPlugin({
           ...(hydrate
             ? [['import.meta.env.WAKU_HYDRATE', JSON.stringify('true')]]
             : []),
+          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
+            ([k, v]) =>
+              k.startsWith('WAKU_PUBLIC_')
+                ? [[`import.meta.env.${k}`, JSON.stringify(v)]]
+                : [],
+          ),
+          // Node style `process.env` for traditional compatibility
+          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
+            ([k, v]) =>
+              k.startsWith('WAKU_PUBLIC_')
+                ? [[`process.env.${k}`, JSON.stringify(v)]]
+                : [],
+          ),
         ]),
       };
     },


### PR DESCRIPTION
While we support non-Node environment, many use cases are with Node. We support using `process.env` on the server with Node, and also `process.env.WAKU_PUBLIC_*` for client bundling in addition to `import.meta.env.WAKU_PUBLIC_*` which is the recommended way.