### PR TITLE
fix: `getEnv` for cross-platform

### DIFF
--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -19,6 +19,13 @@
       "types": "./dist/config.d.ts",
       "default": "./dist/config.js"
     },
+    "./environment": {
+      "types": "./dist/environment/index.d.ts",
+      "deno": "./dist/environment/index.deno.js",
+      "worker": "./dist/environment/index.worker.js",
+      "edge-light": "./dist/environment/index.edge-light.js",
+      "default": "./dist/environment/index.js"
+    },
     "./prd": {
       "types": "./dist/prd.d.ts",
       "default": "./dist/prd.js"

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -22,7 +22,7 @@
     "./environment": {
       "types": "./dist/environment/index.d.ts",
       "deno": "./dist/environment/index.deno.js",
-      "worker": "./dist/environment/index.worker.js",
+      "workerd": "./dist/environment/index.worker.js",
       "edge-light": "./dist/environment/index.edge-light.js",
       "default": "./dist/environment/index.js"
     },

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -84,10 +84,7 @@ if (values.version) {
 
 async function runDev(options: { ssr: boolean }) {
   const app = new Hono();
-  app.use(
-    '*',
-    honoDevMiddleware({ ...options, config, env: process.env as any }),
-  );
+  app.use('*', honoDevMiddleware({ ...options, config }));
   const port = parseInt(process.env.PORT || '3000', 10);
   startServer(app, port);
 }
@@ -96,7 +93,6 @@ async function runBuild(options: { ssr: boolean }) {
   await build({
     ...options,
     config,
-    env: process.env as any,
     vercel:
       values['with-vercel'] ?? !!process.env.VERCEL
         ? {
@@ -114,10 +110,7 @@ async function runStart(options: { ssr: boolean }) {
     pathToFileURL(path.resolve(distDir, entriesJs)).toString()
   );
   const app = new Hono();
-  app.use(
-    '*',
-    honoPrdMiddleware({ ...options, config, entries, env: process.env as any }),
-  );
+  app.use('*', honoPrdMiddleware({ ...options, config, entries }));
   app.use('*', serveStatic({ root: path.join(distDir, publicDir) }));
   const port = parseInt(process.env.PORT || '8080', 10);
   startServer(app, port);

--- a/packages/waku/src/environment/index.deno.ts
+++ b/packages/waku/src/environment/index.deno.ts
@@ -1,4 +1,4 @@
 export function getEnv(key: string): string | undefined {
-  // @ts-expect-error
+  // @ts-expect-error Deno global variable
   return Deno.env.get(key);
 }

--- a/packages/waku/src/environment/index.deno.ts
+++ b/packages/waku/src/environment/index.deno.ts
@@ -1,4 +1,4 @@
 export function getEnv(key: string): string | undefined {
   // @ts-expect-error
-  return Deno.env.get(key)
+  return Deno.env.get(key);
 }

--- a/packages/waku/src/environment/index.deno.ts
+++ b/packages/waku/src/environment/index.deno.ts
@@ -1,0 +1,4 @@
+export function getEnv(key: string): string | undefined {
+  // @ts-expect-error
+  return Deno.env.get(key)
+}

--- a/packages/waku/src/environment/index.edge-light.ts
+++ b/packages/waku/src/environment/index.edge-light.ts
@@ -1,0 +1,3 @@
+export function getEnv(key: string): string | undefined {
+  return process.env[key];
+}

--- a/packages/waku/src/environment/index.ts
+++ b/packages/waku/src/environment/index.ts
@@ -1,0 +1,3 @@
+export function getEnv(key: string): string | undefined {
+  return process.env[key];
+}

--- a/packages/waku/src/environment/index.worker.ts
+++ b/packages/waku/src/environment/index.worker.ts
@@ -1,0 +1,3 @@
+export function getEnv(key: string): string | undefined {
+  return (globalThis as any).__WAKU_PRIVATE_ENV__[key]
+}

--- a/packages/waku/src/environment/index.worker.ts
+++ b/packages/waku/src/environment/index.worker.ts
@@ -1,3 +1,6 @@
 export function getEnv(key: string): string | undefined {
-  return (globalThis as any).__WAKU_PRIVATE_ENV__[key]
+  if (!(globalThis as any).__WAKU_PRIVATE_ENV__) {
+    return undefined;
+  }
+  return (globalThis as any).__WAKU_PRIVATE_ENV__[key];
 }

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -521,7 +521,7 @@ export async function build(options: {
     conditions.push('edge-flight');
   }
   if (options.cloudflare) {
-    conditions.push('worker');
+    conditions.push('workerd');
   }
   if (options.deno) {
     conditions.push('deno');

--- a/packages/waku/src/lib/builder/output-cloudflare.ts
+++ b/packages/waku/src/lib/builder/output-cloudflare.ts
@@ -36,11 +36,11 @@ app.use('*', serveStatic({ root: './' }));
 export default {
   async fetch(request, env, ctx) {
     if (!serveWaku) {
-      const entries = await import('./${entriesFile}');
       globalThis.__WAKU_PRIVATE_ENV__ = Object.assign(
         Object.create(null),
         env,
       );
+      const entries = await import('./${entriesFile}');
       const { honoMiddleware } = await entries;
       serveWaku = honoMiddleware({ entries, ssr: ${ssr}, env });
     }

--- a/packages/waku/src/lib/builder/output-cloudflare.ts
+++ b/packages/waku/src/lib/builder/output-cloudflare.ts
@@ -28,8 +28,6 @@ export const emitCloudflareOutput = async (
 import { Hono } from 'hono';
 import { serveStatic } from 'hono/cloudflare-workers';
 
-const entries = import('./${entriesFile}');
-const { honoMiddleware } = await entries;
 let serveWaku;
 
 const app = new Hono();
@@ -38,6 +36,12 @@ app.use('*', serveStatic({ root: './' }));
 export default {
   async fetch(request, env, ctx) {
     if (!serveWaku) {
+      const entries = await import('./${entriesFile}');
+      globalThis.__WAKU_PRIVATE_ENV__ = Object.assign(
+        Object.create(null),
+        env,
+      );
+      const { honoMiddleware } = await entries;
       serveWaku = honoMiddleware({ entries, ssr: ${ssr}, env });
     }
     return app.fetch(request, env, ctx);

--- a/packages/waku/src/lib/handlers/dev-worker-api.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-api.ts
@@ -71,10 +71,6 @@ export function initializeWorker(config: ResolvedConfig) {
     ])
       .then(([{ Worker, setEnvironmentData }, { default: module }]) => {
         const HAS_MODULE_REGISTER = typeof module.register === 'function';
-        setEnvironmentData(
-          '__WAKU_PRIVATE_ENV__',
-          (globalThis as any).__WAKU_PRIVATE_ENV__,
-        );
         setEnvironmentData('CONFIG_SRC_DIR', config.srcDir);
         setEnvironmentData('CONFIG_ENTRIES_JS', config.entriesJs);
         const worker = new Worker(

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -30,9 +30,6 @@ if (HAS_MODULE_REGISTER) {
   module.register('waku/node-loader', pathToFileURL('./'));
 }
 
-(globalThis as any).__WAKU_PRIVATE_ENV__ = getEnvironmentData(
-  '__WAKU_PRIVATE_ENV__',
-);
 const configSrcDir = getEnvironmentData('CONFIG_SRC_DIR');
 const configEntriesJs = getEnvironmentData('CONFIG_ENTRIES_JS');
 

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -46,7 +46,6 @@ export function createHandler<
 >(options: {
   config?: Config;
   ssr?: boolean;
-  env?: Record<string, string>;
   unstable_prehook?: (req: Req, res: Res) => Context;
   unstable_posthook?: (req: Req, res: Res, ctx: Context) => void;
 }): Handler<Req, Res> {
@@ -54,7 +53,6 @@ export function createHandler<
   if (!unstable_prehook && unstable_posthook) {
     throw new Error('prehook is required if posthook is provided');
   }
-  (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
   const configPromise = resolveConfig(options.config || {});
   const vitePromise = configPromise.then(async (config) => {
     const mergedViteConfig = await mergeUserViteConfig({

--- a/packages/waku/src/lib/handlers/handler-prd.ts
+++ b/packages/waku/src/lib/handlers/handler-prd.ts
@@ -16,7 +16,6 @@ export function createHandler<
 >(options: {
   config?: Config;
   ssr?: boolean;
-  env?: Record<string, string>;
   unstable_prehook?: (req: Req, res: Res) => Context;
   unstable_posthook?: (req: Req, res: Res, ctx: Context) => void;
   entries: Promise<EntriesPrd>;
@@ -25,7 +24,6 @@ export function createHandler<
   if (!unstable_prehook && unstable_posthook) {
     throw new Error('prehook is required if posthook is provided');
   }
-  (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
   const configPromise = resolveConfig(config || {});
 
   return async (req, res, next) => {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
@@ -31,19 +31,6 @@ export function rscEnvPlugin({
           ...(hydrate
             ? [['import.meta.env.WAKU_HYDRATE', JSON.stringify('true')]]
             : []),
-          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
-            ([k, v]) =>
-              k.startsWith('WAKU_PUBLIC_')
-                ? [[`import.meta.env.${k}`, JSON.stringify(v)]]
-                : [],
-          ),
-          // Node style `process.env` for traditional compatibility
-          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
-            ([k, v]) =>
-              k.startsWith('WAKU_PUBLIC_')
-                ? [[`process.env.${k}`, JSON.stringify(v)]]
-                : [],
-          ),
         ]),
       };
     },

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,4 +1,4 @@
-import { getEnv } from 'waku/environment'
+import { getEnv } from 'waku/environment';
 import type { ReactNode } from 'react';
 
 type Elements = Record<string, ReactNode>;
@@ -59,6 +59,4 @@ export type EntriesPrd = EntriesDev & {
   skipRenderRsc: (input: string) => boolean;
 };
 
-export {
-  getEnv,
-}
+export { getEnv };

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,3 +1,4 @@
+import { getEnv } from 'waku/environment'
 import type { ReactNode } from 'react';
 
 type Elements = Record<string, ReactNode>;
@@ -58,7 +59,6 @@ export type EntriesPrd = EntriesDev & {
   skipRenderRsc: (input: string) => boolean;
 };
 
-export function getEnv(key: string): string | undefined {
-  // HACK we may want to use a server-side context or something
-  return (globalThis as any).__WAKU_PRIVATE_ENV__[key];
+export {
+  getEnv,
 }


### PR DESCRIPTION
main idea is use `conditional exports` to handle cross-platform cases