### PR TITLE
fix: add option to define the root folder of a lambda deployment.

### DIFF
--- a/packages/waku/src/lib/builder/serve-aws-lambda.ts
+++ b/packages/waku/src/lib/builder/serve-aws-lambda.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 
 const ssr = !!import.meta.env.WAKU_BUILD_SSR;
-const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR!;
+const distDir = process.env?.WAKU_BUILD_DIST_DIR ?? '';
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR!;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
 


### PR DESCRIPTION
This change allows to handle the differences of bundling the deployment ZIP for the serverless framework and the AWS CDK.