### PR TITLE
feat: `--with-partykit`, 404 responses

### DIFF
--- a/packages/waku/src/lib/builder/output-partykit.ts
+++ b/packages/waku/src/lib/builder/output-partykit.ts
@@ -17,7 +17,7 @@ export const emitPartyKitOutput = async (
           name: 'waku-project',
           main: `${config.distDir}/${config.serveJs}`,
           compatibilityDate: '2023-02-16',
-          assets: `./${config.distDir}/${config.publicDir}`,
+          serve: `./${config.distDir}/${config.publicDir}`,
         },
         null,
         2,

--- a/packages/waku/src/lib/builder/serve-partykit.ts
+++ b/packages/waku/src/lib/builder/serve-partykit.ts
@@ -8,6 +8,24 @@ let serveWaku: ReturnType<typeof honoMiddleware> | undefined;
 
 const app = new Hono();
 app.use('*', (c, next) => serveWaku!(c, next));
+app.notFound(async (c) => {
+  // @ts-expect-error partykit's types aren't available
+  const assetsFetcher = c.env.assets as {
+    fetch(url: string): Promise<Response | undefined>;
+  };
+  // check if there's a 404.html in the static assets
+  const notFoundStaticAssetResponse = await assetsFetcher.fetch('/404.html');
+  // if there is, return it
+  if (notFoundStaticAssetResponse) {
+    return new Response(notFoundStaticAssetResponse.body, {
+      status: 404,
+      statusText: 'Not Found',
+      headers: notFoundStaticAssetResponse.headers,
+    });
+  }
+  // otherwise, return a simple 404 response
+  return c.text('404 Not Found', 404);
+});
 
 export default {
   onFetch(request: Request, lobby: any, ctx: Parameters<typeof app.fetch>[2]) {


### PR DESCRIPTION
This serves `404.html`, if available in `/public`, for unmatched requests.

(This also adds a bugfix for the generated `partykit.json` config file.)