### PR TITLE
feat(router): unstable_redirect

### DIFF
--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -72,6 +72,7 @@ export const fetchRSC = (
   searchParamsString: string,
   setElements: SetElements,
   cache = fetchCache,
+  unstable_onFetchData?: (data: unknown) => void,
 ): Elements => {
   let entry: CacheEntry | undefined = cache[0];
   if (entry && entry[0] === input && entry[1] === searchParamsString) {
@@ -91,6 +92,7 @@ export const fetchRSC = (
         checkStatus(response),
         options,
       );
+      unstable_onFetchData?.(data);
       const setElements = entry![2];
       startTransition(() => {
         // FIXME this causes rerenders even if data is empty
@@ -110,6 +112,7 @@ export const fetchRSC = (
     checkStatus(response),
     options,
   );
+  unstable_onFetchData?.(data);
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   cache[0] = entry = [input, searchParamsString, setElements, data];
   return data;
@@ -140,11 +143,13 @@ export const Root = ({
   initialInput,
   initialSearchParamsString,
   cache,
+  unstable_onFetchData,
   children,
 }: {
   initialInput?: string;
   initialSearchParamsString?: string;
   cache?: typeof fetchCache;
+  unstable_onFetchData?: (data: unknown) => void;
   children: ReactNode;
 }) => {
   const [elements, setElements] = useState(() =>
@@ -153,6 +158,7 @@ export const Root = ({
       initialSearchParamsString || '',
       (fn) => setElements(fn),
       cache,
+      unstable_onFetchData,
     ),
   );
   const refetch = useCallback(
@@ -163,10 +169,11 @@ export const Root = ({
         searchParams?.toString() || '',
         setElements,
         cache,
+        unstable_onFetchData,
       );
       setElements((prev) => mergeElements(prev, data));
     },
-    [cache],
+    [cache, unstable_onFetchData],
   );
   return createElement(
     RefetchContext.Provider,

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -27,8 +27,11 @@ export function parseInputString(input: string): string {
 
 export const PARAM_KEY_SKIP = 'waku_router_skip';
 
-// It starts with "/" to avoid conflicing with normal component ids.
+// It starts with "/" to avoid conflicting with normal component ids.
 export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
+
+// It starts with "/" to avoid conflicting with normal component ids.
+export const LOCATION_ID = '/LOCATION';
 
 // TODO revisit shouldSkip API
 export type ShouldSkip = (readonly [

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -22,6 +22,9 @@ export function getInputString(path: string): string {
 }
 
 export function parseInputString(input: string): string {
+  if (input.startsWith('/')) {
+    throw new Error('Input should not start with `/`');
+  }
   return '/' + input;
 }
 

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -30,11 +30,11 @@ export const PARAM_KEY_SKIP = 'waku_router_skip';
 // It starts with "/" to avoid conflicing with normal component ids.
 export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
 
-// The key is componentId
-export type ShouldSkip = Record<
-  string,
-  {
-    path?: boolean; // if we compare path
-    keys?: string[]; // searchParams keys to compare
-  }
->;
+// TODO revisit shouldSkip API
+export type ShouldSkip = (readonly [
+  componentId: string,
+  readonly [
+    path?: boolean, // if we compare path
+    keys?: string[], // searchParams keys to compare
+  ],
+])[];

--- a/packages/waku/src/router/create-pages.ts
+++ b/packages/waku/src/router/create-pages.ts
@@ -250,7 +250,7 @@ export function createPages(
       await configure(unstable_buildConfig);
       const staticComponent = staticComponentMap.get(id);
       if (staticComponent) {
-        unstable_setShouldSkip({});
+        unstable_setShouldSkip([]);
         return staticComponent;
       }
       for (const [pathSpec, Component] of dynamicPathMap.values()) {
@@ -281,7 +281,7 @@ export function createPages(
           return WrappedComponent;
         }
       }
-      unstable_setShouldSkip({}); // negative cache
+      unstable_setShouldSkip([]); // negative cache
       return null; // not found
     },
   );

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -224,6 +224,6 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
 export function unstable_redirect(
   pathname: string,
   searchParams?: URLSearchParams,
-){
+) {
   rerender(pathname, searchParams);
 }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -15,6 +15,7 @@ import {
   parseInputString,
   PARAM_KEY_SKIP,
   SHOULD_SKIP_ID,
+  LOCATION_ID,
 } from './common.js';
 import type { RouteProps, ShouldSkip } from './common.js';
 import { getPathMapping } from '../lib/utils/path.js';
@@ -137,6 +138,7 @@ export function unstable_defineRouter(
       )
     ).flat();
     entries.push([SHOULD_SKIP_ID, Object.entries(shouldSkipObj)]);
+    entries.push([LOCATION_ID, [pathname, searchParams.toString()]]);
     return Object.fromEntries(entries);
   };
 

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -106,6 +106,7 @@ export function unstable_defineRouter(
       return null;
     }
     const skip = searchParams.getAll(PARAM_KEY_SKIP) || [];
+    searchParams.delete(PARAM_KEY_SKIP); // delete all
     const componentIds = getComponentIds(pathname);
     const props: RouteProps = { path: pathname, searchParams };
     const entries = (
@@ -224,6 +225,13 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
 export function unstable_redirect(
   pathname: string,
   searchParams?: URLSearchParams,
+  skip?: string[],
 ) {
+  if (skip) {
+    searchParams = new URLSearchParams(searchParams);
+    for (const id of skip) {
+      searchParams.append(PARAM_KEY_SKIP, id);
+    }
+  }
   rerender(pathname, searchParams);
 }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import type { ComponentProps, FunctionComponent, ReactNode } from 'react';
 
-import { defineEntries } from '../server.js';
+import { defineEntries, rerender } from '../server.js';
 import type {
   BuildConfig,
   RenderEntries,
@@ -219,4 +219,11 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
   };
 
   return { renderEntries, getBuildConfig, getSsrConfig };
+}
+
+export function unstable_redirect(
+  pathname: string,
+  searchParams?: URLSearchParams,
+){
+  rerender(pathname, searchParams);
 }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -228,5 +228,6 @@ export function unstable_redirect(
       searchParams.append(PARAM_KEY_SKIP, id);
     }
   }
-  rerender(pathname, searchParams);
+  const input = getInputString(pathname);
+  rerender(input, searchParams);
 }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -21,12 +21,7 @@ import { getPathMapping } from '../lib/utils/path.js';
 import type { PathSpec } from '../lib/utils/path.js';
 import { ServerRouter } from './client.js';
 
-// TODO revisit shouldSkip API
-const ShoudSkipComponent = ({ shouldSkip }: { shouldSkip: ShouldSkip }) =>
-  createElement('meta', {
-    name: 'waku-should-skip',
-    content: JSON.stringify(shouldSkip),
-  });
+type ShouldSkipValue = ShouldSkip[number][1];
 
 export function unstable_defineRouter(
   getPathConfig: () => Promise<
@@ -41,7 +36,7 @@ export function unstable_defineRouter(
     componentId: string, // "**/layout" or "**/page"
     options: {
       // TODO setShouldSkip API is too hard to understand
-      unstable_setShouldSkip: (val?: ShouldSkip[string]) => void;
+      unstable_setShouldSkip: (val?: ShouldSkipValue) => void;
       unstable_buildConfig: BuildConfig | undefined;
     },
   ) => Promise<
@@ -95,7 +90,9 @@ export function unstable_defineRouter(
         ? ['NOT_FOUND', 'HAS_404']
         : ['NOT_FOUND'];
   };
-  const shouldSkip: ShouldSkip = {};
+  const shouldSkipObj: {
+    [componentId: ShouldSkip[number][0]]: ShouldSkip[number][1];
+  } = {};
 
   const renderEntries: RenderEntries = async (
     input,
@@ -109,17 +106,17 @@ export function unstable_defineRouter(
     searchParams.delete(PARAM_KEY_SKIP); // delete all
     const componentIds = getComponentIds(pathname);
     const props: RouteProps = { path: pathname, searchParams };
-    const entries = (
+    const entries: (readonly [string, ReactNode])[] = (
       await Promise.all(
         componentIds.map(async (id) => {
           if (skip?.includes(id)) {
             return [];
           }
-          const setShoudSkip = (val?: ShouldSkip[string]) => {
+          const setShoudSkip = (val?: ShouldSkipValue) => {
             if (val) {
-              shouldSkip[id] = val;
+              shouldSkipObj[id] = val;
             } else {
-              delete shouldSkip[id];
+              delete shouldSkipObj[id];
             }
           };
           const mod = await getComponent(id, {
@@ -139,10 +136,7 @@ export function unstable_defineRouter(
         }),
       )
     ).flat();
-    entries.push([
-      SHOULD_SKIP_ID,
-      createElement(ShoudSkipComponent, { shouldSkip }) as any,
-    ]);
+    entries.push([SHOULD_SKIP_ID, Object.entries(shouldSkipObj)]);
     return Object.fromEntries(entries);
   };
 
@@ -210,7 +204,6 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         Omit<ComponentProps<typeof ServerRouter>, 'children'>
       >,
       { loc: { path: pathname, searchParams } },
-      createElement(Slot, { id: SHOULD_SKIP_ID }),
       componentIds.reduceRight(
         (acc: ReactNode, id) => createElement(Slot, { id, fallback: acc }, acc),
         null,

--- a/packages/waku/src/router/server.ts
+++ b/packages/waku/src/router/server.ts
@@ -1,3 +1,3 @@
-export { unstable_defineRouter } from './define-router.js';
+export { unstable_defineRouter, unstable_redirect } from './define-router.js';
 export { createPages } from './create-pages.js';
 export { fsRouter } from './fs-router.js';


### PR DESCRIPTION
`rerender` is from `waku/server`.
`redirect` is from `waku/router/server`.

It's confusing because `input` and `pathname` look similar with current router implementation, but it might be very different in the future.

- [x] expose `unstable_redirect`
- [x] accept skip
- [x] refactor should-skip
- [x] change location
