### PR TITLE
fix: reduce unnecessary ts config from examples

### DIFF
--- a/examples/01_counter/tsconfig.json
+++ b/examples/01_counter/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/01_counter/tsconfig.json
+++ b/examples/01_counter/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/02_async/tsconfig.json
+++ b/examples/02_async/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/03_promise/tsconfig.json
+++ b/examples/03_promise/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/03_promise/tsconfig.json
+++ b/examples/03_promise/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/04_callserver/tsconfig.json
+++ b/examples/04_callserver/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/04_callserver/tsconfig.json
+++ b/examples/04_callserver/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/05_mutation/tsconfig.json
+++ b/examples/05_mutation/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/05_mutation/tsconfig.json
+++ b/examples/05_mutation/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/06_nesting/tsconfig.json
+++ b/examples/06_nesting/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/06_nesting/tsconfig.json
+++ b/examples/06_nesting/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/07_router/tsconfig.json
+++ b/examples/07_router/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/07_router/tsconfig.json
+++ b/examples/07_router/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/08_cookies/package.json
+++ b/examples/08_cookies/package.json
@@ -16,6 +16,7 @@
     "waku": "0.19.0-beta.0"
   },
   "devDependencies": {
+    "@types/node": "^20.10.6",
     "@types/react": "18.2.46",
     "@types/react-dom": "18.2.18",
     "typescript": "5.3.3"

--- a/examples/08_cookies/tsconfig.json
+++ b/examples/08_cookies/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental", "node"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/08_cookies/tsconfig.json
+++ b/examples/08_cookies/tsconfig.json
@@ -8,9 +8,8 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["node", "react/experimental"],
+    "types": ["react/experimental", "node"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/09_cssmodules/tsconfig.json
+++ b/examples/09_cssmodules/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/09_cssmodules/tsconfig.json
+++ b/examples/09_cssmodules/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -10,8 +10,7 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "outDir": "./dist",
-    "composite": true
+    "outDir": "./dist"
   },
   "include": ["./src", "tsconfig.json"]
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -13,10 +13,5 @@
     "outDir": "./dist",
     "composite": true
   },
-  "include": ["./src"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "include": ["./src", "tsconfig.json"]
 }

--- a/examples/10_dynamicroute/tsconfig.json
+++ b/examples/10_dynamicroute/tsconfig.json
@@ -11,6 +11,5 @@
     "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
-  },
-  "include": ["./src", "tsconfig.json"]
+  }
 }

--- a/examples/10_dynamicroute/tsconfig.node.json
+++ b/examples/10_dynamicroute/tsconfig.node.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist/node",
-    "types": ["node"]
-  },
-  "include": ["vite.config.ts"]
-}

--- a/examples/11_form/tsconfig.json
+++ b/examples/11_form/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/11_form/tsconfig.json
+++ b/examples/11_form/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
   }
 }

--- a/examples/12_css/tsconfig.json
+++ b/examples/12_css/tsconfig.json
@@ -10,8 +10,7 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "outDir": "./dist",
-    "composite": true
+    "outDir": "./dist"
   },
   "include": ["./src", "tsconfig.json"]
 }

--- a/examples/12_css/tsconfig.json
+++ b/examples/12_css/tsconfig.json
@@ -9,7 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "outDir": "./dist"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/12_css/tsconfig.json
+++ b/examples/12_css/tsconfig.json
@@ -13,10 +13,5 @@
     "outDir": "./dist",
     "composite": true
   },
-  "include": ["./src"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "include": ["./src", "tsconfig.json"]
 }

--- a/examples/12_css/tsconfig.json
+++ b/examples/12_css/tsconfig.json
@@ -11,6 +11,5 @@
     "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist"
-  },
-  "include": ["./src", "tsconfig.json"]
+  }
 }

--- a/examples/12_css/tsconfig.node.json
+++ b/examples/12_css/tsconfig.node.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist/node",
-    "types": ["node"]
-  },
-  "include": ["vite.config.ts"]
-}

--- a/examples/13_path-alias/tsconfig.json
+++ b/examples/13_path-alias/tsconfig.json
@@ -16,10 +16,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["./src"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "include": ["./src", "tsconfig.json"]
 }

--- a/examples/13_path-alias/tsconfig.json
+++ b/examples/13_path-alias/tsconfig.json
@@ -14,6 +14,5 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  },
-  "include": ["./src", "tsconfig.json"]
+  }
 }

--- a/examples/13_path-alias/tsconfig.json
+++ b/examples/13_path-alias/tsconfig.json
@@ -10,7 +10,6 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/examples/13_path-alias/tsconfig.json
+++ b/examples/13_path-alias/tsconfig.json
@@ -11,7 +11,6 @@
     "types": ["react/experimental"],
     "jsx": "react-jsx",
     "outDir": "./dist",
-    "composite": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/examples/13_path-alias/tsconfig.node.json
+++ b/examples/13_path-alias/tsconfig.node.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist/node",
-    "types": ["node"]
-  },
-  "include": ["vite.config.ts"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
         specifier: 0.19.0-beta.0
         version: link:../../packages/waku
     devDependencies:
+      '@types/node':
+        specifier: ^20.10.6
+        version: 20.10.6
       '@types/react':
         specifier: 18.2.46
         version: 18.2.46

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,46 +35,6 @@
     {
       "path": "./packages/website"
     },
-    // Examples
-    {
-      "path": "./examples/01_counter"
-    },
-    {
-      "path": "./examples/02_async"
-    },
-    {
-      "path": "./examples/03_promise"
-    },
-    {
-      "path": "./examples/04_callserver"
-    },
-    {
-      "path": "./examples/05_mutation"
-    },
-    {
-      "path": "./examples/06_nesting"
-    },
-    {
-      "path": "./examples/07_router"
-    },
-    {
-      "path": "./examples/08_cookies"
-    },
-    {
-      "path": "./examples/09_cssmodules"
-    },
-    {
-      "path": "./examples/10_dynamicroute"
-    },
-    {
-      "path": "./examples/11_form"
-    },
-    {
-      "path": "./examples/12_css"
-    },
-    {
-      "path": "./examples/13_path-alias"
-    },
     // E2E
     {
       "path": "./tsconfig.e2e.json"


### PR DESCRIPTION
It might be ok to remove this. Don't be too strict with the user.

Also remove examples from monorepo. E2e smoke check will build the project and check the type