### PR TITLE
fix: patch-react-refresh

### DIFF
--- a/packages/waku/src/lib/middleware/dev-server.ts
+++ b/packages/waku/src/lib/middleware/dev-server.ts
@@ -10,6 +10,7 @@ import {
   renderRscWithWorker,
   getSsrConfigWithWorker,
 } from '../renderers/dev-worker-api.js';
+import { patchReactRefresh } from '../plugins/patch-react-refresh.js';
 import { nonjsResolvePlugin } from '../plugins/vite-plugin-nonjs-resolve.js';
 import { rscTransformPlugin } from '../plugins/vite-plugin-rsc-transform.js';
 import { rscIndexPlugin } from '../plugins/vite-plugin-rsc-index.js';
@@ -79,7 +80,7 @@ export const devServer: Middleware = (options) => {
       cacheDir: 'node_modules/.vite/waku-dev-server',
       base: config.basePath,
       plugins: [
-        viteReact(),
+        patchReactRefresh(viteReact()),
         nonjsResolvePlugin(),
         rscEnvPlugin({ config }),
         rscPrivatePlugin(config),

--- a/packages/waku/src/lib/plugins/patch-react-refresh.ts
+++ b/packages/waku/src/lib/plugins/patch-react-refresh.ts
@@ -1,0 +1,26 @@
+import type { Plugin, PluginOption } from 'vite';
+
+export const patchReactRefresh = <T extends PluginOption[]>(options: T): T =>
+  options.map((option) => {
+    const plugin = option as Plugin;
+    const origTransformIndexHtml = plugin?.transformIndexHtml;
+    if (
+      plugin?.name === 'vite:react-refresh' &&
+      typeof origTransformIndexHtml === 'function'
+    ) {
+      return {
+        ...option,
+        transformIndexHtml(...args) {
+          const result = origTransformIndexHtml(...args);
+          if (Array.isArray(result)) {
+            return result.map((item) => ({
+              ...item,
+              attrs: { ...item.attrs, async: true },
+            }));
+          }
+          return result;
+        },
+      };
+    }
+    return option;
+  }) as T;


### PR DESCRIPTION
I removed it in #713, because all tests pass without it, but it actually broke example 20,21,22.
I'm not sure why smoke tests didn't catch it.