### PR TITLE
html-renderer: Simplify module loading for react

### DIFF
--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -4,7 +4,7 @@ import { createElement } from 'react';
 import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
 import { injectRSCPayload } from 'rsc-html-stream/server';
 
-import { ServerRoot } from '../../client.js';
+import type * as WakuClientType from '../../client.js';
 import type { EntriesPrd } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { concatUint8Arrays } from '../utils/stream.js';
@@ -214,8 +214,10 @@ export const renderHtml = async (
     {
       default: { renderToReadableStream },
     },
+    { ServerRoot },
   ] = await Promise.all([
     loadClientModule<{ default: typeof RDServerType }>('rd-server'),
+    loadClientModule<typeof WakuClientType>('waku-client'),
   ]);
 
   const ssrConfig = await getSsrConfigForHtml?.(pathname, searchParams);

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -22,7 +22,6 @@ import { DIST_SSR } from '../builder/constants.js';
 import { DEFAULT_HTML_HEAD } from '../plugins/vite-plugin-rsc-index.js';
 
 export const CLIENT_MODULE_MAP = {
-  react: 'react',
   'rd-server': 'react-dom/server.edge',
   'rsdw-client': 'react-server-dom-webpack/client.edge',
   'waku-client': 'waku/client',

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -1,6 +1,6 @@
 import type { ReactNode, FunctionComponent, ComponentProps } from 'react';
+import type * as RDServerType from 'react-dom/server.edge';
 import { createElement } from 'react';
-import { renderToReadableStream } from 'react-dom/server.edge';
 import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
 import { injectRSCPayload } from 'rsc-html-stream/server';
 
@@ -204,6 +204,19 @@ export const renderHtml = async (
     getSsrConfigForHtml,
     isDev,
   } = opts;
+
+  const loadClientModule = <T>(key: keyof typeof CLIENT_MODULE_MAP) =>
+    (isDev
+      ? opts.loadServerModuleMain(CLIENT_MODULE_MAP[key])
+      : opts.loadModule(CLIENT_PREFIX + key)) as Promise<T>;
+
+  const [
+    {
+      default: { renderToReadableStream },
+    },
+  ] = await Promise.all([
+    loadClientModule<{ default: typeof RDServerType }>('rd-server'),
+  ]);
 
   const ssrConfig = await getSsrConfigForHtml?.(pathname, searchParams);
   if (!ssrConfig) {

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -1,7 +1,7 @@
+import { createElement } from 'react';
 import type { ReactNode, FunctionComponent, ComponentProps } from 'react';
 import type * as RDServerType from 'react-dom/server.edge';
-import { createElement } from 'react';
-import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
+import type { default as RSDWClientType } from 'react-server-dom-webpack/client.edge';
 import { injectRSCPayload } from 'rsc-html-stream/server';
 
 import type * as WakuClientType from '../../client.js';
@@ -214,9 +214,13 @@ export const renderHtml = async (
     {
       default: { renderToReadableStream },
     },
+    {
+      default: { createFromReadableStream },
+    },
     { ServerRoot },
   ] = await Promise.all([
     loadClientModule<{ default: typeof RDServerType }>('rd-server'),
+    loadClientModule<{ default: typeof RSDWClientType }>('rsdw-client'),
     loadClientModule<typeof WakuClientType>('waku-client'),
   ]);
 

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -1,14 +1,10 @@
-import type {
-  default as ReactType,
-  ReactNode,
-  FunctionComponent,
-  ComponentProps,
-} from 'react';
-import type * as RDServerType from 'react-dom/server.edge';
-import type { default as RSDWClientType } from 'react-server-dom-webpack/client.edge';
+import type { ReactNode, FunctionComponent, ComponentProps } from 'react';
+import { createElement } from 'react';
+import { renderToReadableStream } from 'react-dom/server.edge';
+import { createFromReadableStream } from 'react-server-dom-webpack/client.edge';
 import { injectRSCPayload } from 'rsc-html-stream/server';
 
-import type * as WakuClientType from '../../client.js';
+import { ServerRoot } from '../../client.js';
 import type { EntriesPrd } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { concatUint8Arrays } from '../utils/stream.js';
@@ -209,28 +205,6 @@ export const renderHtml = async (
     isDev,
   } = opts;
 
-  const loadClientModule = <T>(key: keyof typeof CLIENT_MODULE_MAP) =>
-    (isDev
-      ? opts.loadServerModuleMain(CLIENT_MODULE_MAP[key])
-      : opts.loadModule(CLIENT_PREFIX + key)) as Promise<T>;
-
-  const [
-    {
-      default: { createElement },
-    },
-    {
-      default: { renderToReadableStream },
-    },
-    {
-      default: { createFromReadableStream },
-    },
-    { ServerRoot },
-  ] = await Promise.all([
-    loadClientModule<{ default: typeof ReactType }>('react'),
-    loadClientModule<{ default: typeof RDServerType }>('rd-server'),
-    loadClientModule<{ default: typeof RSDWClientType }>('rsdw-client'),
-    loadClientModule<typeof WakuClientType>('waku-client'),
-  ]);
   const ssrConfig = await getSsrConfigForHtml?.(pathname, searchParams);
   if (!ssrConfig) {
     return null;


### PR DESCRIPTION
In my testing I discovered that `react` and `react-dom-server-webpack/client.edge` could be imported using regular imports. No need to have a local build of those and import that build.