### PR TITLE
fix build for RSC and SSR

### DIFF
--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -186,6 +186,7 @@ const buildServerBundle = async (
       external:
         (serve === 'cloudflare' && ['hono', 'hono/cloudflare-workers']) || [],
       noExternal: /^(?!node:)/,
+      target: 'webworker',
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),
@@ -284,6 +285,7 @@ const buildSsrBundle = async (
     ],
     ssr: {
       noExternal: /^(?!node:)/,
+      target: 'webworker',
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -179,6 +179,7 @@ const buildServerBundle = async (
         : []),
     ],
     ssr: {
+      target: 'webworker',
       resolve: {
         conditions: ['react-server', 'workerd'],
         externalConditions: ['react-server', 'workerd'],
@@ -186,7 +187,6 @@ const buildServerBundle = async (
       external:
         (serve === 'cloudflare' && ['hono', 'hono/cloudflare-workers']) || [],
       noExternal: /^(?!node:)/,
-      target: 'webworker',
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),
@@ -284,8 +284,8 @@ const buildSsrBundle = async (
       rscEnvPlugin({ config, hydrate: true }),
     ],
     ssr: {
-      noExternal: /^(?!node:)/,
       target: 'webworker',
+      noExternal: /^(?!node:)/,
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/packages/waku/src/lib/handlers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/handlers/dev-worker-impl.ts
@@ -138,6 +138,7 @@ const mergedViteConfig = await mergeUserViteConfig({
     entries: [`${configSrcDir}/${configEntriesJs}`.replace(/\.js$/, '.*')],
   },
   ssr: {
+    target: 'webworker',
     resolve: {
       conditions: ['react-server', 'workerd'],
       externalConditions: ['react-server', 'workerd'],

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -70,6 +70,7 @@ export function createHandler<
         ],
       },
       ssr: {
+        target: 'webworker',
         external: [
           'waku',
           'waku/client',


### PR DESCRIPTION
There's an issue with cloudflare deploy since #457.
As it turns, it's targeting `node`.
https://vitejs.dev/config/ssr-options.html#ssr-target

This should fix.