### PR TITLE
fix: resolve use client/server boundary problem

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-delegate.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-delegate.ts
@@ -12,15 +12,26 @@ const isClientEntry = (id: string, code: string) => {
       syntax: 'typescript',
       tsx: ext.endsWith('x'),
     });
+    let isDirective = true;
+    
     for (const item of mod.body) {
       if (
         item.type === 'ExpressionStatement' &&
         item.expression.type === 'StringLiteral' &&
         item.expression.value === 'use client'
       ) {
+        if (!isDirective) {
+          const e = {
+            messageText:
+              'The `"use client"` directive must be put at the top of the file.',
+          }
+          throw e;
+        }
         return true;
+      } else {
+        isDirective = false;
       }
-    }
+    } 
   }
   return false;
 };


### PR DESCRIPTION
Resolve the current issue with the ‘use client/server’ directive that involves ambiguity in the boundary of instruction resolution during compilation.