### PR TITLE
fix: Do not process empty search params to avoid redundant question mark

### DIFF
--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -223,7 +223,7 @@ function InnerRouter() {
       if (typeof path === 'string') {
         url.pathname = path;
       }
-      if (searchParams) {
+      if (searchParams?.size) {
         url.search = '?' + searchParams.toString();
       }
       if (typeof hash === 'string') {

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -223,8 +223,8 @@ function InnerRouter() {
       if (typeof path === 'string') {
         url.pathname = path;
       }
-      if (searchParams?.size) {
-        url.search = '?' + searchParams.toString();
+      if (searchParams) {
+        url.search = searchParams.toString();
       }
       if (typeof hash === 'string') {
         url.hash = hash;


### PR DESCRIPTION
Link is always appends `?` to the end of the url even if there are no search params.