### PR TITLE
fix: build with customised entriesJs

### DIFF
--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -49,7 +49,8 @@ export interface Config {
    */
   mainJs?: string;
   /**
-   * The entries.js file relative to srcDir or distDir.
+   * The entries.js file relative to srcDir.
+   * Will be generated as `entries.js` to distDir.
    * The extension should be `.js`,
    * but resolved with other extensions in the development mode.
    * Defaults to "entries.js".

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -642,7 +642,7 @@ export async function build(options: {
     joinPath(rootDir, config.srcDir, config.entriesJs),
   );
   const distEntriesFile = resolveFileName(
-    joinPath(rootDir, config.distDir, config.entriesJs),
+    joinPath(rootDir, config.distDir, 'entries.js'),
   );
   const mainJsFile = resolveFileName(
     joinPath(rootDir, config.srcDir, config.mainJs),


### PR DESCRIPTION
We always generate it as `entries.js` in dist folder, which makes sense if we have something like `entriesJs: /foo/bar/baz.start.ts`