### PR TITLE
fix: default nodejs runtime to 20

### DIFF
--- a/packages/waku/src/lib/builder/output-vercel.ts
+++ b/packages/waku/src/lib/builder/output-vercel.ts
@@ -36,7 +36,7 @@ export const emitVercelOutput = async (
       );
     }
     const vcConfigJson = {
-      runtime: 'nodejs18.x',
+      runtime: 'nodejs20.x',
       handler: `${config.distDir}/${config.serveJs}`,
       launcherType: 'Nodejs',
     };


### PR DESCRIPTION
Vercel changed their default nodejs version to 20, waku will throw error when deploy to vercel if it's 18