### PR TITLE
fix: do not crash whole server when error

### DIFF
--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -3,6 +3,7 @@ import { decodeInput, hasStatusCode } from '../renderers/utils.js';
 import { renderRsc } from '../renderers/rsc-renderer.js';
 import type { RenderRscArgs } from '../renderers/rsc-renderer.js';
 import type { Middleware } from './types.js';
+import { stringToStream } from '../utils/stream.js';
 
 export const rsc: Middleware = (options) => {
   (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
@@ -49,6 +50,7 @@ export const rsc: Middleware = (options) => {
         ctx.res.body = readable;
         return;
       } catch (err) {
+        ctx.res.body = stringToStream(`${err}`);
         if (hasStatusCode(err)) {
           ctx.res.status = err.statusCode;
         } else {

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -4,6 +4,7 @@ import { renderHtml } from '../renderers/html-renderer.js';
 import { hasStatusCode, encodeInput } from '../renderers/utils.js';
 import { getSsrConfig } from '../renderers/rsc-renderer.js';
 import type { Middleware } from './types.js';
+import { stringToStream } from '../utils/stream.js';
 
 export const ssr: Middleware = (options) => {
   (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
@@ -94,6 +95,7 @@ export const ssr: Middleware = (options) => {
         }
       }
     } catch (err) {
+      ctx.res.body = stringToStream(`${err}`);
       if (hasStatusCode(err)) {
         ctx.res.status = err.statusCode;
       } else {

--- a/packages/waku/src/lib/renderers/dev-worker-impl.ts
+++ b/packages/waku/src/lib/renderers/dev-worker-impl.ts
@@ -67,6 +67,14 @@ const resolveClientEntryForDev = (
   return config.basePath + file;
 };
 
+const handleErr = (id: number, err: unknown) => {
+  const mesg: MessageRes = { id, type: 'err', err: `${err}` };
+  if (hasStatusCode(err)) {
+    mesg.statusCode = err.statusCode;
+  }
+  parentPort!.postMessage(mesg);
+};
+
 const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
   const vite = await vitePromise;
   const {
@@ -94,6 +102,9 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
         body: rest.body,
         contentType: rest.contentType,
         moduleIdCallback,
+        onError: (err) => {
+          handleErr(id, err);
+        },
       },
       {
         isDev: true,
@@ -119,11 +130,7 @@ const handleRender = async (mesg: MessageReq & { type: 'render' }) => {
     parentPort!.postMessage(mesg, [readable as unknown as TransferListItem]);
     deepFreeze(rest.context);
   } catch (err) {
-    const mesg: MessageRes = { id, type: 'err', err: `${err}` };
-    if (hasStatusCode(err)) {
-      mesg.statusCode = err.statusCode;
-    }
-    parentPort!.postMessage(mesg);
+    handleErr(id, err);
   }
 };
 
@@ -162,11 +169,7 @@ const handleGetSsrConfig = async (
       ssrConfig ? [ssrConfig.body as unknown as TransferListItem] : undefined,
     );
   } catch (err) {
-    const mesg: MessageRes = { id, type: 'err', err: `${err}` };
-    if (hasStatusCode(err)) {
-      mesg.statusCode = err.statusCode;
-    }
-    parentPort!.postMessage(mesg);
+    handleErr(id, err);
   }
 };
 

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -33,6 +33,7 @@ export type RenderRscArgs = {
   body?: ReadableStream | undefined;
   contentType?: string | undefined;
   moduleIdCallback?: ((id: string) => void) | undefined;
+  onError?: (err: unknown) => void;
 };
 
 type RenderRscOpts =
@@ -57,6 +58,7 @@ export async function renderRsc(
     context,
     body,
     moduleIdCallback,
+    onError,
   } = args;
   const { isDev, entries } = opts;
 
@@ -125,7 +127,9 @@ export async function renderRsc(
       if (Object.keys(elements).some((key) => key.startsWith('_'))) {
         throw new Error('"_" prefix is reserved');
       }
-      return renderToReadableStream(elements, bundlerConfig);
+      return renderToReadableStream(elements, bundlerConfig, {
+        onError,
+      });
     });
   };
 
@@ -164,6 +168,9 @@ export async function renderRsc(
       return renderToReadableStream(
         { ...elements, _value: actionValue },
         bundlerConfig,
+        {
+          onError,
+        },
       );
     });
   };

--- a/packages/waku/src/types.d.ts
+++ b/packages/waku/src/types.d.ts
@@ -1,3 +1,7 @@
+interface Reference {}
+
+type TemporaryReferenceSet = Map<string, Reference | symbol>;
+
 type ImportManifestEntry = {
   id: string;
   chunks: string[];
@@ -31,6 +35,15 @@ type ClientManifest = {
 declare module 'react-server-dom-webpack/node-loader';
 
 declare module 'react-server-dom-webpack/server.edge' {
+  type Options = {
+    environmentName?: string;
+    identifierPrefix?: string;
+    signal?: AbortSignal;
+    temporaryReferences?: TemporaryReferenceSet;
+    onError?: ((error: unknown) => void) | undefined;
+    onPostpone?: ((reason: string) => void) | undefined;
+  };
+
   export function renderToReadableStream(
     model: ReactClientValue,
     webpackMap: ClientManifest,
@@ -43,12 +56,23 @@ declare module 'react-server-dom-webpack/server.edge' {
 }
 
 declare module 'react-server-dom-webpack/client' {
+  type CallServerCallback = <T, A extends unknown[] = unknown[]>(
+    string,
+    args: A,
+  ) => Promise<T>;
+
+  type Options<T> = {
+    callServer?: CallServerCallback<T>;
+    temporaryReferences?: TemporaryReferenceSet;
+  };
+
   export function createFromFetch<T>(
     promiseForResponse: Promise<Response>,
-    options?: Options,
+    options?: Options<T>,
   ): Promise<T>;
   export function encodeReply(
     value: ReactServerValue,
+    options?: { temporaryReferences?: TemporaryReferenceSet },
   ): Promise<string | URLSearchParams | FormData>;
 }
 
@@ -59,7 +83,7 @@ declare module 'react-server-dom-webpack/client.edge' {
   };
   export function createFromReadableStream<T>(
     stream: ReadableStream,
-    options: Options,
+    options: Options<T>,
   ): Promise<T>;
 }
 


### PR DESCRIPTION
The main logic is `ctx.res.body = stringToStream(`${err}`);`

Cleanup response stream when it raises an error because it's locked by react (how to release it?) otherwise hono server will crash