### PR TITLE
fix(ssr): catch-all route

### DIFF
--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -132,6 +132,16 @@ export function createHandler<
     });
   };
 
+  const willBeHandledByVite = async (pathname: string) => {
+    const vite = await vitePromise;
+    try {
+      const result = await vite.transformRequest(pathname);
+      return !!result;
+    } catch {
+      return false;
+    }
+  };
+
   return async (req, res, next) => {
     const [config, vite] = await Promise.all([configPromise, vitePromise]);
     const basePrefix = config.basePath + config.rscPath + '/';
@@ -174,7 +184,7 @@ export function createHandler<
       }
       return;
     }
-    if (ssr) {
+    if (ssr && !(await willBeHandledByVite(req.url.pathname))) {
       try {
         const readable = await renderHtml({
           config,

--- a/packages/waku/src/lib/middleware/dev-server.ts
+++ b/packages/waku/src/lib/middleware/dev-server.ts
@@ -149,6 +149,16 @@ export const devServer: Middleware = (options) => {
     });
   };
 
+  const willBeHandledLater = async (pathname: string) => {
+    const vite = await vitePromise;
+    try {
+      const result = await vite.transformRequest(pathname);
+      return !!result;
+    } catch {
+      return false;
+    }
+  };
+
   return async (ctx, next) => {
     const [config, vite] = await Promise.all([configPromise, vitePromise]);
     ctx.devServer = {
@@ -157,6 +167,7 @@ export const devServer: Middleware = (options) => {
       getSsrConfigWithWorker,
       loadServerFile,
       transformIndexHtml,
+      willBeHandledLater,
     };
 
     await next();

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -24,6 +24,13 @@ export const ssr: Middleware = (options) => {
 
   return async (ctx, next) => {
     const { devServer } = ctx;
+    if (
+      devServer &&
+      (await devServer.willBeHandledLater(ctx.req.url.pathname))
+    ) {
+      await next();
+      return;
+    }
     const [config, entries] = await Promise.all([
       configPromise,
       entriesPromise,

--- a/packages/waku/src/lib/middleware/types.ts
+++ b/packages/waku/src/lib/middleware/types.ts
@@ -32,6 +32,7 @@ export type HandlerContext = {
     transformIndexHtml: (
       pathname: string,
     ) => Promise<TransformStream<any, any>>;
+    willBeHandledLater: (pathname: string) => Promise<boolean>;
   };
 };
 


### PR DESCRIPTION
There was a regression in #534.
I shouldn't have deleted `willBeHandledByVite`.