### PR TITLE
fix: fs-router for non-Node envs

### DIFF
--- a/e2e/fixtures/rsc-basic/waku.config.ts
+++ b/e2e/fixtures/rsc-basic/waku.config.ts
@@ -1,11 +1,12 @@
+const DO_NOT_BUNDLE = '';
+
 /** @type {import('waku/config').Config} */
 export default {
   middleware: (cmd: 'dev' | 'start') => [
     ...(cmd === 'dev'
       ? [
           import(
-            /* @vite-ignore */ 'DO_NOT_BUNDLE'.slice(Infinity) +
-              'waku/middleware/dev-server'
+            /* @vite-ignore */ DO_NOT_BUNDLE + 'waku/middleware/dev-server'
           ),
         ]
       : []),

--- a/e2e/fixtures/rsc-router/waku.config.ts
+++ b/e2e/fixtures/rsc-router/waku.config.ts
@@ -1,11 +1,12 @@
+const DO_NOT_BUNDLE = '';
+
 /** @type {import('waku/config').Config} */
 export default {
   middleware: (cmd: 'dev' | 'start') => [
     ...(cmd === 'dev'
       ? [
           import(
-            /* @vite-ignore */ 'DO_NOT_BUNDLE'.slice(Infinity) +
-              'waku/middleware/dev-server'
+            /* @vite-ignore */ DO_NOT_BUNDLE + 'waku/middleware/dev-server'
           ),
         ]
       : []),

--- a/examples/08_cookies/waku.config.ts
+++ b/examples/08_cookies/waku.config.ts
@@ -1,3 +1,5 @@
+const DO_NOT_BUNDLE = '';
+
 /** @type {import('waku/config').Config} */
 export default {
   middleware: (cmd: 'dev' | 'start') => [
@@ -5,8 +7,7 @@ export default {
     ...(cmd === 'dev'
       ? [
           import(
-            /* @vite-ignore */ 'DO_NOT_BUNDLE'.slice(Infinity) +
-              'waku/middleware/dev-server'
+            /* @vite-ignore */ DO_NOT_BUNDLE + 'waku/middleware/dev-server'
           ),
         ]
       : []),

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -6,7 +6,7 @@ import viteReact from '@vitejs/plugin-react';
 import type { LoggingFunction, RollupLog } from 'rollup';
 
 import type { Config } from '../../config.js';
-import type { EntriesPrd } from '../../server.js';
+import type { BuildConfig, EntriesPrd } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { resolveConfig } from '../config.js';
 import type { PathSpec } from '../utils/path.js';
@@ -374,7 +374,7 @@ const emitRscFiles = async (
   rootDir: string,
   config: ResolvedConfig,
   distEntries: EntriesPrd,
-  buildConfig: Awaited<ReturnType<typeof getBuildConfig>>,
+  buildConfig: BuildConfig,
 ) => {
   const clientModuleMap = new Map<string, Set<string>>();
   const addClientModule = (input: string, id: string) => {
@@ -452,7 +452,7 @@ const emitHtmlFiles = async (
   config: ResolvedConfig,
   distEntriesFile: string,
   distEntries: EntriesPrd,
-  buildConfig: Awaited<ReturnType<typeof getBuildConfig>>,
+  buildConfig: BuildConfig,
   getClientModules: (input: string) => string[],
 ) => {
   const basePrefix = config.basePath + config.rscPath + '/';
@@ -639,6 +639,10 @@ export async function build(options: {
 
   const distEntries = await import(filePathToFileURL(distEntriesFile));
   const buildConfig = await getBuildConfig({ config, entries: distEntries });
+  await appendFile(
+    distEntriesFile,
+    `export const buildConfig = ${JSON.stringify(buildConfig)};`,
+  );
   const { getClientModules } = await emitRscFiles(
     rootDir,
     config,

--- a/packages/waku/src/lib/config.ts
+++ b/packages/waku/src/lib/config.ts
@@ -13,14 +13,11 @@ const DEFAULT_HTML_HEAD = `
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 `.trim();
 
+const DO_NOT_BUNDLE = '';
+
 const DEFAULT_MIDDLEWARE = (cmd: 'dev' | 'start') => [
   ...(cmd === 'dev'
-    ? [
-        import(
-          /* @vite-ignore */ 'DO_NOT_BUNDLE'.slice(Infinity) +
-            'waku/middleware/dev-server'
-        ),
-      ]
+    ? [import(/* @vite-ignore */ DO_NOT_BUNDLE + 'waku/middleware/dev-server')]
     : []),
   import('waku/middleware/ssr'),
   import('waku/middleware/rsc'),

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -157,7 +157,7 @@ export async function renderRsc(
       },
     };
     const elements = await runWithRenderContext(renderContext, () =>
-      renderEntries(input, searchParams),
+      renderEntries(input, { searchParams }),
     );
     if (elements === null) {
       const err = new Error('No function component found');
@@ -186,7 +186,7 @@ export async function renderRsc(
         }
         elementsPromise = Promise.all([
           elementsPromise,
-          renderEntries(input, searchParams),
+          renderEntries(input, { searchParams }),
         ]).then(([oldElements, newElements]) => ({
           ...oldElements,
           // FIXME we should actually check if newElements is null and send an error

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -71,12 +71,15 @@ export async function renderRsc(
   const {
     default: { renderEntries },
     loadModule,
-  } = entries as (EntriesDev & { loadModule: undefined }) | EntriesPrd;
+    buildConfig,
+  } = entries as
+    | (EntriesDev & { loadModule: never; buildConfig: never })
+    | EntriesPrd;
 
   const loadServerModule = <T>(key: keyof typeof SERVER_MODULE_MAP) =>
     (isDev
       ? import(/* @vite-ignore */ SERVER_MODULE_MAP[key])
-      : loadModule!(key)) as Promise<T>;
+      : loadModule(key)) as Promise<T>;
 
   const [
     {
@@ -95,7 +98,7 @@ export async function renderRsc(
     loadServerModule<{ default: typeof RSDWClientType }>('rsdw-client'),
     (isDev
       ? opts.loadServerModule(SERVER_MODULE_MAP['waku-server'])
-      : loadModule!('waku-server')) as Promise<{
+      : loadModule('waku-server')) as Promise<{
       setRenderContext: typeof setRenderContextType;
     }>,
   ]);
@@ -157,7 +160,7 @@ export async function renderRsc(
       },
     };
     const elements = await runWithRenderContext(renderContext, () =>
-      renderEntries(input, { searchParams }),
+      renderEntries(input, { searchParams, buildConfig }),
     );
     if (elements === null) {
       const err = new Error('No function component found');
@@ -186,7 +189,7 @@ export async function renderRsc(
         }
         elementsPromise = Promise.all([
           elementsPromise,
-          renderEntries(input, { searchParams }),
+          renderEntries(input, { searchParams, buildConfig }),
         ]).then(([oldElements, newElements]) => ({
           ...oldElements,
           // FIXME we should actually check if newElements is null and send an error
@@ -240,7 +243,7 @@ export async function renderRsc(
       if (!fileId.startsWith('@id/')) {
         throw new Error('Unexpected server entry in PRD');
       }
-      mod = await loadModule!(fileId.slice('@id/'.length));
+      mod = await loadModule(fileId.slice('@id/'.length));
     }
     const fn = mod[name] || mod;
     const elements = await renderWithContextWithAction(context, () =>
@@ -334,12 +337,18 @@ export async function getSsrConfig(
   const {
     default: { getSsrConfig },
     loadModule,
-  } = entries as (EntriesDev & { loadModule: undefined }) | EntriesPrd;
+    buildConfig,
+  } = entries as
+    | (EntriesDev & { loadModule: never; buildConfig: never })
+    | EntriesPrd;
   const { renderToReadableStream } = await (isDev
     ? import(/* @vite-ignore */ SERVER_MODULE_MAP['rsdw-server'])
-    : loadModule!('rsdw-server').then((m: any) => m.default));
+    : loadModule('rsdw-server').then((m: any) => m.default));
 
-  const ssrConfig = await getSsrConfig?.(pathname, { searchParams });
+  const ssrConfig = await getSsrConfig?.(pathname, {
+    searchParams,
+    buildConfig,
+  });
   if (!ssrConfig) {
     return null;
   }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -30,7 +30,12 @@ const ShoudSkipComponent = ({ shouldSkip }: { shouldSkip: ShouldSkip }) =>
 
 export function unstable_defineRouter(
   getPathConfig: () => Promise<
-    Iterable<{ path: PathSpec; isStatic?: boolean; noSsr?: boolean }>
+    Iterable<{
+      path: PathSpec;
+      isStatic?: boolean;
+      noSsr?: boolean;
+      data?: unknown; // For build: put in customData
+    }>
   >,
   getComponent: (
     componentId: string, // "**/layout" or "**/page"
@@ -50,7 +55,7 @@ export function unstable_defineRouter(
   type MyPathConfig = {
     pathname: PathSpec;
     isStatic?: boolean | undefined;
-    customData: { noSsr?: boolean; is404: boolean };
+    customData: { noSsr?: boolean; is404: boolean; data: unknown };
   }[];
   let cachedPathConfig: MyPathConfig | undefined;
   const getMyPathConfig = async (
@@ -68,7 +73,7 @@ export function unstable_defineRouter(
         return {
           pathname: item.path,
           isStatic: item.isStatic,
-          customData: { is404, noSsr: !!item.noSsr },
+          customData: { is404, noSsr: !!item.noSsr, data: item.data },
         };
       });
     }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -34,10 +34,11 @@ export function unstable_defineRouter(
   >,
   getComponent: (
     componentId: string, // "**/layout" or "**/page"
-    /**
-     * HACK setShouldSkip API is too hard to understand
-     */
-    setShouldSkip: (val?: ShouldSkip[string]) => void,
+    options: {
+      // TODO setShouldSkip API is too hard to understand
+      unstable_setShouldSkip: (val?: ShouldSkip[string]) => void;
+      unstable_buildConfig: BuildConfig | undefined;
+    },
   ) => Promise<
     | FunctionComponent<RouteProps>
     | FunctionComponent<RouteProps & { children: ReactNode }>
@@ -108,12 +109,16 @@ export function unstable_defineRouter(
           if (skip?.includes(id)) {
             return [];
           }
-          const mod = await getComponent(id, (val) => {
+          const setShoudSkip = (val?: ShouldSkip[string]) => {
             if (val) {
               shouldSkip[id] = val;
             } else {
               delete shouldSkip[id];
             }
+          };
+          const mod = await getComponent(id, {
+            unstable_setShouldSkip: setShoudSkip,
+            unstable_buildConfig: buildConfig,
           });
           const component = mod && 'default' in mod ? mod.default : mod;
           if (!component) {

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -2,7 +2,12 @@ import { createElement } from 'react';
 import type { ComponentProps, FunctionComponent, ReactNode } from 'react';
 
 import { defineEntries } from '../server.js';
-import type { RenderEntries, GetBuildConfig, GetSsrConfig } from '../server.js';
+import type {
+  BuildConfig,
+  RenderEntries,
+  GetBuildConfig,
+  GetSsrConfig,
+} from '../server.js';
 import { Children, Slot } from '../client.js';
 import {
   getComponentIds,
@@ -41,32 +46,57 @@ export function unstable_defineRouter(
     | null
   >,
 ): ReturnType<typeof defineEntries> {
-  const pathConfigPromise = getPathConfig().then((pathConfig) =>
-    Array.from(pathConfig).map((item) => {
-      const is404 =
-        item.path.length === 1 &&
-        item.path[0]!.type === 'literal' &&
-        item.path[0]!.name === '404';
-      return { ...item, is404 };
-    }),
-  );
-  const has404Promise = pathConfigPromise.then((pathConfig) =>
-    pathConfig.some(({ is404 }) => is404),
-  );
+  type MyPathConfig = {
+    pathname: PathSpec;
+    isStatic?: boolean | undefined;
+    customData: { noSsr?: boolean; is404: boolean };
+  }[];
+  let cachedPathConfig: MyPathConfig | undefined;
+  const getMyPathConfig = async (
+    buildConfig?: BuildConfig,
+  ): Promise<MyPathConfig> => {
+    if (buildConfig) {
+      return buildConfig as MyPathConfig;
+    }
+    if (!cachedPathConfig) {
+      cachedPathConfig = Array.from(await getPathConfig()).map((item) => {
+        const is404 =
+          item.path.length === 1 &&
+          item.path[0]!.type === 'literal' &&
+          item.path[0]!.name === '404';
+        return {
+          pathname: item.path,
+          isStatic: item.isStatic,
+          customData: { is404, noSsr: !!item.noSsr },
+        };
+      });
+    }
+    return cachedPathConfig;
+  };
   const existsPath = async (
     pathname: string,
-  ): Promise<false | true | 'NO_SSR'> => {
-    const pathConfig = await pathConfigPromise;
-    const found = pathConfig.find(({ path: pathSpec }) =>
+    buildConfig: BuildConfig | undefined,
+  ): Promise<['FOUND', 'NO_SSR'?] | ['NOT_FOUND', 'HAS_404'?]> => {
+    const pathConfig = await getMyPathConfig(buildConfig);
+    const found = pathConfig.find(({ pathname: pathSpec }) =>
       getPathMapping(pathSpec, pathname),
     );
-    return found ? (found.noSsr ? 'NO_SSR' : true) : false;
+    return found
+      ? found.customData.noSsr
+        ? ['FOUND', 'NO_SSR']
+        : ['FOUND']
+      : pathConfig.some(({ customData: { is404 } }) => is404) // FIXMEs should avoid re-computation
+        ? ['NOT_FOUND', 'HAS_404']
+        : ['NOT_FOUND'];
   };
   const shouldSkip: ShouldSkip = {};
 
-  const renderEntries: RenderEntries = async (input, { searchParams }) => {
+  const renderEntries: RenderEntries = async (
+    input,
+    { searchParams, buildConfig },
+  ) => {
     const pathname = parseInputString(input);
-    if (!existsPath(pathname)) {
+    if ((await existsPath(pathname, buildConfig))[0] === 'NOT_FOUND') {
       return null;
     }
     const skip = searchParams.getAll(PARAM_KEY_SKIP) || [];
@@ -108,9 +138,9 @@ export function unstable_defineRouter(
   const getBuildConfig: GetBuildConfig = async (
     unstable_collectClientModules,
   ) => {
-    const pathConfig = await pathConfigPromise;
+    const pathConfig = await getMyPathConfig();
     const path2moduleIds: Record<string, string[]> = {};
-    for (const { path: pathSpec } of pathConfig) {
+    for (const { pathname: pathSpec } of pathConfig) {
       if (pathSpec.some(({ type }) => type !== 'literal')) {
         continue;
       }
@@ -126,14 +156,9 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
     import(id);
   }
 };`;
-    const buildConfig: {
-      pathname: PathSpec;
-      isStatic: boolean;
-      entries: { input: string; isStatic: boolean }[];
-      customCode: string;
-    }[] = [];
-    for (const { path: pathSpec, isStatic = false, is404 } of pathConfig) {
-      const entries: (typeof buildConfig)[number]['entries'] = [];
+    const buildConfig: BuildConfig = [];
+    for (const { pathname: pathSpec, isStatic, customData } of pathConfig) {
+      const entries: BuildConfig[number]['entries'] = [];
       if (pathSpec.every(({ type }) => type === 'literal')) {
         const pathname = '/' + pathSpec.map(({ name }) => name).join('/');
         const input = getInputString(pathname);
@@ -144,19 +169,24 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         isStatic,
         entries,
         customCode:
-          customCode + (is404 ? 'globalThis.__WAKU_ROUTER_404__ = true;' : ''),
+          customCode +
+          (customData.is404 ? 'globalThis.__WAKU_ROUTER_404__ = true;' : ''),
+        customData,
       });
     }
     return buildConfig;
   };
 
-  const getSsrConfig: GetSsrConfig = async (pathname, { searchParams }) => {
-    const found = await existsPath(pathname);
-    if (found === 'NO_SSR') {
+  const getSsrConfig: GetSsrConfig = async (
+    pathname,
+    { searchParams, buildConfig },
+  ) => {
+    const pathStatus = await existsPath(pathname, buildConfig);
+    if (pathStatus[1] === 'NO_SSR') {
       return null;
     }
-    if (!found) {
-      if (await has404Promise) {
+    if (pathStatus[0] === 'NOT_FOUND') {
+      if (pathStatus[1] === 'HAS_404') {
         pathname = '/404';
       } else {
         return null;

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -64,7 +64,7 @@ export function unstable_defineRouter(
   };
   const shouldSkip: ShouldSkip = {};
 
-  const renderEntries: RenderEntries = async (input, searchParams) => {
+  const renderEntries: RenderEntries = async (input, { searchParams }) => {
     const pathname = parseInputString(input);
     if (!existsPath(pathname)) {
       return null;

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -35,7 +35,7 @@ export function fsRouter(
             return [];
           }
           // HACK: replace "_slug_" to "[slug]"
-          file = file.replace(/(^|\/)_(\w+)_(\/|\.)/g, '$1[$2]$3');
+          file = file.replace(/(^|\/|\\)_(\w+)_(\/|\\|\.)/g, '$1[$2]$3');
           if (sep === '/') {
             return [file];
           }

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,5 +1,7 @@
 import { createPages } from './create-pages.js';
 
+const DO_NOT_BUNDLE = '';
+
 export function fsRouter(
   importMetaUrl: string,
   loader: (dir: string, file: string) => Promise<any>,
@@ -21,9 +23,9 @@ export function fsRouter(
           { join, dirname, extname, sep },
           { fileURLToPath },
         ] = await Promise.all([
-          import('node:fs/promises'),
-          import('node:path'),
-          import('node:url'),
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:fs/promises'),
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:path'),
+          import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:url'),
         ]);
         const pagesDir = join(dirname(fileURLToPath(importMetaUrl)), pages);
         files = await readdir(pagesDir, {

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,11 +1,3 @@
-import {
-  joinPath,
-  fileURLToFilePath,
-  extname,
-  decodeFilePathFromAbsolute,
-} from '../lib/utils/path.js';
-import { readdir } from '../lib/utils/node-fs.js';
-
 import { createPages } from './create-pages.js';
 
 export function fsRouter(
@@ -13,52 +5,76 @@ export function fsRouter(
   loader: (dir: string, file: string) => Promise<any>,
   pages = 'pages',
 ) {
-  const pagesDir = decodeFilePathFromAbsolute(
-    joinPath(fileURLToFilePath(importMetaUrl), '..', pages),
-  );
-  return createPages(async ({ createPage, createLayout }) => {
-    const files = await readdir(pagesDir, {
-      encoding: 'utf8',
-      recursive: true,
-    });
-    for (const file of files) {
-      if (!['.tsx', '.js'].includes(extname(file))) {
-        continue;
-      }
-      const fname = (
-        pagesDir.startsWith('/')
-          ? file
-          : // For Windows
-            file.replace(/\\/g, '/')
-      )
-        // HACK: replace "_slug_" to "[slug]"
-        .replace(/(^|\/)_(\w+)_(\/|\.)/g, '$1[$2]$3');
-      const mod = await loader(pages, fname);
-      const config = await mod.getConfig?.();
-      const pathItems = fname
-        .replace(/\.\w+$/, '')
-        .split('/')
-        .filter(Boolean);
-      if (pathItems.at(-1) === '_layout') {
-        createLayout({
-          path: '/' + pathItems.slice(0, -1).join('/'),
-          component: mod.default,
-          render: 'static',
-          ...config,
-        });
+  return createPages(
+    async ({ createPage, createLayout }, { unstable_buildPaths }) => {
+      let files: string[];
+      if (unstable_buildPaths) {
+        files = unstable_buildPaths.map((pathSpec) =>
+          pathSpec
+            .map((item) => {
+              if (!item.name) {
+                throw new Error('[Bug] No name in pathSpec');
+              }
+              return item.name;
+            })
+            .join('/'),
+        );
       } else {
-        createPage({
-          path:
-            '/' +
-            (pathItems.at(-1) === 'index'
-              ? pathItems.slice(0, -1)
-              : pathItems
-            ).join('/'),
-          component: mod.default,
-          render: 'dynamic',
-          ...config,
+        // dev and build only
+        const [{ readdir }, path, { fileURLToPath }] = await Promise.all([
+          import('node:fs/promises'),
+          import('node:path'),
+          import('node:url'),
+        ]);
+        const pagesDir = path.join(
+          path.dirname(fileURLToPath(importMetaUrl)),
+          pages,
+        );
+        files = await readdir(pagesDir, {
+          encoding: 'utf8',
+          recursive: true,
+        });
+        files = files.flatMap((file) => {
+          if (!['.tsx', '.js'].includes(path.extname(file))) {
+            return [];
+          }
+          // HACK: replace "_slug_" to "[slug]"
+          file = file.replace(/(^|\/)_(\w+)_(\/|\.)/g, '$1[$2]$3');
+          if (path.sep === '/') {
+            return [file];
+          }
+          // For Windows
+          return [file.replace(/\\/g, '/')];
         });
       }
-    }
-  });
+      for (const file of files) {
+        const mod = await loader(pages, file);
+        const config = await mod.getConfig?.();
+        const pathItems = file
+          .replace(/\.\w+$/, '')
+          .split('/')
+          .filter(Boolean);
+        if (pathItems.at(-1) === '_layout') {
+          createLayout({
+            path: '/' + pathItems.slice(0, -1).join('/'),
+            component: mod.default,
+            render: 'static',
+            ...config,
+          });
+        } else {
+          createPage({
+            path:
+              '/' +
+              (pathItems.at(-1) === 'index'
+                ? pathItems.slice(0, -1)
+                : pathItems
+              ).join('/'),
+            component: mod.default,
+            render: 'dynamic',
+            ...config,
+          });
+        }
+      }
+    },
+  );
 }

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -23,7 +23,7 @@ export type RenderEntries = (
   input: string,
   options: {
     searchParams: URLSearchParams;
-    buildConfig?: BuildConfig | undefined;
+    buildConfig: BuildConfig | undefined;
   },
 ) => Promise<Elements | null>;
 

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -6,33 +6,36 @@ import type { PathSpec } from './lib/utils/path.js';
 
 type Elements = Record<string, ReactNode>;
 
+export type BuildConfig = {
+  pathname: string | PathSpec; // TODO drop support for string?
+  isStatic?: boolean;
+  entries?: {
+    input: string;
+    skipPrefetch?: boolean;
+    isStatic?: boolean;
+  }[];
+  context?: Record<string, unknown>;
+  customCode?: string; // optional code to inject TODO hope to remove this
+  customData?: unknown; // should be serializable with JSON.stringify
+}[];
+
 export type RenderEntries = (
   input: string,
-  opts: {
+  options: {
     searchParams: URLSearchParams;
+    buildConfig?: BuildConfig;
   },
 ) => Promise<Elements | null>;
 
 export type GetBuildConfig = (
   unstable_collectClientModules: (input: string) => Promise<string[]>,
-) => Promise<
-  Iterable<{
-    pathname: string | PathSpec; // TODO drop support for string?
-    isStatic?: boolean;
-    entries?: Iterable<{
-      input: string;
-      skipPrefetch?: boolean;
-      isStatic?: boolean;
-    }>;
-    customCode?: string; // optional code to inject TODO hope to remove this
-    context?: Record<string, unknown>;
-  }>
->;
+) => Promise<BuildConfig>;
 
 export type GetSsrConfig = (
   pathname: string,
   options: {
     searchParams: URLSearchParams;
+    buildConfig?: BuildConfig;
   },
 ) => Promise<{
   input: string;
@@ -55,6 +58,7 @@ export type EntriesDev = {
 export type EntriesPrd = EntriesDev & {
   loadConfig: () => Promise<Config>;
   loadModule: (id: string) => Promise<unknown>;
+  buildConfig: BuildConfig;
   dynamicHtmlPaths: [pathSpec: PathSpec, htmlHead: string][];
   publicIndexHtml: string;
 };

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -8,7 +8,9 @@ type Elements = Record<string, ReactNode>;
 
 export type RenderEntries = (
   input: string,
-  searchParams: URLSearchParams,
+  opts: {
+    searchParams: URLSearchParams;
+  },
 ) => Promise<Elements | null>;
 
 export type GetBuildConfig = (

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -8,11 +8,11 @@ type Elements = Record<string, ReactNode>;
 
 export type BuildConfig = {
   pathname: string | PathSpec; // TODO drop support for string?
-  isStatic?: boolean;
+  isStatic?: boolean | undefined;
   entries?: {
     input: string;
-    skipPrefetch?: boolean;
-    isStatic?: boolean;
+    skipPrefetch?: boolean | undefined;
+    isStatic?: boolean | undefined;
   }[];
   context?: Record<string, unknown>;
   customCode?: string; // optional code to inject TODO hope to remove this
@@ -23,7 +23,7 @@ export type RenderEntries = (
   input: string,
   options: {
     searchParams: URLSearchParams;
-    buildConfig?: BuildConfig;
+    buildConfig?: BuildConfig | undefined;
   },
 ) => Promise<Elements | null>;
 
@@ -35,7 +35,7 @@ export type GetSsrConfig = (
   pathname: string,
   options: {
     searchParams: URLSearchParams;
-    buildConfig?: BuildConfig;
+    buildConfig?: BuildConfig | undefined;
   },
 ) => Promise<{
   input: string;
@@ -58,7 +58,7 @@ export type EntriesDev = {
 export type EntriesPrd = EntriesDev & {
   loadConfig: () => Promise<Config>;
   loadModule: (id: string) => Promise<unknown>;
-  buildConfig: BuildConfig;
+  buildConfig?: BuildConfig;
   dynamicHtmlPaths: [pathSpec: PathSpec, htmlHead: string][];
   publicIndexHtml: string;
 };


### PR DESCRIPTION
#572 depends on Node.js even in production build, which isn't ideal.

- [x] persist build config in entries
- [x] fix defineRouter
- [x] fix createPages
- [x] fix fsRouter