### PR TITLE
fix: remove paths in examples

### DIFF
--- a/examples/01_template/tsconfig.json
+++ b/examples/01_template/tsconfig.json
@@ -9,9 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "paths": {
-      "~/*": ["./src/*"]
-    }
+    "jsx": "react-jsx"
   }
 }

--- a/examples/02_demo/tsconfig.json
+++ b/examples/02_demo/tsconfig.json
@@ -9,9 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "paths": {
-      "~/*": ["./src/*"]
-    }
+    "jsx": "react-jsx"
   }
 }

--- a/examples/14_react-tweet/tsconfig.json
+++ b/examples/14_react-tweet/tsconfig.json
@@ -9,9 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
-    "jsx": "react-jsx",
-    "paths": {
-      "~/*": ["./src/*"]
-    }
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
There is no support for path alias unless you add vite plugin