### PR TITLE
fix: split any filepath by `?`

### DIFF
--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -260,21 +260,21 @@ export const renderHtml = async (
           {},
           {
             get(_target, name: string) {
-              let file = filePath.slice(config.basePath.length);
-              // TODO too long, we need to refactor this logic
               if (isDev) {
+                // TODO too long, we need to refactor this logic
+                let file = filePath.slice(config.basePath.length);
                 file = file.split('?')[0]!;
-                const filePath = file.startsWith('@fs/')
+                file = file.startsWith('@fs/')
                   ? file.slice('@fs'.length)
                   : encodeFilePathToAbsolute(joinPath(opts.rootDir, file));
                 const wakuDist = joinPath(
                   fileURLToFilePath(import.meta.url),
                   '../../..',
                 );
-                if (filePath.startsWith(wakuDist)) {
+                if (file.startsWith(wakuDist)) {
                   const id =
                     'waku' +
-                    filePath.slice(wakuDist.length).replace(/\.\w+$/, '');
+                    file.slice(wakuDist.length).replace(/\.\w+$/, '');
                   if (!moduleLoading.has(id)) {
                     moduleLoading.set(
                       id,
@@ -285,7 +285,7 @@ export const renderHtml = async (
                   }
                   return { id, chunks: [id], name };
                 }
-                const id = filePathToFileURL(filePath);
+                const id = filePathToFileURL(file);
                 if (!moduleLoading.has(id)) {
                   moduleLoading.set(
                     id,
@@ -297,7 +297,7 @@ export const renderHtml = async (
                 return { id, chunks: [id], name };
               }
               // !isDev
-              const id = file;
+              const id = filePath.slice(config.basePath.length);
               if (!moduleLoading.has(id)) {
                 moduleLoading.set(
                   id,

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -260,11 +260,10 @@ export const renderHtml = async (
           {},
           {
             get(_target, name: string) {
-              const file = filePath
-                .slice(config.basePath.length)
-                .split('?')[0]!;
+              let file = filePath.slice(config.basePath.length);
               // TODO too long, we need to refactor this logic
               if (isDev) {
+                file = file.split('?')[0]!;
                 const filePath = file.startsWith('@fs/')
                   ? file.slice('@fs'.length)
                   : encodeFilePathToAbsolute(joinPath(opts.rootDir, file));

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -260,13 +260,13 @@ export const renderHtml = async (
           {},
           {
             get(_target, name: string) {
-              const file = filePath.slice(config.basePath.length);
+              const file = filePath.slice(config.basePath.length).split('?')[0]!;
               // TODO too long, we need to refactor this logic
               if (isDev) {
                 const filePath = file.startsWith('@fs/')
                   ? file.slice('@fs'.length)
                   : encodeFilePathToAbsolute(
-                      joinPath(opts.rootDir, file.split('?')[0]!),
+                      joinPath(opts.rootDir, file),
                     );
                 const wakuDist = joinPath(
                   fileURLToFilePath(import.meta.url),

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -260,14 +260,14 @@ export const renderHtml = async (
           {},
           {
             get(_target, name: string) {
-              const file = filePath.slice(config.basePath.length).split('?')[0]!;
+              const file = filePath
+                .slice(config.basePath.length)
+                .split('?')[0]!;
               // TODO too long, we need to refactor this logic
               if (isDev) {
                 const filePath = file.startsWith('@fs/')
                   ? file.slice('@fs'.length)
-                  : encodeFilePathToAbsolute(
-                      joinPath(opts.rootDir, file),
-                    );
+                  : encodeFilePathToAbsolute(joinPath(opts.rootDir, file));
                 const wakuDist = joinPath(
                   fileURLToFilePath(import.meta.url),
                   '../../..',

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -273,8 +273,7 @@ export const renderHtml = async (
                 );
                 if (file.startsWith(wakuDist)) {
                   const id =
-                    'waku' +
-                    file.slice(wakuDist.length).replace(/\.\w+$/, '');
+                    'waku' + file.slice(wakuDist.length).replace(/\.\w+$/, '');
                   if (!moduleLoading.has(id)) {
                     moduleLoading.set(
                       id,


### PR DESCRIPTION
Resolves #611 

Apparently, the `./router/client.js?v=a3348fd2` query occurs in monorepos for non `/@fs/` paths.