### PR TITLE
fix: stop sending ssr hydrate flag when the `--with-ssr` flag is absent

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -77,7 +77,7 @@ if (values.version) {
       await runDev({ ssr });
       break;
     case 'build':
-      await runBuild();
+      await runBuild({ ssr });
       break;
     case 'start':
       await runStart({ ssr });

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -95,7 +95,7 @@ async function runDev(options: { ssr: boolean }) {
   const config = await loadConfig();
   const app = new Hono();
   if (!process.env.WAKU_OLD_MIDDLEWARE) {
-    app.use('*', runner({ cmd: 'dev', config, env: process.env as any }));
+    app.use('*', runner({ ssr: options.ssr, cmd: 'dev', config, env: process.env as any }));
   } else {
     app.use(
       '*',
@@ -106,11 +106,12 @@ async function runDev(options: { ssr: boolean }) {
   await startServer(app, port);
 }
 
-async function runBuild() {
+async function runBuild(options: { ssr: boolean }) {
   const config = await loadConfig();
   process.env.NODE_ENV = 'production';
   await build({
     config,
+    ssr: options.ssr,
     env: process.env as any,
     deploy:
       (values['with-vercel'] ?? !!process.env.VERCEL
@@ -140,7 +141,7 @@ async function runStart(options: { ssr: boolean }) {
   if (!process.env.WAKU_OLD_MIDDLEWARE) {
     app.use(
       '*',
-      runner({ cmd: 'start', loadEntries, env: process.env as any }),
+      runner({ ssr: options.ssr, cmd: 'start', loadEntries, env: process.env as any }),
     );
   } else {
     app.use(

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -95,7 +95,10 @@ async function runDev(options: { ssr: boolean }) {
   const config = await loadConfig();
   const app = new Hono();
   if (!process.env.WAKU_OLD_MIDDLEWARE) {
-    app.use('*', runner({ ssr: options.ssr, cmd: 'dev', config, env: process.env as any }));
+    app.use(
+      '*',
+      runner({ ssr: options.ssr, cmd: 'dev', config, env: process.env as any }),
+    );
   } else {
     app.use(
       '*',
@@ -141,7 +144,12 @@ async function runStart(options: { ssr: boolean }) {
   if (!process.env.WAKU_OLD_MIDDLEWARE) {
     app.use(
       '*',
-      runner({ ssr: options.ssr, cmd: 'start', loadEntries, env: process.env as any }),
+      runner({
+        ssr: options.ssr,
+        cmd: 'start',
+        loadEntries,
+        env: process.env as any,
+      }),
     );
   } else {
     app.use(

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -174,6 +174,7 @@ const buildServerBundle = async (
     | 'deno'
     | 'aws-lambda'
     | false,
+  ssr: boolean,
   isNodeCompatible: boolean,
 ) => {
   const serverBuildOutput = await buildVite({
@@ -222,6 +223,7 @@ const buildServerBundle = async (
                 ),
               ),
               serve,
+              ssr
             }),
           ]
         : []),
@@ -462,6 +464,7 @@ const pathSpec2pathname = (pathSpec: PathSpec): string => {
 const emitHtmlFiles = async (
   rootDir: string,
   config: ResolvedConfig,
+  ssr: boolean,
   distEntriesFile: string,
   distEntries: EntriesPrd,
   buildConfig: Awaited<ReturnType<typeof getBuildConfig>>,
@@ -531,6 +534,7 @@ const emitHtmlFiles = async (
         );
         const htmlReadable = await renderHtml({
           config,
+          ssr,
           pathname,
           searchParams: new URLSearchParams(),
           htmlHead,
@@ -597,6 +601,7 @@ const resolveFileName = (fname: string) => {
 
 export async function build(options: {
   config: Config;
+  ssr: boolean;
   env?: Record<string, string>;
   deploy?:
     | 'vercel-static'
@@ -640,6 +645,7 @@ export async function build(options: {
       (options.deploy === 'partykit' ? 'partykit' : false) ||
       (options.deploy === 'deno' ? 'deno' : false) ||
       (options.deploy === 'aws-lambda' ? 'aws-lambda' : false),
+    options.ssr,
     isNodeCompatible,
   );
   await buildSsrBundle(
@@ -662,6 +668,7 @@ export async function build(options: {
   await emitHtmlFiles(
     rootDir,
     config,
+    options.ssr,
     distEntriesFile,
     distEntries,
     buildConfig,

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -223,7 +223,7 @@ const buildServerBundle = async (
                 ),
               ),
               serve,
-              ssr
+              ssr,
             }),
           ]
         : []),

--- a/packages/waku/src/lib/builder/serve-aws-lambda.ts
+++ b/packages/waku/src/lib/builder/serve-aws-lambda.ts
@@ -9,7 +9,7 @@ import { runner } from '../hono/runner.js';
 const distDir = process.env?.WAKU_BUILD_DIST_DIR ?? '';
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR!;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 
 const env = process.env as Record<string, string>;
 

--- a/packages/waku/src/lib/builder/serve-aws-lambda.ts
+++ b/packages/waku/src/lib/builder/serve-aws-lambda.ts
@@ -9,12 +9,13 @@ import { runner } from '../hono/runner.js';
 const distDir = process.env?.WAKU_BUILD_DIST_DIR ?? '';
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR!;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 
 const env = process.env as Record<string, string>;
 
 const app = new Hono();
 app.use('*', serveStatic({ root: `${distDir}/${publicDir}` }));
-app.use('*', runner({ cmd: 'start', loadEntries, env }));
+app.use('*', runner({ ssr, cmd: 'start', loadEntries, env }));
 app.notFound(async (c) => {
   const file = path.join(distDir, publicDir, '404.html');
   if (existsSync(file)) {

--- a/packages/waku/src/lib/builder/serve-cloudflare.ts
+++ b/packages/waku/src/lib/builder/serve-cloudflare.ts
@@ -11,7 +11,7 @@ let serveWaku: ReturnType<typeof runner> | undefined;
 let staticContent: any;
 
 const parsedManifest: Record<string, string> = JSON.parse(manifest);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 
 const app = new Hono();
 app.use('*', serveStatic({ root: './', manifest }));

--- a/packages/waku/src/lib/builder/serve-cloudflare.ts
+++ b/packages/waku/src/lib/builder/serve-cloudflare.ts
@@ -11,6 +11,7 @@ let serveWaku: ReturnType<typeof runner> | undefined;
 let staticContent: any;
 
 const parsedManifest: Record<string, string> = JSON.parse(manifest);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 
 const app = new Hono();
 app.use('*', serveStatic({ root: './', manifest }));
@@ -33,7 +34,7 @@ export default {
     ctx: Parameters<typeof app.fetch>[2],
   ) {
     if (!serveWaku) {
-      serveWaku = runner({ cmd: 'start', loadEntries, env });
+      serveWaku = runner({ ssr, cmd: 'start', loadEntries, env });
       staticContent = env.__STATIC_CONTENT;
     }
     return app.fetch(request, env, ctx);

--- a/packages/waku/src/lib/builder/serve-deno.ts
+++ b/packages/waku/src/lib/builder/serve-deno.ts
@@ -12,11 +12,12 @@ declare const Deno: any;
 const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR;
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 const env = Deno.env.toObject();
 
 const app = new Hono();
 app.use('*', serveStatic({ root: `${distDir}/${publicDir}` }));
-app.use('*', runner({ cmd: 'start', loadEntries, env }));
+app.use('*', runner({ ssr, cmd: 'start', loadEntries, env }));
 app.notFound(async (c: any) => {
   const file = `${distDir}/${publicDir}/404.html`;
   const info = await Deno.stat(file);

--- a/packages/waku/src/lib/builder/serve-deno.ts
+++ b/packages/waku/src/lib/builder/serve-deno.ts
@@ -12,7 +12,7 @@ declare const Deno: any;
 const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR;
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 const env = Deno.env.toObject();
 
 const app = new Hono();

--- a/packages/waku/src/lib/builder/serve-netlify.ts
+++ b/packages/waku/src/lib/builder/serve-netlify.ts
@@ -4,7 +4,7 @@ import type { Context } from '@netlify/functions';
 import { runner } from '../hono/runner.js';
 
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 const env: Record<string, string> = process.env as any;
 
 const app = new Hono();

--- a/packages/waku/src/lib/builder/serve-netlify.ts
+++ b/packages/waku/src/lib/builder/serve-netlify.ts
@@ -4,10 +4,11 @@ import type { Context } from '@netlify/functions';
 import { runner } from '../hono/runner.js';
 
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 const env: Record<string, string> = process.env as any;
 
 const app = new Hono();
-app.use('*', runner({ cmd: 'start', loadEntries, env }));
+app.use('*', runner({ ssr, cmd: 'start', loadEntries, env }));
 app.notFound((c) => {
   const notFoundHtml = (globalThis as any).__WAKU_NOT_FOUND_HTML__;
   if (typeof notFoundHtml === 'string') {

--- a/packages/waku/src/lib/builder/serve-partykit.ts
+++ b/packages/waku/src/lib/builder/serve-partykit.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { runner } from '../hono/runner.js';
 
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 let serveWaku: ReturnType<typeof runner> | undefined;
 
 const app = new Hono();

--- a/packages/waku/src/lib/builder/serve-partykit.ts
+++ b/packages/waku/src/lib/builder/serve-partykit.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { runner } from '../hono/runner.js';
 
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 let serveWaku: ReturnType<typeof runner> | undefined;
 
 const app = new Hono();
@@ -29,7 +30,7 @@ app.notFound(async (c) => {
 export default {
   onFetch(request: Request, lobby: any, ctx: Parameters<typeof app.fetch>[2]) {
     if (!serveWaku) {
-      serveWaku = runner({ cmd: 'start', loadEntries, env: lobby });
+      serveWaku = runner({ ssr, cmd: 'start', loadEntries, env: lobby });
     }
     return app.fetch(request, lobby, ctx);
   },

--- a/packages/waku/src/lib/builder/serve-vercel.ts
+++ b/packages/waku/src/lib/builder/serve-vercel.ts
@@ -9,7 +9,7 @@ import { runner } from '../hono/runner.js';
 const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR!;
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR!;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
-const ssr: boolean = import.meta.env.WAKU_SSR === "true"
+const ssr: boolean = import.meta.env.WAKU_SSR === 'true';
 const env: Record<string, string> = process.env as any;
 
 const app = new Hono();

--- a/packages/waku/src/lib/builder/serve-vercel.ts
+++ b/packages/waku/src/lib/builder/serve-vercel.ts
@@ -9,10 +9,11 @@ import { runner } from '../hono/runner.js';
 const distDir = import.meta.env.WAKU_CONFIG_DIST_DIR!;
 const publicDir = import.meta.env.WAKU_CONFIG_PUBLIC_DIR!;
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
+const ssr: boolean = import.meta.env.WAKU_SSR === "true"
 const env: Record<string, string> = process.env as any;
 
 const app = new Hono();
-app.use('*', runner({ cmd: 'start', loadEntries, env }));
+app.use('*', runner({ ssr, cmd: 'start', loadEntries, env }));
 app.notFound((c) => {
   // FIXME better implementation using node stream?
   const file = path.join(distDir, publicDir, '404.html');

--- a/packages/waku/src/lib/handlers/handler-dev.ts
+++ b/packages/waku/src/lib/handlers/handler-dev.ts
@@ -191,6 +191,7 @@ export function createHandler<
       try {
         const readable = await renderHtml({
           config,
+          ssr,
           pathname: req.url.pathname,
           searchParams: req.url.searchParams,
           htmlHead: config.htmlHead,

--- a/packages/waku/src/lib/handlers/handler-prd.ts
+++ b/packages/waku/src/lib/handlers/handler-prd.ts
@@ -94,6 +94,7 @@ export function createHandler<
         if (htmlHead) {
           const readable = await renderHtml({
             config,
+            ssr,
             pathname: req.url.pathname,
             searchParams: req.url.searchParams,
             htmlHead,

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -11,7 +11,7 @@ const createEmptyReadableStream = () =>
   });
 
 export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
-  console.log('runner', options)
+  console.log('runner', options);
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -11,6 +11,7 @@ const createEmptyReadableStream = () =>
   });
 
 export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
+  console.log('runner', options)
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -15,7 +15,6 @@ export type CLIENT_MODULE_KEY = keyof typeof CLIENT_MODULE_MAP;
 export const CLIENT_PREFIX = 'client/';
 
 export const ssr: Middleware = (options) => {
-  console.log('options', options);
   (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
   const entriesPromise =
     options.cmd === 'start'

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -15,6 +15,7 @@ export type CLIENT_MODULE_KEY = keyof typeof CLIENT_MODULE_MAP;
 export const CLIENT_PREFIX = 'client/';
 
 export const ssr: Middleware = (options) => {
+  console.log('options', options);
   (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
   const entriesPromise =
     options.cmd === 'start'
@@ -49,6 +50,7 @@ export const ssr: Middleware = (options) => {
       if (htmlHead) {
         const readable = await renderHtml({
           config,
+          ssr: options.ssr,
           pathname: ctx.req.url.pathname,
           searchParams: ctx.req.url.searchParams,
           htmlHead,

--- a/packages/waku/src/lib/middleware/types.ts
+++ b/packages/waku/src/lib/middleware/types.ts
@@ -42,7 +42,7 @@ export type Handler = (
 ) => Promise<void>;
 
 export type MiddlewareOptions = {
-  ssr: boolean,
+  ssr: boolean;
   env?: Record<string, string>;
 } & (
   | { cmd: 'dev'; config: Config }

--- a/packages/waku/src/lib/middleware/types.ts
+++ b/packages/waku/src/lib/middleware/types.ts
@@ -42,6 +42,7 @@ export type Handler = (
 ) => Promise<void>;
 
 export type MiddlewareOptions = {
+  ssr: boolean,
   env?: Record<string, string>;
 } & (
   | { cmd: 'dev'; config: Config }

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -14,6 +14,7 @@ export function rscServePlugin(opts: {
     | 'partykit'
     | 'deno'
     | 'aws-lambda';
+  ssr: boolean;
 }): Plugin {
   return {
     name: 'rsc-serve-plugin',
@@ -24,6 +25,7 @@ export function rscServePlugin(opts: {
       }
       viteConfig.define = {
         ...viteConfig.define,
+        'import.meta.env.WAKU_SSR': JSON.stringify(opts.ssr),
         'import.meta.env.WAKU_ENTRIES_FILE': JSON.stringify(opts.entriesFile),
         'import.meta.env.WAKU_CONFIG_DIST_DIR': JSON.stringify(opts.distDir),
         'import.meta.env.WAKU_CONFIG_PUBLIC_DIR': JSON.stringify(

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -149,7 +149,7 @@ const buildHtml = (
     'html',
     null,
     createElement('head', { dangerouslySetInnerHTML: { __html: head } }),
-    createElement('body', { 'data-hydrate': ssr ? "true" : undefined }, body),
+    createElement('body', { 'data-hydrate': ssr ? 'true' : undefined }, body),
   );
 
 export const renderHtml = async (
@@ -310,7 +310,6 @@ export const renderHtml = async (
   const body: Promise<ReactNode> = createFromReadableStream(ssrConfig.body, {
     ssrManifest: { moduleMap, moduleLoading: null },
   });
-  console.log('hereeee', ssr)
   const readable = (
     await renderToReadableStream(
       buildHtml(

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -140,6 +140,7 @@ const rectifyHtml = () => {
 };
 
 const buildHtml = (
+  ssr: boolean,
   createElement: typeof createElementType,
   head: string,
   body: ReactNode,
@@ -148,12 +149,13 @@ const buildHtml = (
     'html',
     null,
     createElement('head', { dangerouslySetInnerHTML: { __html: head } }),
-    createElement('body', { 'data-hydrate': true }, body),
+    createElement('body', { 'data-hydrate': ssr ? "true" : undefined }, body),
   );
 
 export const renderHtml = async (
   opts: {
     config: Omit<ResolvedConfig, 'middleware'>;
+    ssr: boolean;
     pathname: string;
     searchParams: URLSearchParams;
     htmlHead: string;
@@ -181,6 +183,7 @@ export const renderHtml = async (
 ): Promise<ReadableStream | null> => {
   const {
     config,
+    ssr,
     pathname,
     searchParams,
     htmlHead,
@@ -307,9 +310,11 @@ export const renderHtml = async (
   const body: Promise<ReactNode> = createFromReadableStream(ssrConfig.body, {
     ssrManifest: { moduleMap, moduleLoading: null },
   });
+  console.log('hereeee', ssr)
   const readable = (
     await renderToReadableStream(
       buildHtml(
+        ssr,
         createElement,
         htmlHead,
         createElement(


### PR DESCRIPTION
While working on #552 

I found out that the ci was giving hydration error while the withSSR was false. The reason was that `data-hydrate` was always true.