### PR TITLE
fix: build target for vercel will throw error

### DIFF
--- a/e2e/multi-platform.spec.ts
+++ b/e2e/multi-platform.spec.ts
@@ -4,7 +4,18 @@ import { test } from './utils.js';
 import { rm } from 'node:fs/promises';
 import { expect } from '@playwright/test';
 
-const cwd = fileURLToPath(new URL('../examples/01_template', import.meta.url));
+const dryRunList = [
+  // without entries.tsx
+  {
+    cwd: fileURLToPath(new URL('../examples/01_template', import.meta.url)),
+    project: '01_template',
+  },
+  // with entries.tsx
+  {
+    cwd: fileURLToPath(new URL('../examples/20_minimal', import.meta.url)),
+    project: '20_minimal',
+  },
+];
 
 const waku = fileURLToPath(
   new URL('../packages/waku/dist/cli.js', import.meta.url),
@@ -17,15 +28,15 @@ const buildPlatformTarget = [
   },
   {
     platform: '--with-vercel-static',
-    clearDirOrFile: ['dist', '.vercel'],
+    clearDirOrFile: ['dist'],
   },
   {
     platform: '--with-netlify',
-    clearDirOrFile: ['dist', 'netlify'],
+    clearDirOrFile: ['dist', 'netlify', 'netlify.toml'],
   },
   {
     platform: '--with-netlify-static',
-    clearDirOrFile: ['dist', 'netlify', 'netlify.toml'],
+    clearDirOrFile: ['dist'],
   },
   {
     platform: '--with-cloudflare',
@@ -45,22 +56,40 @@ const buildPlatformTarget = [
   },
 ];
 
+const cleanListAfterBuild = new Set(
+  buildPlatformTarget.reduce(
+    (prev: string[], { clearDirOrFile }) => [...prev, ...clearDirOrFile],
+    [],
+  ),
+);
+
 test.describe(`multi platform builds`, () => {
-  for (const { platform, clearDirOrFile } of buildPlatformTarget) {
-    test(`build with ${platform} should not throw error`, async () => {
-      for (const name of clearDirOrFile) {
+  for (const { cwd, project } of dryRunList) {
+    for (const { platform, clearDirOrFile } of buildPlatformTarget) {
+      test(`build ${project} with ${platform} should not throw error`, async () => {
+        for (const name of clearDirOrFile) {
+          await rm(`${cwd}/${name}`, {
+            recursive: true,
+            force: true,
+          });
+        }
+        try {
+          execSync(`node ${waku} build ${platform}`, {
+            cwd,
+            env: process.env,
+          });
+        } catch (error) {
+          expect(error).toBeNull();
+        }
+      });
+    }
+
+    test.afterAll(async () => {
+      for (const name of cleanListAfterBuild) {
         await rm(`${cwd}/${name}`, {
           recursive: true,
           force: true,
         });
-      }
-      try {
-        execSync(`node ${waku} build ${platform}`, {
-          cwd,
-          env: process.env,
-        });
-      } catch (error) {
-        expect(error).toBeNull();
       }
     });
   }

--- a/e2e/multi-platform.spec.ts
+++ b/e2e/multi-platform.spec.ts
@@ -1,0 +1,67 @@
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { test } from './utils.js';
+import { rm } from 'node:fs/promises';
+import { expect } from '@playwright/test';
+
+const cwd = fileURLToPath(new URL('../examples/01_template', import.meta.url));
+
+const waku = fileURLToPath(
+  new URL('../packages/waku/dist/cli.js', import.meta.url),
+);
+
+const buildPlatformTarget = [
+  {
+    platform: '--with-vercel',
+    clearDirOrFile: ['dist', '.vercel'],
+  },
+  {
+    platform: '--with-vercel-static',
+    clearDirOrFile: ['dist', '.vercel'],
+  },
+  {
+    platform: '--with-netlify',
+    clearDirOrFile: ['dist', 'netlify'],
+  },
+  {
+    platform: '--with-netlify-static',
+    clearDirOrFile: ['dist', 'netlify', 'netlify.toml'],
+  },
+  {
+    platform: '--with-cloudflare',
+    clearDirOrFile: ['dist', 'wrangler.toml'],
+  },
+  {
+    platform: '--with-partykit',
+    clearDirOrFile: ['dist', 'partykit.json'],
+  },
+  {
+    platform: '--with-deno',
+    clearDirOrFile: ['dist'],
+  },
+  {
+    platform: '--with-aws-lambda',
+    clearDirOrFile: ['dist'],
+  },
+];
+
+test.describe(`multi platform builds`, () => {
+  for (const { platform, clearDirOrFile } of buildPlatformTarget) {
+    test(`build with ${platform} should not throw error`, async () => {
+      for (const name of clearDirOrFile) {
+        await rm(`${cwd}/${name}`, {
+          recursive: true,
+          force: true,
+        });
+      }
+      try {
+        execSync(`node ${waku} build ${platform}`, {
+          cwd,
+          env: process.env,
+        });
+      } catch (error) {
+        expect(error).toBeNull();
+      }
+    });
+  }
+});

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -38,7 +38,7 @@ export function rscServePlugin(opts: {
     config(viteConfig) {
       // FIXME This seems too hacky (The use of viteConfig.root, '.', path.resolve and resolveFileName)
       const entriesFile = resolveFileName(
-        path.resolve(viteConfig.root || '.', opts.srcDir, SRC_ENTRIES + '.js'),
+        path.resolve(viteConfig.root || '.', opts.srcDir, SRC_ENTRIES + '.jsx'),
       );
       const { input } = viteConfig.build?.rollupOptions ?? {};
       if (input && !(typeof input === 'string') && !(input instanceof Array)) {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { normalizePath } from 'vite';
 import type { Plugin } from 'vite';
 
 // HACK: Depending on a different plugin isn't ideal.
@@ -38,7 +39,13 @@ export function rscServePlugin(opts: {
     config(viteConfig) {
       // FIXME This seems too hacky (The use of viteConfig.root, '.', path.resolve and resolveFileName)
       const entriesFile = resolveFileName(
-        path.resolve(viteConfig.root || '.', opts.srcDir, SRC_ENTRIES + '.jsx'),
+        normalizePath(
+          path.resolve(
+            viteConfig.root || '.',
+            opts.srcDir,
+            SRC_ENTRIES + '.jsx',
+          ),
+        ),
       );
       const { input } = viteConfig.build?.rollupOptions ?? {};
       if (input && !(typeof input === 'string') && !(input instanceof Array)) {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -38,8 +38,8 @@ export function rscServePlugin(opts: {
     name: 'rsc-serve-plugin',
     config(viteConfig) {
       // FIXME This seems too hacky (The use of viteConfig.root, '.', path.resolve and resolveFileName)
-      const entriesFile = resolveFileName(
-        normalizePath(
+      const entriesFile = normalizePath(
+        resolveFileName(
           path.resolve(
             viteConfig.root || '.',
             opts.srcDir,


### PR DESCRIPTION
Solve https://github.com/dai-shi/waku/issues/700

The bug was introduced in https://github.com/dai-shi/waku/pull/682, the reason is that the logic of https://github.com/dai-shi/waku/pull/682/files#diff-6de2cc9d9f6423e3f4faa0cb1a6200112f1bc057af0db1a9362fe6117c51d18aR79-R82 was adjusted.

I think the logic now assmues the entry file is endsWith .jsx while while the dynamic import in serve-vercel.js is endsWith .js

![CleanShot 2024-05-05 at 17 02 38@2x](https://github.com/dai-shi/waku/assets/24316656/5c5d0b14-70f9-4565-84e6-9328b08ac946)

![CleanShot 2024-05-05 at 17 03 30@2x](https://github.com/dai-shi/waku/assets/24316656/27a7240b-6e1c-4420-9ba8-8b187d72282c)

I am not so sure it is a correct way to remove .js extension, but I added the dry run testing, maybe it can help.
