### PR TITLE
chore: eliminate workerd condition

### DIFF
--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -118,8 +118,8 @@ const analyzeEntries = async (rootDir: string, config: ResolvedConfig) => {
     ssr: {
       target: 'webworker',
       resolve: {
-        conditions: ['react-server', 'workerd'],
-        externalConditions: ['react-server', 'workerd'],
+        conditions: ['react-server'],
+        externalConditions: ['react-server'],
       },
       noExternal: /^(?!node:)/,
     },
@@ -251,16 +251,16 @@ const buildServerBundle = async (
     ssr: isNodeCompatible
       ? {
           resolve: {
-            conditions: ['react-server', 'workerd'],
-            externalConditions: ['react-server', 'workerd'],
+            conditions: ['react-server'],
+            externalConditions: ['react-server'],
           },
           noExternal: /^(?!node:)/,
         }
       : {
           target: 'webworker',
           resolve: {
-            conditions: ['react-server', 'workerd', 'worker'],
-            externalConditions: ['react-server', 'workerd', 'worker'],
+            conditions: ['react-server', 'worker'],
+            externalConditions: ['react-server', 'worker'],
           },
           noExternal: /^(?!node:)/,
         },

--- a/packages/waku/src/lib/middleware/dev-server.ts
+++ b/packages/waku/src/lib/middleware/dev-server.ts
@@ -208,8 +208,8 @@ const createRscViteServer = (
       },
       ssr: {
         resolve: {
-          conditions: ['react-server', 'workerd'],
-          externalConditions: ['react-server', 'workerd'],
+          conditions: ['react-server'],
+          externalConditions: ['react-server'],
         },
         noExternal: /^(?!node:)/,
         optimizeDeps: {


### PR DESCRIPTION
This `workerd` condition was originally required for the worker thread (not because of the worker thread, but of `server.edge`), and for consistency, the same config existed in build.ts.
Now, as we removed the worker thread in https://github.com/dai-shi/waku/pull/762, I'm confident of removing it too.

cc @himself65 
