### PR TITLE
fix: avoid vite config has changed

### DIFF
--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -71,13 +71,6 @@ for (const cwd of examples) {
         let cp: ChildProcess;
         let port: number;
         test.beforeAll('remove cache', async () => {
-          // remove the .vite cache
-          // Refs: https://github.com/vitejs/vite/discussions/8146
-          await rm(`${cwd}/node_modules/.vite`, {
-            recursive: true,
-            force: true,
-          });
-
           await rm(`${cwd}/dist`, {
             recursive: true,
             force: true,
@@ -128,13 +121,6 @@ for (const cwd of examples) {
         let cp: ChildProcess;
         let port: number;
         test.beforeAll('remove cache', async () => {
-          // remove the .vite cache
-          // Refs: https://github.com/vitejs/vite/discussions/8146
-          await rm(`${cwd}/node_modules/.vite`, {
-            recursive: true,
-            force: true,
-          });
-
           await rm(`${cwd}/dist`, {
             recursive: true,
             force: true,

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -26,13 +26,6 @@ for (const { build, command } of commands) {
     let cp: ChildProcess;
     let port: number;
     test.beforeAll('remove cache', async () => {
-      // remove the .vite cache
-      // Refs: https://github.com/vitejs/vite/discussions/8146
-      await rm(`${cwd}/node_modules/.vite`, {
-        recursive: true,
-        force: true,
-      });
-
       await rm(`${cwd}/dist`, {
         recursive: true,
         force: true,

--- a/e2e/rsc-router.spec.ts
+++ b/e2e/rsc-router.spec.ts
@@ -26,13 +26,6 @@ for (const { build, command } of commands) {
     let cp: ChildProcess;
     let port: number;
     test.beforeAll('remove cache', async () => {
-      // remove the .vite cache
-      // Refs: https://github.com/vitejs/vite/discussions/8146
-      await rm(`${cwd}/node_modules/.vite`, {
-        recursive: true,
-        force: true,
-      });
-
       await rm(`${cwd}/dist`, {
         recursive: true,
         force: true,

--- a/e2e/ssr-basic.spec.ts
+++ b/e2e/ssr-basic.spec.ts
@@ -26,13 +26,6 @@ for (const { build, command } of commands) {
     let cp: ChildProcess;
     let port: number;
     test.beforeAll('remove cache', async () => {
-      // remove the .vite cache
-      // Refs: https://github.com/vitejs/vite/discussions/8146
-      await rm(`${cwd}/node_modules/.vite`, {
-        recursive: true,
-        force: true,
-      });
-
       await rm(`${cwd}/dist`, {
         recursive: true,
         force: true,

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -112,9 +112,11 @@ const moduleImports: Set<string> = new Set();
 const mergedViteConfig = await mergeUserViteConfig({
   plugins: [
     viteReact(),
+    rscEnvPlugin({}),
+    { name: 'rsc-index-plugin' }, // dummy to match with handler-dev.ts
+    { name: 'rsc-hmr-plugin', enforce: 'post' }, // dummy to match with handler-dev.ts
     nonjsResolvePlugin(),
     rscTransformPlugin({ isBuild: false }),
-    rscEnvPlugin({}),
     rscReloadPlugin(moduleImports, (type) => {
       const mesg: MessageRes = { type };
       parentPort!.postMessage(mesg);

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -59,6 +59,16 @@ export function createHandler<
   const vitePromise = configPromise.then(async (config) => {
     const mergedViteConfig = await mergeUserViteConfig({
       base: config.basePath,
+      plugins: [
+        patchReactRefresh(viteReact()),
+        rscEnvPlugin({ config, hydrate: ssr }),
+        rscIndexPlugin(config),
+        rscHmrPlugin(),
+        { name: 'nonjs-resolve-plugin' }, // dummy to match with dev-worker-impl.ts
+        { name: 'rsc-transform-plugin' }, // dummy to match with dev-worker-impl.ts
+        { name: 'rsc-reload-plugin' }, // dummy to match with dev-worker-impl.ts
+        { name: 'rsc-delegate-plugin' }, // dummy to match with dev-worker-impl.ts
+      ],
       optimizeDeps: {
         include: ['react-server-dom-webpack/client', 'react-dom'],
         exclude: ['waku'],
@@ -66,12 +76,6 @@ export function createHandler<
           `${config.srcDir}/${config.entriesJs}`.replace(/\.js$/, '.*'),
         ],
       },
-      plugins: [
-        patchReactRefresh(viteReact()),
-        rscIndexPlugin(config),
-        rscHmrPlugin(),
-        rscEnvPlugin({ config, hydrate: ssr }),
-      ],
       ssr: {
         external: [
           'waku',


### PR DESCRIPTION
For a long time, we have `Re-optimizing dependencies because vite config has changed` message and not sure how to fix.

Reading the vite code, we can work it around.
https://github.com/vitejs/vite/blob/ed56d96cec8fd3b9b6dae88d5511e386177e6d5c/packages/vite/src/node/optimizer/index.ts#L1218

Note that it depends on the vite internals and can be fragile.