### PR TITLE
fix (create-waku): example GitHub urls can contain `www` too

### DIFF
--- a/packages/create-waku/src/helpers/example-option.ts
+++ b/packages/create-waku/src/helpers/example-option.ts
@@ -140,7 +140,10 @@ export async function parseExampleOption(
   }
 
   // NOTE check github origin
-  if (repoUrl.origin !== 'https://github.com' && repoUrl.origin !== 'https://www.github.com') {
+  if (
+    repoUrl.origin !== 'https://github.com' &&
+    repoUrl.origin !== 'https://www.github.com'
+  ) {
     console.error(
       `Invalid URL: ${red(
         `"${example}"`,

--- a/packages/create-waku/src/helpers/example-option.ts
+++ b/packages/create-waku/src/helpers/example-option.ts
@@ -140,7 +140,7 @@ export async function parseExampleOption(
   }
 
   // NOTE check github origin
-  if (repoUrl.origin !== 'https://github.com') {
+  if (repoUrl.origin !== 'https://github.com' && repoUrl.origin !== 'https://www.github.com') {
     console.error(
       `Invalid URL: ${red(
         `"${example}"`,


### PR DESCRIPTION
**Current Behaviour:**

```bash
pnpm start --example https://www.github.com/dai-shi/waku/tree/main/examples/02_template_js                                                                                                                 

> create-waku@0.9.2-alpha.0 start /Users/joelmathew/WebProjects/waku-dev/waku/packages/create-waku
> node ./dist/index.js "--example" "https://www.github.com/dai-shi/waku/tree/main/examples/02_template_js"

Invalid URL: "https://www.github.com/dai-shi/waku/tree/main/examples/02_template_js". Only GitHub repositories are supported. Please use a GitHub URL and try again.
```

The url is a valid GitHub url which should be accepted by the `create-waku` utility. This pr should fix this behaviour.