### PR TITLE
refactor: naming convention for globals

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -82,14 +82,14 @@ const createStringLiteral = (value: string): swc.StringLiteral => ({
 });
 
 const serverActionsInitCode = swc.parseSync(`
-import { registerServerReference as __waku_registerServerReference__ } from 'react-server-dom-webpack/server';
-export const __waku_serverActions__ = new Map();
-let __waku_actionIndex__ = 0;
-function __waku_registerServerAction__(fn, actionId) {
-  const actionName = 'action' + __waku_actionIndex__++;
-  __waku_registerServerReference__(fn, actionId, actionName);
+import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server';
+export const __waku_serverActions = new Map();
+let __waku_actionIndex = 0;
+function __waku_registerServerAction(fn, actionId) {
+  const actionName = 'action' + __waku_actionIndex++;
+  __waku_registerServerReference(fn, actionId, actionName);
   // FIXME this can cause memory leaks
-  __waku_serverActions__.set(actionName, fn);
+  __waku_serverActions.set(actionName, fn);
   return fn;
 }
 `).body;
@@ -126,7 +126,7 @@ const transformServerActions = (
     hasServerActions = true;
     const exp: swc.CallExpression = {
       type: 'CallExpression',
-      callee: createIdentifier('__waku_registerServerAction__'),
+      callee: createIdentifier('__waku_registerServerAction'),
       arguments: [
         { expression: fn.type === 'FunctionDeclaration' ? fn.identifier : fn },
         { expression: createStringLiteral(getActionId()) },

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -195,7 +195,7 @@ export async function renderRsc(
       }
       mod = await loadModule(fileId.slice('@id/'.length));
     }
-    const fn = mod.__waku_serverActions__?.get(name) || mod[name] || mod;
+    const fn = mod.__waku_serverActions?.get(name) || mod[name] || mod;
     return renderWithContextWithAction(context, fn, args);
   }
 

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -45,9 +45,9 @@ export const hasStatusCode = (x: unknown): x is { statusCode: number } =>
   typeof (x as any)?.statusCode === 'number';
 
 export const codeToInject = `
-globalThis.__waku_module_cache__ = new Map();
-globalThis.__webpack_chunk_load__ = (id) => import(id).then((m) => globalThis.__waku_module_cache__.set(id, m));
-globalThis.__webpack_require__ = (id) => globalThis.__waku_module_cache__.get(id);`;
+globalThis.__WAKU_MODULE_CACHE__ = new Map();
+globalThis.__webpack_chunk_load__ = (id) => import(id).then((m) => globalThis.__WAKU_MODULE_CACHE__.set(id, m));
+globalThis.__webpack_require__ = (id) => globalThis.__WAKU_MODULE_CACHE__.get(id);`;
 
 export const generatePrefetchCode = (
   basePrefix: string,


### PR DESCRIPTION
We use the following naming convention to avoid collisions (best effort).

- For `globalThis`, use `__WAKU_SNAKE_CASE__`
- For others, use `__waku_camelCalse`