### PR TITLE
fix(website): prop mismatch error with ssr by turning off autoprefixing

### DIFF
--- a/packages/website/postcss.config.js
+++ b/packages/website/postcss.config.js
@@ -5,7 +5,7 @@ export default {
     tailwindcss: {},
     autoprefixer: {
       // TODO: This should be removed after `bright` https://github.com/postcss/autoprefixer?tab=readme-ov-file#control-comments for auto prefixes
-      add: false
+      add: false,
     },
   },
 };

--- a/packages/website/postcss.config.js
+++ b/packages/website/postcss.config.js
@@ -3,6 +3,9 @@ export default {
   plugins: {
     'tailwindcss/nesting': {},
     tailwindcss: {},
-    autoprefixer: {},
+    autoprefixer: {
+      // TODO: This should be removed after `bright` https://github.com/postcss/autoprefixer?tab=readme-ov-file#control-comments for auto prefixes
+      add: false
+    },
   },
 };


### PR DESCRIPTION
fixes [prop mismatch error with ssr](https://github.com/dai-shi/waku/pull/364#issuecomment-1888505712) in #344 

In transformIndexHtml, waku will transform and return the result to the browser! In this process, vite will apply its transformation which postcss/autoprefixer is part of. Autoprefixer will add the -moz- pseudo-class. 
A better solution will be an upstream one, in the `bright` package which should use autoprefixer [control comments](https://github.com/postcss/autoprefixer?tab=readme-ov-file#control-comments) and disable the prefixing to the inline CSS part that React will process. 

With this PR's solution, what we do is just disable the prefixing for the whole website.

```html
React stream: 
<style>
[data-bright-theme] ::selection { background-color: var(--selection-background) }
  </style>

after transformIndexHtml:
<style>
  [data-bright-theme] ::-moz-selection { background-color: var(--selection-background) }
[data-bright-theme] ::selection { background-color: var(--selection-background) }

  </style>
```