### PR TITLE
fix: React.cache to work correctly if AsyncLocalStorage is available

### DIFF
--- a/examples/08_cookies/src/components/App.tsx
+++ b/examples/08_cookies/src/components/App.tsx
@@ -1,10 +1,17 @@
-import { Suspense } from 'react';
+import { Suspense, cache } from 'react';
 import { getContext } from 'waku/server';
 
 import { Counter } from './Counter.js';
 
+const cachedFn = cache(() => Date.now());
+
 const InternalAsyncComponent = async () => {
+  const val1 = cachedFn();
   await new Promise((resolve) => setTimeout(resolve, 1000));
+  const val2 = cachedFn();
+  if (val1 !== val2) {
+    throw new Error('Cache not working');
+  }
   console.log(getContext());
   return null;
 };

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -242,6 +242,7 @@ const buildServerBundle = async (
     build: {
       ssr: true,
       ssrEmitAssets: true,
+      target: 'node18',
       outDir: joinPath(rootDir, config.distDir),
       rollupOptions: {
         onwarn,
@@ -299,6 +300,7 @@ const buildSsrBundle = async (
     publicDir: false,
     build: {
       ssr: true,
+      target: 'node18',
       outDir: joinPath(rootDir, config.distDir, config.ssrDir),
       rollupOptions: {
         onwarn,

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -119,6 +119,7 @@ const analyzeEntries = async (
     build: {
       write: false,
       ssr: true,
+      target: 'node18',
       rollupOptions: {
         onwarn,
         input: {

--- a/packages/waku/src/lib/renderers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/renderers/dev-worker-impl.ts
@@ -3,6 +3,7 @@
 import { pathToFileURL } from 'node:url';
 import { parentPort, getEnvironmentData } from 'node:worker_threads';
 import { Server } from 'node:http';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { TransferListItem } from 'node:worker_threads';
 import { createServer as createViteServer } from 'vite';
 import viteReact from '@vitejs/plugin-react';
@@ -24,6 +25,9 @@ import { rscManagedPlugin } from '../plugins/vite-plugin-rsc-managed.js';
 import { rscDelegatePlugin } from '../plugins/vite-plugin-rsc-delegate.js';
 import { mergeUserViteConfig } from '../utils/merge-vite-config.js';
 import { viteHot } from '../plugins/vite-plugin-rsc-hmr.js';
+
+// For react-server-dom-webpack/server.edge
+(globalThis as any).AsyncLocalStorage = AsyncLocalStorage;
 
 const { default: module } = await import('node:module');
 const HAS_MODULE_REGISTER = typeof module.register === 'function';

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -77,15 +77,14 @@ type RenderStore<
 
 let renderStorage: AsyncLocalStorageType<RenderStore> | undefined;
 
-import('node:async_hooks')
-  .then(({ AsyncLocalStorage }) => {
-    renderStorage = new AsyncLocalStorage();
-  })
-  .catch(() => {
-    console.warn(
-      'AsyncLocalStorage is not available, rerender and getContext are only available in sync.',
-    );
-  });
+try {
+  const { AsyncLocalStorage } = await import('node:async_hooks');
+  renderStorage = new AsyncLocalStorage();
+} catch (e) {
+  console.warn(
+    'AsyncLocalStorage is not available, rerender and getContext are only available in sync.',
+  );
+}
 
 let previousRenderStore: RenderStore | undefined;
 let currentRenderStore: RenderStore | undefined;

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -75,11 +75,9 @@ type RenderStore<
   context: RscContext;
 };
 
-const DO_NOT_BUNDLE = '';
-
 let renderStorage: AsyncLocalStorageType<RenderStore> | undefined;
 
-import(/* @vite-ignore */ DO_NOT_BUNDLE + 'node:async_hooks')
+import('node:async_hooks')
   .then(({ AsyncLocalStorage }) => {
     renderStorage = new AsyncLocalStorage();
   })


### PR DESCRIPTION
Related with #587, `cache` hasn't been working as expected. This is to fix it.