### PR TITLE
fix: client build css

### DIFF
--- a/examples/12_css/src/components/Counter.css
+++ b/examples/12_css/src/components/Counter.css
@@ -1,0 +1,3 @@
+h3 {
+  font-style: italic;
+}

--- a/examples/12_css/src/components/Counter.tsx
+++ b/examples/12_css/src/components/Counter.tsx
@@ -1,5 +1,5 @@
 'use client';
-import './Counter.css'
+import './Counter.css';
 
 import { useState } from 'react';
 

--- a/examples/12_css/src/components/Counter.tsx
+++ b/examples/12_css/src/components/Counter.tsx
@@ -1,4 +1,5 @@
 'use client';
+import './Counter.css'
 
 import { useState } from 'react';
 

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -400,7 +400,7 @@ export const extractNonJsAssets = (buildOutput: RollupOutput) =>
     type === 'asset' && !fileName.endsWith('.js') ? [fileName] : [],
   );
 
-export const extracCssAssets = (assets: string[]) =>
+const extracCssAssets = (assets: string[]) =>
   assets.filter((asset) => asset.endsWith('.css'));
 
 const emitRscFiles = async (

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -395,7 +395,7 @@ const buildClientBundle = async (
   return clientBuildOutput;
 };
 
-export const extractNonJsAssets = (buildOutput: RollupOutput) =>
+const extractNonJsAssets = (buildOutput: RollupOutput) =>
   buildOutput.output.flatMap(({ type, fileName }) =>
     type === 'asset' && !fileName.endsWith('.js') ? [fileName] : [],
   );


### PR DESCRIPTION
Resolves #452 

For Server build (not ssr), the determined css was being injected using cssAssets into the html when building the ssr/client output. That's why rsc css used to work in build.

The issue is when the client output was emitted, the css was generated too. But since vite does not find that css being generated by the index.html/main.tsx, rather by other entries, it didn't include it in the final index.html output.

The solution is to get that generated css and inject it manually into the final html file.