### PR TITLE
feat: migrate cloudflare workers adapter to cloudflare pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,20 @@ Adding the `--with-netlify-static` flag to the build script will produce static 
 }
 ```
 
-### Cloudflare (experimental)
+### Cloudflare Pages (experimental)
+
+**Note:** the current integration with Cloudflare Pages requires a `waku.config.ts` file to be
+added at the root of your project, with the basePath set like so:
+
+```
+export default {
+  basePath: "/public/"
+}
+```
+
+From here, it's recommended to follow Cloudflare Page's workflow of creating a new Pages
+application and connecting it to your GitHub or GitLab repo for automatic deployments.
+See [the docs](https://developers.cloudflare.com/pages/get-started/git-integration/).
 
 ```
 npm run build -- --with-cloudflare

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -752,7 +752,7 @@ export async function build(options: {
       options.deploy.slice('netlify-'.length) as 'static' | 'functions',
     );
   } else if (options.deploy === 'cloudflare') {
-    await emitCloudflareOutput(rootDir, config, DIST_SERVE_JS);
+    await emitCloudflareOutput(rootDir, config);
   } else if (options.deploy === 'partykit') {
     await emitPartyKitOutput(rootDir, config, DIST_SERVE_JS);
   } else if (options.deploy === 'aws-lambda') {

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -298,6 +298,24 @@ const buildServerBundle = async (
   if (!('output' in serverBuildOutput)) {
     throw new Error('Unexpected vite server build output');
   }
+
+  if (serve === 'cloudflare') {
+    // For Cloudflare Pages, create `_routes.json` which prevents calls to
+    // static client assets from invoking the server-side function.
+    // TODO: check for existing `_routes.json` in users' root directory? And
+    // merge this with default staticRoutes provided below
+    const routesJsonFilePath = joinPath(rootDir,
+      config.distDir,
+      '_routes.json');
+    const staticRoutes = {
+      version: 1,
+      include: ['/*'],
+      exclude: ['/public/assets/*']
+    };
+
+    await writeFile(routesJsonFilePath, JSON.stringify(staticRoutes));
+  }
+
   return serverBuildOutput;
 };
 

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -58,6 +58,7 @@ import { emitAwsLambdaOutput } from './output-aws-lambda.js';
 import {
   DIST_ENTRIES_JS,
   DIST_SERVE_JS,
+  DIST_WORKER_JS,
   DIST_PUBLIC,
   DIST_ASSETS,
   DIST_SSR,
@@ -237,7 +238,11 @@ const buildServerBundle = async (
         ? [
             rscServePlugin({
               ...config,
-              distServeJs: DIST_SERVE_JS,
+              distServeJs: serve !== 'cloudflare'
+                ? DIST_SERVE_JS
+                // Cloudflare Pages advanced mode requires the dist entry file
+                // to be named `_worker.js`
+                : DIST_WORKER_JS,
               distPublic: DIST_PUBLIC,
               srcServeFile: decodeFilePathFromAbsolute(
                 joinPath(

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -298,24 +298,6 @@ const buildServerBundle = async (
   if (!('output' in serverBuildOutput)) {
     throw new Error('Unexpected vite server build output');
   }
-
-  if (serve === 'cloudflare') {
-    // For Cloudflare Pages, create `_routes.json` which prevents calls to
-    // static client assets from invoking the server-side function.
-    // TODO: check for existing `_routes.json` in users' root directory? And
-    // merge this with default staticRoutes provided below
-    const routesJsonFilePath = joinPath(rootDir,
-      config.distDir,
-      '_routes.json');
-    const staticRoutes = {
-      version: 1,
-      include: ['/*'],
-      exclude: ['/public/assets/*']
-    };
-
-    await writeFile(routesJsonFilePath, JSON.stringify(staticRoutes));
-  }
-
   return serverBuildOutput;
 };
 

--- a/packages/waku/src/lib/builder/constants.ts
+++ b/packages/waku/src/lib/builder/constants.ts
@@ -2,7 +2,7 @@
 // We may change this in the future
 export const DIST_ENTRIES_JS = 'entries.js';
 export const DIST_SERVE_JS = 'serve.js';
-export const DIST_WORKER_JS = '_worker.js';
+export const DIST_WORKER_JS = '_worker.js'; // for CloudFlare Pages
 export const DIST_PUBLIC = 'public';
 export const DIST_ASSETS = 'assets';
 export const DIST_SSR = 'ssr';

--- a/packages/waku/src/lib/builder/constants.ts
+++ b/packages/waku/src/lib/builder/constants.ts
@@ -2,6 +2,7 @@
 // We may change this in the future
 export const DIST_ENTRIES_JS = 'entries.js';
 export const DIST_SERVE_JS = 'serve.js';
+export const DIST_WORKER_JS = '_worker.js';
 export const DIST_PUBLIC = 'public';
 export const DIST_ASSETS = 'assets';
 export const DIST_SSR = 'ssr';

--- a/packages/waku/src/lib/builder/output-cloudflare.ts
+++ b/packages/waku/src/lib/builder/output-cloudflare.ts
@@ -1,14 +1,28 @@
 import path from 'node:path';
 import { existsSync, writeFileSync } from 'node:fs';
+import { joinPath } from '../utils/path.js';
+import { DIST_ASSETS, DIST_PUBLIC } from './constants.js';
 
 import type { ResolvedConfig } from '../config.js';
-import { DIST_PUBLIC } from './constants.js';
 
-// XXX this can be very limited. FIXME if anyone has better knowledge.
 export const emitCloudflareOutput = async (
   rootDir: string,
   config: ResolvedConfig
 ) => {
+  const routesJsonPublicFile = joinPath(rootDir, config.srcDir, DIST_PUBLIC);
+  if (!existsSync(routesJsonPublicFile)) {
+    const routesJsonDistFile = joinPath(rootDir,
+      config.distDir,
+      '_routes.json');
+    const staticRoutes = {
+      version: 1,
+      include: ['/*'],
+      exclude: [`/${DIST_PUBLIC}/${DIST_ASSETS}/*`]
+    };
+
+    writeFileSync(routesJsonDistFile, JSON.stringify(staticRoutes));
+  }
+
   const wranglerTomlFile = path.join(rootDir, 'wrangler.toml');
   if (!existsSync(wranglerTomlFile)) {
     writeFileSync(

--- a/packages/waku/src/lib/builder/output-cloudflare.ts
+++ b/packages/waku/src/lib/builder/output-cloudflare.ts
@@ -7,8 +7,7 @@ import { DIST_PUBLIC } from './constants.js';
 // XXX this can be very limited. FIXME if anyone has better knowledge.
 export const emitCloudflareOutput = async (
   rootDir: string,
-  config: ResolvedConfig,
-  serveJs: string,
+  config: ResolvedConfig
 ) => {
   const wranglerTomlFile = path.join(rootDir, 'wrangler.toml');
   if (!existsSync(wranglerTomlFile)) {
@@ -16,12 +15,10 @@ export const emitCloudflareOutput = async (
       wranglerTomlFile,
       `
 name = "waku-project"
-main = "${config.distDir}/${serveJs}"
-compatibility_date = "2023-12-06"
-compatibility_flags = [ "nodejs_als" ]
+compatibility_date = "2024-04-05"
+compatibility_flags = ["nodejs_compat"]
 
-[site]
-bucket = "./${config.distDir}/${DIST_PUBLIC}"
+pages_build_output_dir = "./${config.distDir}/${DIST_PUBLIC}"
 `,
     );
   }

--- a/packages/waku/src/lib/builder/serve-cloudflare.ts
+++ b/packages/waku/src/lib/builder/serve-cloudflare.ts
@@ -1,28 +1,15 @@
 import { Hono } from 'hono';
-import { serveStatic } from 'hono/cloudflare-workers';
-// @ts-expect-error no types
-// eslint-disable-next-line import/no-unresolved
-import manifest from '__STATIC_CONTENT_MANIFEST';
+import { serveStatic } from 'hono/cloudflare-pages';
 
 import { runner } from '../hono/runner.js';
 
 const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
 let serveWaku: ReturnType<typeof runner> | undefined;
-let staticContent: any;
-
-const parsedManifest: Record<string, string> = JSON.parse(manifest);
 
 const app = new Hono();
-app.use('*', serveStatic({ root: './', manifest }));
+app.use('/assets/*', serveStatic());
 app.use('*', (c, next) => serveWaku!(c, next));
 app.notFound(async (c) => {
-  const path = parsedManifest['404.html'];
-  const content: ArrayBuffer | undefined =
-    path && (await staticContent?.get(path, { type: 'arrayBuffer' }));
-  if (content) {
-    c.header('Content-Type', 'text/html; charset=utf-8');
-    return c.body(content, 404);
-  }
   return c.text('404 Not Found', 404);
 });
 
@@ -34,7 +21,6 @@ export default {
   ) {
     if (!serveWaku) {
       serveWaku = runner({ cmd: 'start', loadEntries, env });
-      staticContent = env.__STATIC_CONTENT;
     }
     return app.fetch(request, env, ctx);
   },

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -67,8 +67,10 @@ export function rscServePlugin(opts: {
           viteConfig.build.rollupOptions.external.push('hono');
           if (opts.serve === 'cloudflare') {
             viteConfig.build.rollupOptions.external.push(
-              'hono/cloudflare-workers',
-              '__STATIC_CONTENT_MANIFEST',
+              // Needs investigating: when building from Cloudflare's dashboard,
+              // an error is thrown because `hono` & `hono/cloudflare-pages` are
+              // not properly externalised despite being added here.
+              'hono/cloudflare-pages'
             );
           }
         } else {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-serve.ts
@@ -67,9 +67,6 @@ export function rscServePlugin(opts: {
           viteConfig.build.rollupOptions.external.push('hono');
           if (opts.serve === 'cloudflare') {
             viteConfig.build.rollupOptions.external.push(
-              // Needs investigating: when building from Cloudflare's dashboard,
-              // an error is thrown because `hono` & `hono/cloudflare-pages` are
-              // not properly externalised despite being added here.
               'hono/cloudflare-pages'
             );
           }


### PR DESCRIPTION
This PR implements a minimal set of changes so that running waku build with the flag `-- --with-cloudflare` now creates a build specifically for Cloudflare Pages (using their advanced mode strategy). This is the recommended way to deploy web apps on Cloudflare now; worker sites are deprecated.

More discussion and context can be found here: https://github.com/dai-shi/waku/discussions/763

Note: I have tested numerous times that the changes work and can successfully deploy a CF Pages site with no errors. To test this, I used a custom workflow which deploys `examples/10_fs-router` from the monorepo with a compiled version of the waku pnpm workspace. To get this to work I also made the following changes to the example project (these are not committed): 

1. Add `waku.config.ts` with the base path set to `/public/` (explained in the updated docs). 
2. Also needed to add hono as a dependency in the example project, otherwise deploying via Cloudflare would throw an error about a missing hono dependency.

![image](https://github.com/user-attachments/assets/5e1a5539-718e-4a71-b3ad-f70b1d22d843)
![image](https://github.com/user-attachments/assets/1a0adc2d-e69e-4764-9c2d-5d880002134e)


There is a chance that behaviour could be different when consuming Waku as an external npm package. But I can't think of any good ways to replicate this. So I suggest we just test the end-to-end deployment again after merging and releasing this PR

Just let me know if any changes should be made