### PR TITLE
fix(waku/router): regex in file replacement to correctly handle all matches (fs-router)

### DIFF
--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -41,7 +41,7 @@ export function fsRouter(
             return [];
           }
           // HACK: replace "_slug_" to "[slug]" for build
-          file = file.replace(/(^|\/|\\)_([^/]+)_(\/|\\|\.)/g, '$1[$2]$3');
+          file = file.replace(/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g, '[$1]');
           // For Windows
           file = sep === '/' ? file : file.replace(/\\/g, '/');
           // HACK: resolve different extensions for build


### PR DESCRIPTION
The current `fs-router` regex, `/(^|\/|\\)_([^/]+)_(\/|\\|\.)/g`, which is ran during build only replaces the first occurrence of underscores in scenarios where multiple underscore-surrounded segments are separated by single slashes. For example, in the string "app/\_propertyId\_/\_surveyPartKey\_.js", only \_propertyId\_ was being replaced, but \_surveyPartKey\_ was left unchanged due to the / being consumed during the first match.

This can easily be checked by running the following code:
```
const file = "app/_propertyId_/_surveyPartKey_.js";
console.log(file.replace(/(^|\/|\\)_([^/]+)_(\/|\\|\.)/g, '$1[$2]$3'));
// app/[propertyId]/_surveyPartKey_.js
```

## Solution
The regex has been updated to `/(?<=^|\/|\\)_([^/]+)_(?=\/|\\|\.)/g`. This uses positive lookbehind (`?<=^|\/|\\`) and lookahead (`?=\/|\\|\.`) assertions to check for preceding and succeeding characters without consuming them. This allows every instance of the pattern to be replaced, regardless of their position in the string.