### PR TITLE
fix: document body undefined

### DIFF
--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -182,8 +182,7 @@ export function createHandler<
           config,
           pathname: req.url.pathname,
           searchParams: req.url.searchParams,
-          htmlHead: `${config.htmlHead}
-<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`,
+          htmlHead: config.htmlHead,
           renderRscForHtml: async (input, searchParams) => {
             const [readable, nextCtx] = await renderRscWithWorker({
               input,

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-index.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-index.ts
@@ -15,9 +15,9 @@ export function rscIndexPlugin(config: {
 <html>
   <head>
 ${config.htmlHead}
-<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>
   </head>
   <body>
+    <script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>
   </body>
 </html>
 `;
@@ -26,9 +26,9 @@ ${config.htmlHead}
     configureServer(server) {
       return () => {
         server.middlewares.use((req, res) => {
-          res.statusCode = 200;
-          res.setHeader('content-type', 'text/html; charset=utf-8');
           server.transformIndexHtml(req.url || '', html).then((content) => {
+            res.statusCode = 200;
+            res.setHeader('content-type', 'text/html; charset=utf-8');
             res.end(content);
           });
         });

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -103,8 +103,12 @@ globalThis.__WAKU_PREFETCHED__ = {
       if (scriptsClosed) {
         return;
       }
-      // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded 
-      controller.enqueue(encoder.encode(`<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`));
+      // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded
+      controller.enqueue(
+        encoder.encode(
+          `<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`,
+        ),
+      );
 
       const scripts = chunks.splice(0).map(
         (chunk) =>

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -349,7 +349,7 @@ export const renderHtml = async (
   );
   const [copied, interleave] = injectRscPayload(
     stream,
-    config,
+    `${config.basePath}${config.srcDir}/${config.mainJs}`,
     config.basePath + config.rscPath + '/' + encodeInput(ssrConfig.input),
   );
   const elements: Promise<Record<string, ReactNode>> = createFromReadableStream(

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -108,7 +108,7 @@ globalThis.__WAKU_PREFETCHED__ = {
         // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded
         controller.enqueue(
           encoder.encode(
-            `<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`,
+            `<script src="${mainJsPath}" async type="module"></script>`,
           ),
         );
         mainJsSent = true;

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -44,7 +44,7 @@ Promise.resolve(new Response(new ReadableStream({
 
 const injectRscPayload = (
   readable: ReadableStream,
-  config: ResolvedConfig,
+  mainJsPath: string,
   urlForFakeFetch: string,
 ) => {
   const chunks: Uint8Array[] = [];

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -94,6 +94,7 @@ globalThis.__WAKU_PREFETCHED__ = {
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
     let headSent = false;
+    let mainJsSent = false;
     let data = '';
     let scriptsClosed = false;
     const sendScripts = (
@@ -103,12 +104,15 @@ globalThis.__WAKU_PREFETCHED__ = {
       if (scriptsClosed) {
         return;
       }
-      // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded
-      controller.enqueue(
-        encoder.encode(
-          `<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`,
-        ),
-      );
+      if (!mainJsSent) {
+        // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded
+        controller.enqueue(
+          encoder.encode(
+            `<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`,
+          ),
+        );
+        mainJsSent = true;
+      }
 
       const scripts = chunks.splice(0).map(
         (chunk) =>

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -44,6 +44,7 @@ Promise.resolve(new Response(new ReadableStream({
 
 const injectRscPayload = (
   readable: ReadableStream,
+  config: ResolvedConfig,
   urlForFakeFetch: string,
 ) => {
   const chunks: Uint8Array[] = [];
@@ -102,6 +103,9 @@ globalThis.__WAKU_PREFETCHED__ = {
       if (scriptsClosed) {
         return;
       }
+      // enqueue `mainJs` first in the body to avoid the document.body undefined error, before we used to inject it in the head which sometimes made it load before the document.body was loaded 
+      controller.enqueue(encoder.encode(`<script src="${config.basePath}${config.srcDir}/${config.mainJs}" async type="module"></script>`));
+
       const scripts = chunks.splice(0).map(
         (chunk) =>
           `
@@ -337,6 +341,7 @@ export const renderHtml = async (
   );
   const [copied, interleave] = injectRscPayload(
     stream,
+    config,
     config.basePath + config.rscPath + '/' + encodeInput(ssrConfig.input),
   );
   const elements: Promise<Record<string, ReactNode>> = createFromReadableStream(


### PR DESCRIPTION
Partially resolves #344 

When refreshing a waku page (website), the hydration failed and as result, hmr would not work. 

The reason behind the failure, is that for the next refreshes, the `/main.tsx` file is optimized and warm so it gets resolved before the `<body>` is getting streamed to the browser since it was in the `<head>` and that loads before the `<body>`, what that mean is the `document.body` would be undefined during the hydration and React would throw an error since that is undefined. One solution was to restart the server so we get `/main.tsx` cold again.

What this PR does is that it puts the script of `/main.tsx` in the body so it gets resolved after the body is being streamed and as a result, document.body would be never be `undefined`. 

This also fixed the hmr issue after the page manual refresh.