### PR TITLE
fix: client components default exports

### DIFF
--- a/examples/05_actions/src/components/App.tsx
+++ b/examples/05_actions/src/components/App.tsx
@@ -1,6 +1,6 @@
 import { Balancer } from 'react-wrap-balancer';
 
-import { Counter } from './Counter.js';
+import Counter from './Counter.js';
 import { greet, getCounter, increment } from './funcs.js';
 
 type ServerFunction<T> = T extends (...args: infer A) => infer R

--- a/examples/05_actions/src/components/Counter.tsx
+++ b/examples/05_actions/src/components/Counter.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from 'react';
 
 import { TextBox } from './TextBox.js';
 
-export const Counter = ({
+const Counter = ({
   greet,
   increment,
 }: {
@@ -36,3 +36,5 @@ export const Counter = ({
     </div>
   );
 };
+
+export default Counter;

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -228,9 +228,15 @@ export function createHandler<
         item.url !== viteUrl &&
         !item.url.includes('?html-proxy')
       ) {
+        const { code } = (await vite.transformRequest(item.url))!;
         res.setHeader('Content-Type', 'application/javascript');
         res.setStatus(200);
-        endStream(res.stream, `export * from "${item.url}";`);
+        let exports = `export * from "${item.url}";`;
+        // `export *` does not re-export `default`
+        if (code.includes('export default')) {
+          exports += `export { default } from "${item.url}";`;
+        }
+        endStream(res.stream, exports);
         return;
       }
     }


### PR DESCRIPTION
Resolves #434 

TIL: 
```ts
export * from 'url'
```
does not re-export the `default` export.

