### PR TITLE
fix: output AWS Lambda / AWS HTTP API V2 breaks RSC POST requests url needed for server actions

### DIFF
--- a/packages/waku/src/lib/builder/serve-aws-lambda.ts
+++ b/packages/waku/src/lib/builder/serve-aws-lambda.ts
@@ -15,7 +15,7 @@ app.use('*', serveStatic({ root: `${distDir}/${publicDir}` }));
 app.use('*', honoMiddleware({ loadEntries, ssr, env }));
 
 /*
- FIX: AWS HTTP API V2 breaks RSC POST requests needed for server actions
+ FIX: AWS HTTP API V2 breaks RSC POST requests url needed for server actions
     - AWS HTTP API V2 sets rawPath to a decoded path
     - We need to encode the string after /RSC/ and replace the orginal rawPath
     - Hono bug: https://github.com/honojs/hono/issues/2156

--- a/packages/waku/src/lib/builder/serve-aws-lambda.ts
+++ b/packages/waku/src/lib/builder/serve-aws-lambda.ts
@@ -1,8 +1,7 @@
 import { Hono } from 'hono';
-import { handle } from 'hono/aws-lambda';
-import { serveStatic } from '@hono/node-server/serve-static';
-
 import { honoMiddleware } from '../middleware/hono-prd.js';
+import { handle, type LambdaContext, type LambdaEvent } from 'hono/aws-lambda';
+import { serveStatic } from '@hono/node-server/serve-static';
 
 const ssr = !!import.meta.env.WAKU_BUILD_SSR;
 const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR;
@@ -15,4 +14,32 @@ const app = new Hono();
 app.use('*', serveStatic({ root: `${distDir}/${publicDir}` }));
 app.use('*', honoMiddleware({ loadEntries, ssr, env }));
 
-export const handler = handle(app);
+/*
+ FIX: AWS HTTP API V2 breaks RSC POST requests needed for server actions
+    - AWS HTTP API V2 sets rawPath to a decoded path
+    - We need to encode the string after /RSC/ and replace the orginal rawPath
+    - Hono bug: https://github.com/honojs/hono/issues/2156
+*/
+
+const fixHTTPAPIV2 = (event: LambdaEvent) => {
+  if ('version' in event && event?.version === '2.0') {
+    if (
+      'http' in event.requestContext &&
+      event?.requestContext?.http?.method === 'POST' &&
+      'rawPath' in event &&
+      event?.rawPath?.startsWith('/RSC/')
+    ) {
+      const encodedRSCPath = encodeURIComponent(event.rawPath.substring(5));
+      const url = new URL(event.rawPath, `http://${event.headers.host}`);
+      url.pathname = `/RSC/${encodedRSCPath}`;
+      event.rawPath = url.pathname;
+      return event;
+    }
+  }
+  return event;
+};
+
+const honoHandler = handle(app);
+export const handler = (event: LambdaEvent, context: LambdaContext) => {
+  return honoHandler(fixHTTPAPIV2(event), context);
+};


### PR DESCRIPTION
This fix is hack to revert the decoded url in the rawPath property provided by the AWS API Gateway with a HTTP API V2 Event.

The hack will only apply to POST request which start with `/RSC/`.

There is no way to fix this in the Hono layer as an arbitrary decoded Path cannot be encoded back to the same original!

see https://github.com/honojs/hono/issues/2156

Without this fix, the `url: new URL(c.req.url),` will ignore everything after the `#` on the decoded url.

**default url (e.g. node environment):**
`http://localhost/RSC/%40id%2Fassets%2Frsf0.js%23save.txt`

**url (AWS API Gateway):**
`http://localhost/RSC/@id/assets/rsf0.js#save.txt`

`new URL(http://localhost/RSC/@id/assets/rsf0.js#save.txt').pathname` => `/RSC/@id/assets/rsf0.js` 
**missing:** `#save.txt`

https://github.com/dai-shi/waku/blob/32d52242c1450b5f5965860e671ff73c42da8bd0/packages/waku/src/lib/middleware/hono-utils.ts#L49-L63