### PR TITLE
fix: server action cases

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -91,9 +91,17 @@ const createCallExpression = (
   span: { start: 0, end: 0, ctxt: 0 },
 });
 
-const serverActionsInitCode = swc.parseSync(`
+const serverInitCode = swc.parseSync(`
 import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
 `).body;
+
+const findLastImportIndex = (mod: swc.Module) => {
+  const lastImportIndex = mod.body.findIndex(
+    (node) =>
+      node.type !== 'ExpressionStatement' && node.type !== 'ImportDeclaration',
+  );
+  return lastImportIndex === -1 ? 0 : lastImportIndex;
+};
 
 type FunctionWithBlockBody = (
   | swc.FunctionDeclaration
@@ -323,62 +331,59 @@ const transformServerActions = (
   if (!serverActionIndex) {
     return;
   }
-  const serverActionsCode = [...serverActionsInitCode];
-  for (const [actionIndex, [actionFn, closureVars]] of serverActions) {
-    if (actionFn.type === 'FunctionDeclaration') {
-      const stmt1: swc.ExportDeclaration = {
-        type: 'ExportDeclaration',
-        declaration: prependArgsToFn(actionFn, closureVars),
-        span: { start: 0, end: 0, ctxt: 0 },
-      };
-      const stmt2: swc.ExpressionStatement = {
-        type: 'ExpressionStatement',
-        expression: createCallExpression(
-          createIdentifier('__waku_registerServerReference'),
-          [
-            createIdentifier(actionFn.identifier.value),
-            createStringLiteral(getActionId()),
-            createStringLiteral('__waku_action' + actionIndex),
-          ],
-        ),
-        span: { start: 0, end: 0, ctxt: 0 },
-      };
-      serverActionsCode.push(stmt1, stmt2);
-    } else {
-      const stmt: swc.ExportDeclaration = {
-        type: 'ExportDeclaration',
-        declaration: {
-          type: 'VariableDeclaration',
-          kind: 'const',
-          declare: false,
-          declarations: [
-            {
-              type: 'VariableDeclarator',
-              id: createIdentifier('__waku_action' + actionIndex),
-              init: createCallExpression(
-                createIdentifier('__waku_registerServerReference'),
-                [
-                  prependArgsToFn(actionFn, closureVars),
-                  createStringLiteral(getActionId()),
-                  createStringLiteral('__waku_action' + actionIndex),
-                ],
-              ),
-              definite: false,
-              span: { start: 0, end: 0, ctxt: 0 },
-            },
-          ],
+  const serverActionsCode = Array.from(serverActions).flatMap(
+    ([actionIndex, [actionFn, closureVars]]) => {
+      if (actionFn.type === 'FunctionDeclaration') {
+        const stmt1: swc.ExportDeclaration = {
+          type: 'ExportDeclaration',
+          declaration: prependArgsToFn(actionFn, closureVars),
           span: { start: 0, end: 0, ctxt: 0 },
-        },
-        span: { start: 0, end: 0, ctxt: 0 },
-      };
-      serverActionsCode.push(stmt);
-    }
-  }
-  const lastImportIndex = mod.body.findIndex(
-    (node) =>
-      node.type !== 'ExpressionStatement' && node.type !== 'ImportDeclaration',
+        };
+        const stmt2: swc.ExpressionStatement = {
+          type: 'ExpressionStatement',
+          expression: createCallExpression(
+            createIdentifier('__waku_registerServerReference'),
+            [
+              createIdentifier(actionFn.identifier.value),
+              createStringLiteral(getActionId()),
+              createStringLiteral('__waku_action' + actionIndex),
+            ],
+          ),
+          span: { start: 0, end: 0, ctxt: 0 },
+        };
+        return [stmt1, stmt2];
+      } else {
+        const stmt: swc.ExportDeclaration = {
+          type: 'ExportDeclaration',
+          declaration: {
+            type: 'VariableDeclaration',
+            kind: 'const',
+            declare: false,
+            declarations: [
+              {
+                type: 'VariableDeclarator',
+                id: createIdentifier('__waku_action' + actionIndex),
+                init: createCallExpression(
+                  createIdentifier('__waku_registerServerReference'),
+                  [
+                    prependArgsToFn(actionFn, closureVars),
+                    createStringLiteral(getActionId()),
+                    createStringLiteral('__waku_action' + actionIndex),
+                  ],
+                ),
+                definite: false,
+                span: { start: 0, end: 0, ctxt: 0 },
+              },
+            ],
+            span: { start: 0, end: 0, ctxt: 0 },
+          },
+          span: { start: 0, end: 0, ctxt: 0 },
+        };
+        return [stmt];
+      }
+    },
   );
-  mod.body.splice(lastImportIndex, 0, ...serverActionsCode);
+  mod.body.splice(findLastImportIndex(mod), 0, ...serverActionsCode);
   return mod;
 };
 
@@ -391,14 +396,18 @@ const transformServer = (
   const ext = extname(id);
   const mod = swc.parseSync(code, parseOpts(ext));
   let hasUseClient = false;
-  let hasUseServer: swc.ExpressionStatement | true | undefined;
-  for (const item of mod.body) {
+  let hasUseServer = false;
+  for (let i = 0; i < mod.body.length; ++i) {
+    const item = mod.body[i]!;
     if (item.type === 'ExpressionStatement') {
       if (item.expression.type === 'StringLiteral') {
         if (item.expression.value === 'use client') {
           hasUseClient = true;
+          break;
         } else if (item.expression.value === 'use server') {
-          hasUseServer = item;
+          hasUseServer = true;
+          mod.body.splice(i, 1); // remove this directive
+          break;
         }
       }
     } else {
@@ -417,96 +426,58 @@ export ${name === 'default' ? name : `const ${name} =`} registerClientReference(
 `;
     }
     return newCode;
-  } else {
-    const walkFindServerAction = (
-      parentFn: swc.Fn | swc.ArrowFunctionExpression | undefined,
-      node: swc.Node,
-    ) => {
-      // FIXME do we need to walk the entire tree? feels inefficient
-      Object.values(node).forEach((value) => {
-        const fn =
-          node.type === 'FunctionDeclaration' ||
-          node.type === 'FunctionExpression' ||
-          node.type === 'ArrowFunctionExpression'
-            ? (node as swc.Fn | swc.ArrowFunctionExpression)
-            : parentFn;
-        (Array.isArray(value) ? value : [value]).forEach((v) => {
-          if (typeof v?.type === 'string') {
-            walkFindServerAction(fn, v);
-          } else if (typeof v?.expression?.type === 'string') {
-            walkFindServerAction(fn, v.expression);
-          }
-        });
-      });
-      if (
-        node.type === 'FunctionExpression' ||
-        node.type === 'ArrowFunctionExpression' ||
-        node.type === 'FunctionDeclaration'
-      ) {
-        const fnNode = node as
-          | swc.FunctionExpression
-          | swc.ArrowFunctionExpression
-          | swc.FunctionDeclaration;
-        if (
-          fnNode.body &&
-          'stmts' in fnNode.body &&
-          fnNode.body.stmts.find(
-            (stmt) =>
-              stmt.type === 'ExpressionStatement' &&
-              stmt.expression.type === 'StringLiteral' &&
-              stmt.expression.value === 'use server',
-          )
-        ) {
-          hasUseServer = true;
-        }
-      }
-    };
-
-    walkFindServerAction(undefined, mod);
-    if (hasUseServer) {
-      const exportNames = collectExportNames(mod);
-      // transform server actions in server components
-      const newMod = transformServerActions(mod, () => getServerId(id));
-      if (newMod) {
-        code = swc.printSync(newMod).code;
-      }
-      let useServerPosStart: number;
-      let useServerPosEnd: number;
-      if (hasUseServer === true) {
-        useServerPosStart = 0;
-        useServerPosEnd = 0;
-      } else {
-        useServerPosStart = hasUseServer.span.start - mod.span.start;
-        useServerPosEnd = hasUseServer.span.end - mod.span.start;
-      }
-      const lastImportIndex = mod.body.findIndex(
-        (node) =>
-          node.type !== 'ExpressionStatement' &&
-          node.type !== 'ImportDeclaration',
-      );
-      let lastImportPos =
-        lastImportIndex === -1 ? 0 : mod.body[lastImportIndex]!.span.end;
-      if (lastImportIndex < useServerPosEnd) {
-        lastImportPos = useServerPosEnd;
-      }
-      return [
-        newMod === undefined
-          ? `import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';`
-          : '',
-        code.slice(0, useServerPosStart),
-        code.slice(useServerPosEnd, lastImportPos),
-        code.slice(lastImportPos),
-        ...[...exportNames].map((name) =>
-          name === 'default'
-            ? ``
-            : `
-if (typeof ${name} === 'function') {
-  __waku_registerServerReference(${name}, '${getServerId(id)}', '${name}');
-}
-`,
-        ),
-      ].join('');
-    }
+  }
+  if (hasUseServer) {
+    const exportNames = collectExportNames(mod);
+    const serverActionsCode = Array.from(exportNames).map((name) => {
+      const blockStmt: swc.BlockStatement = {
+        type: 'BlockStatement',
+        stmts: [
+          {
+            type: 'ExpressionStatement',
+            expression: createCallExpression(
+              createIdentifier('__waku_registerServerReference'),
+              [
+                createIdentifier(name),
+                createStringLiteral(getServerId(id)),
+                createStringLiteral(name),
+              ],
+            ),
+            span: { start: 0, end: 0, ctxt: 0 },
+          },
+        ],
+        span: { start: 0, end: 0, ctxt: 0 },
+      };
+      const ifStmt: swc.IfStatement = {
+        type: 'IfStatement',
+        test: {
+          type: 'BinaryExpression',
+          operator: '===',
+          left: {
+            type: 'UnaryExpression',
+            operator: 'typeof',
+            argument: createIdentifier(name),
+            span: { start: 0, end: 0, ctxt: 0 },
+          },
+          right: createStringLiteral('function'),
+          span: { start: 0, end: 0, ctxt: 0 },
+        },
+        consequent: blockStmt,
+        span: { start: 0, end: 0, ctxt: 0 },
+      };
+      return ifStmt;
+    });
+    mod.body.push(...serverActionsCode);
+  }
+  // transform server actions in server components
+  const newMod =
+    (code.includes('use server') &&
+      transformServerActions(mod, () => getServerId(id))) ||
+    (hasUseServer && mod);
+  if (newMod) {
+    newMod.body.splice(findLastImportIndex(newMod), 0, ...serverInitCode);
+    const newCode = swc.printSync(newMod).code;
+    return newCode;
   }
 };
 

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -53,14 +53,12 @@ export const log = (mesg) => {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';;
-
-        export const log = (mesg) => {
-          console.log(mesg);
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export const log = (mesg)=>{
+            console.log(mesg);
         };
-
-        if (typeof log === 'function') {
-          __waku_registerServerReference(log, '/src/App.tsx', 'log');
+        if (typeof log === "function") {
+            __waku_registerServerReference(log, "/src/App.tsx", "log");
         }
         "
       `);
@@ -102,10 +100,6 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         }) {
             return <AI>{children}</AI>;
         }
-
-        if (typeof ServerProvider === 'function') {
-          __waku_registerServerReference(ServerProvider, '/src/App.tsx', 'ServerProvider');
-        }
         "
       `);
   });
@@ -139,8 +133,7 @@ export function createAI({ actions }) {
 }`;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "
-        import { InternalProvider } from './shared.js';
+        "import { InternalProvider } from './shared.js';
         import { jsx } from 'react/jsx-runtime';
         import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
         export async function __waku_action1({ action }, ...args) {
@@ -165,9 +158,8 @@ export function createAI({ actions }) {
                 });
             };
         }
-
-        if (typeof createAI === 'function') {
-          __waku_registerServerReference(createAI, '/src/App.tsx', 'createAI');
+        if (typeof createAI === "function") {
+            __waku_registerServerReference(createAI, "/src/App.tsx", "createAI");
         }
         "
       `);

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -53,9 +53,7 @@ export const log = (mesg) => {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "
-        import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        ;
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';;
 
         export const log = (mesg) => {
           console.log(mesg);
@@ -68,10 +66,117 @@ export const log = (mesg) => {
       `);
   });
 
+  test('server action in object', async () => {
+    const code = `
+import type { ReactNode } from 'react';
+import { createAI } from 'ai/rsc';
+
+const AI = createAI({
+  actions: {
+    foo: async () => {
+      'use server';
+      return 0;
+    },
+  },
+});
+
+export function ServerProvider({ children }: { children: ReactNode }) {
+  return <AI>{children}</AI>;
+}
+`;
+    expect(await transform(code, '/src/App.tsx', { ssr: true }))
+      .toMatchInlineSnapshot(`
+        "import type { ReactNode } from 'react';
+        import { createAI } from 'ai/rsc';
+        import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export const __waku_action1 = __waku_registerServerReference(async ()=>{
+            return 0;
+        }, "/src/App.tsx", "__waku_action1");
+        const AI = createAI({
+            actions: {
+                foo: __waku_action1.bind(null)
+            }
+        });
+        export function ServerProvider({ children }: {
+            children: ReactNode;
+        }) {
+            return <AI>{children}</AI>;
+        }
+
+        if (typeof ServerProvider === 'function') {
+          __waku_registerServerReference(ServerProvider, '/src/App.tsx', 'ServerProvider');
+        }
+        "
+      `);
+  });
+
+  test('create server with bind', async () => {
+    const code = `
+'use server';
+import { InternalProvider } from './shared.js';
+import { jsx } from 'react/jsx-runtime';
+
+async function innerAction({ action }, ...args) {
+  'use server';
+  return await action(...args);
+}
+
+function wrapAction(action) {
+  return innerAction.bind(null, { action });
+}
+
+export function createAI({ actions }) {
+  const wrappedActions = {};
+  for (const name in actions) {
+    wrappedActions[name] = wrapAction(actions[name]);
+  }
+  return function AI(props) {
+    return jsx(InternalProvider, {
+      actions: wrappedActions,
+      children: props.children,
+    });
+  };
+}`;
+    expect(await transform(code, '/src/App.tsx', { ssr: true }))
+      .toMatchInlineSnapshot(`
+        "
+        import { InternalProvider } from './shared.js';
+        import { jsx } from 'react/jsx-runtime';
+        import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export async function __waku_action1({ action }, ...args) {
+            return await action(...args);
+        }
+        __waku_registerServerReference(__waku_action1, "/src/App.tsx", "__waku_action1");
+        const innerAction = __waku_action1.bind(null);
+        function wrapAction(action) {
+            return innerAction.bind(null, {
+                action
+            });
+        }
+        export function createAI({ actions }) {
+            const wrappedActions = {};
+            for(const name in actions){
+                wrappedActions[name] = wrapAction(actions[name]);
+            }
+            return function AI(props) {
+                return jsx(InternalProvider, {
+                    actions: wrappedActions,
+                    children: props.children
+                });
+            };
+        }
+
+        if (typeof createAI === 'function') {
+          __waku_registerServerReference(createAI, '/src/App.tsx', 'createAI');
+        }
+        "
+      `);
+  });
+
   test('inline use server (function declaration)', async () => {
     const code = `
 export default function App({ a }) {
-  function log(mesg) {
+  async function log(mesg) {
     'use server';
     console.log(mesg, a);
   }
@@ -80,17 +185,17 @@ export default function App({ a }) {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        export function __waku_action1(a, mesg) {
-            console.log(mesg, a);
-        }
-        __waku_registerServerReference(__waku_action1, "/src/App.tsx", "__waku_action1");
-        export default function App({ a }) {
-            const log = __waku_action1.bind(null, a);
-            return <Hello log={log}/>;
-        }
-        "
-      `);
+      "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+      export async function __waku_action1(a, mesg) {
+          console.log(mesg, a);
+      }
+      __waku_registerServerReference(__waku_action1, "/src/App.tsx", "__waku_action1");
+      export default function App({ a }) {
+          const log = __waku_action1.bind(null, a);
+          return <Hello log={log}/>;
+      }
+      "
+    `);
   });
 
   test('inline use server (const function expression)', async () => {
@@ -148,7 +253,7 @@ export default function App() {
   test('inline use server (in an object)', async () => {
     const code = `
 const actions = {
-  log: (mesg) => {
+  log: async (mesg) => {
     'use server';
     console.log(mesg);
   },
@@ -160,7 +265,7 @@ export default function App() {
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
         "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        export const __waku_action1 = __waku_registerServerReference((mesg)=>{
+        export const __waku_action1 = __waku_registerServerReference(async (mesg)=>{
             console.log(mesg);
         }, "/src/App.tsx", "__waku_action1");
         const actions = {


### PR DESCRIPTION
Fix some RSC case, will fix https://github.com/dai-shi/waku/pull/745. In the future, I will migrate the logic to https://github.com/himself65/react-server and keep same output

Some issues still happening:

1. `export default async function () {"use server"}` cannot be RSCA
2. `export function a() { "use server" }` should throw error, because it's not async