### PR TITLE
feat: server context & middleware

### DIFF
--- a/examples/14_middleware/package.json
+++ b/examples/14_middleware/package.json
@@ -16,6 +16,7 @@
     "react": "18.3.0-canary-4b2a1115a-20240202",
     "react-dom": "18.3.0-canary-4b2a1115a-20240202",
     "react-server-dom-webpack": "18.3.0-canary-4b2a1115a-20240202",
+    "server-only": "^0.0.1",
     "waku": "0.19.2"
   },
   "devDependencies": {

--- a/examples/14_middleware/package.json
+++ b/examples/14_middleware/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "waku-example",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev --with-ssr",
+    "build": "waku build --with-ssr",
+    "start": "waku start --with-ssr"
+  },
+  "dependencies": {
+    "cookie": "^0.6.0",
+    "cookie-parser": "1.4.6",
+    "express": "4.18.2",
+    "hono": "3.12.11",
+    "react": "18.3.0-canary-4b2a1115a-20240202",
+    "react-dom": "18.3.0-canary-4b2a1115a-20240202",
+    "react-server-dom-webpack": "18.3.0-canary-4b2a1115a-20240202",
+    "waku": "0.19.2"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.16",
+    "@types/react": "18.2.54",
+    "@types/react-dom": "18.2.18",
+    "typescript": "5.3.3"
+  }
+}

--- a/examples/14_middleware/src/components/App.tsx
+++ b/examples/14_middleware/src/components/App.tsx
@@ -1,0 +1,21 @@
+import { Counter } from './Counter.js';
+
+const App = ({
+  name,
+  count
+}: {
+  name: string;
+  count: number
+}) => {
+  return (
+    <div style={{ border: '3px red dashed', margin: '1em', padding: '1em' }}>
+      <title>Waku</title>
+      <h1>Hello {name}!!</h1>
+      <h3>This is a server component.</h3>
+      <p>Cookie count: {count}</p>
+      <Counter />
+    </div>
+  );
+};
+
+export default App;

--- a/examples/14_middleware/src/components/App.tsx
+++ b/examples/14_middleware/src/components/App.tsx
@@ -1,5 +1,6 @@
+import 'server-only';
+import { useServerProvider } from '../use-server-provider.js';
 import { Counter } from './Counter.js';
-
 const App = ({
   name,
   count
@@ -7,6 +8,8 @@ const App = ({
   name: string;
   count: number
 }) => {
+  const [context] = useServerProvider<number>('context');
+  console.log('ctx', context)
   return (
     <div style={{ border: '3px red dashed', margin: '1em', padding: '1em' }}>
       <title>Waku</title>

--- a/examples/14_middleware/src/components/Counter.tsx
+++ b/examples/14_middleware/src/components/Counter.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useState } from 'react';
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+  return (
+    <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+      <h3>This is a client component.</h3>
+    </div>
+  );
+};

--- a/examples/14_middleware/src/components/ServerContextWrapper.tsx
+++ b/examples/14_middleware/src/components/ServerContextWrapper.tsx
@@ -1,0 +1,6 @@
+import { useServerProvider } from "../use-server-provider.js";
+
+export const ServerContextWrapper = async ({context,children})=>{
+    useServerProvider('context', context);
+    return children;
+}

--- a/examples/14_middleware/src/entries.tsx
+++ b/examples/14_middleware/src/entries.tsx
@@ -1,9 +1,8 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import fsPromises from 'node:fs/promises';
 import { lazy } from 'react';
 import { defineEntries } from 'waku/server';
 import { Slot } from 'waku/client';
+//import { setServerContext } from './server-context.js';
+import { ServerContextWrapper } from './components/ServerContextWrapper.js';
 
 const App = lazy(() => import('./components/App.js'));
 
@@ -13,7 +12,8 @@ export default defineEntries(
     const ctx = this.context as { count: number };
     ++ctx.count;
     return {
-      App: <App name={input || 'Waku'} count={ctx.count}  />,
+      App: <ServerContextWrapper context={ctx}><App name={input || 'Waku'} count={ctx.count} /></ServerContextWrapper>
+
     };
   },
   // getBuildConfig

--- a/examples/14_middleware/src/entries.tsx
+++ b/examples/14_middleware/src/entries.tsx
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fsPromises from 'node:fs/promises';
+import { lazy } from 'react';
+import { defineEntries } from 'waku/server';
+import { Slot } from 'waku/client';
+
+const App = lazy(() => import('./components/App.js'));
+
+export default defineEntries(
+  // renderEntries
+  async function (input) {
+    const ctx = this.context as { count: number };
+    ++ctx.count;
+    return {
+      App: <App name={input || 'Waku'} count={ctx.count}  />,
+    };
+  },
+  // getBuildConfig
+  async () => [
+    { pathname: '/', entries: [{ input: '' }], context: { count: 0 } },
+  ],
+  // getSsrConfig
+  async (pathname) => {
+    switch (pathname) {
+      case '/':
+        return {
+          input: '',
+          body: <Slot id="App" />,
+        };
+      default:
+        return null;
+    }
+  },
+);

--- a/examples/14_middleware/src/main.tsx
+++ b/examples/14_middleware/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { Root, Slot } from 'waku/client';
+
+const rootElement = (
+  <StrictMode>
+    <Root>
+      <Slot id="App" />
+    </Root>
+  </StrictMode>
+);
+
+if (import.meta.env.WAKU_HYDRATE) {
+  hydrateRoot(document.body, rootElement);
+} else {
+  createRoot(document.body).render(rootElement);
+}

--- a/examples/14_middleware/src/middleware/index.js
+++ b/examples/14_middleware/src/middleware/index.js
@@ -1,0 +1,13 @@
+//import cookie from 'cookie';
+import { getCookie, getSignedCookie, setCookie, setSignedCookie, deleteCookie } from 'hono/cookie'
+export const prehook=(req, res, ctx) => {
+    //const cookies = cookie.parse(req.c.req.raw.headers.get('Cookie'));
+    const count=getCookie(req.c,'count')??0;
+    console.log('prehook',count);
+    return {count}
+}
+
+export const posthook=(req, res, ctx) => {
+    //res.c.res.headers.append("Set-Cookie",`count=${String(ctx.count)}`);
+    setCookie(res.c,'count',String(ctx.count));
+  }

--- a/examples/14_middleware/src/use-server-provider.tsx
+++ b/examples/14_middleware/src/use-server-provider.tsx
@@ -1,0 +1,20 @@
+import 'server-only';
+import { cache } from 'react';
+
+const serverContext = cache(() => new Map());
+
+export const useServerProvider = <T,>(
+    key: string,
+    defaultValue?: T
+) => {
+    const global = serverContext();
+
+    if (defaultValue !== undefined) {
+        global.set(key, defaultValue);
+    }
+
+    return [
+        global.get(key),
+        (value: T) => global.set(key, value)
+    ];
+};

--- a/examples/14_middleware/tsconfig.json
+++ b/examples/14_middleware/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "nodenext",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["react/experimental", "node"],
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/14_middleware/waku.config.ts
+++ b/examples/14_middleware/waku.config.ts
@@ -1,0 +1,9 @@
+
+import { posthook, prehook } from './src/middleware/index.js';
+ const  wakuConfig = {
+    middleware: {
+        prehook,
+        posthook
+    },
+}
+export default wakuConfig;  

--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -62,6 +62,19 @@ export interface Config {
    * <meta name="viewport" content="width=device-width, initial-scale=1" />
    */
   htmlHead?: string;
+  middleware?: {
+    /**
+     * The prehook function.
+     * It's called before rendering RSC.
+     */
+    prehook?: Function;
+    /**
+     * The posthook function.
+     * It's called after rendering RSC.
+     */
+    posthook?: Function;
+  } | undefined;
+  
 }
 
 export function defineConfig(config: Config) {

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -50,7 +50,10 @@ export function createHandler<
   unstable_prehook?: (req: Req, res: Res) => Context;
   unstable_posthook?: (req: Req, res: Res, ctx: Context) => void;
 }): Handler<Req, Res> {
-  const { ssr, unstable_prehook, unstable_posthook } = options;
+  const { ssr } = options;
+  const unstable_prehook= options?.unstable_prehook??options?.config?.middleware?.prehook;
+  const unstable_posthook= options?.unstable_posthook??options?.config?.middleware?.posthook;
+  if (options?.config?.middleware) options.config.middleware=undefined
   if (!unstable_prehook && unstable_posthook) {
     throw new Error('prehook is required if posthook is provided');
   }

--- a/packages/waku/src/lib/handlers/handler-prd.ts
+++ b/packages/waku/src/lib/handlers/handler-prd.ts
@@ -22,8 +22,10 @@ export function createHandler<
   unstable_posthook?: (req: Req, res: Res, ctx: Context) => void;
   loadEntries: () => Promise<EntriesPrd>;
 }): Handler<Req, Res> {
-  const { config, ssr, unstable_prehook, unstable_posthook, loadEntries } =
-    options;
+    const {config, ssr,loadEntries } = options;
+  const unstable_prehook= options?.unstable_prehook??options?.config?.middleware?.prehook;
+  const unstable_posthook= options?.unstable_posthook??options?.config?.middleware?.posthook;
+  if (options?.config?.middleware) options.config.middleware=undefined
   if (!unstable_prehook && unstable_posthook) {
     throw new Error('prehook is required if posthook is provided');
   }


### PR DESCRIPTION
This is a proof of concept:
* define middleware in the `waku.config.ts`
* no need to change the build processes

ToDo:
* [ ] avoid to remove the middleware from the config `handler-dev.ts:56` - maybe using a different config file
  https://github.com/aheissenberger/waku/blob/fe2584c7766ac15e0a6e3b87ce3d0c780bd76c45/packages/waku/src/lib/handlers/handler-dev.ts#L53-L59  
* [X] access Server Context in any Server Component or Server Action- e.g. `useServerContext()`
* [ ] support typescript for middleware `examples/14_middleware/src/middleware/index.js` - maybe different loading of `waku.config.ts` in `loadConfig()`
* [ ] support an array of middleware functions 
* [ ] allow posthook without prehook
* [ ] rename hooks to `onBeforeRequest` and `onBeforeResponse`
* [ ] hot reload on code changes