### PR TITLE
fix: Hono runner 404 response

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -96,8 +96,9 @@ async function runDev() {
   const config = await loadConfig();
   const app = new Hono();
   app.use('*', runner({ cmd: 'dev', config, env: process.env as any }));
-  // @ts-expect-error bypassing hono default notFound handler
-  app.use('*', (_c, _next) => {})
+  // bypassing hono default notFound handler
+  // @ts-expect-error FIXME there might be a better way to handle this
+  app.use('*', (_c, _next) => {});
   const port = parseInt(values.port || '3000', 10);
   await startServer(app, port);
 }

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -96,6 +96,8 @@ async function runDev() {
   const config = await loadConfig();
   const app = new Hono();
   app.use('*', runner({ cmd: 'dev', config, env: process.env as any }));
+  // @ts-expect-error bypassing hono default notFound handler
+  app.use('*', (_c, _next) => {})
   const port = parseInt(values.port || '3000', 10);
   await startServer(app, port);
 }

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -53,10 +53,12 @@ export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
       });
     };
     await run(0);
-    return c.body(
-      ctx.res.body || null,
-      (ctx.res.status as any) || 200,
-      ctx.res.headers || {},
-    );
+    if (!c.finalized) {
+      return c.body(
+        ctx.res.body || null,
+        (ctx.res.status as any) || 200,
+        ctx.res.headers || {},
+      );
+    }
   };
 };

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -53,8 +53,7 @@ export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
       });
     };
     await run(0);
-    /* checking ctx.res.body is a workaround for dev server 404 response */
-    if (!c.finalized/* || ctx.res.body*/) {
+    if (!c.finalized) {
       return c.body(
         ctx.res.body || null,
         (ctx.res.status as any) || 200,

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -53,7 +53,8 @@ export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
       });
     };
     await run(0);
-    if (!c.finalized) {
+    /* checking ctx.res.body is a workaround for dev server 404 response */
+    if (!c.finalized/* || ctx.res.body*/) {
       return c.body(
         ctx.res.body || null,
         (ctx.res.status as any) || 200,


### PR DESCRIPTION
This fixes the issue for me mentioned in #644 where an empty 200 status response is returned instead of a 404 error page.

I found the RSC middleware doesn't run in that case so the ctx.res is never set. I added a fallback to move the hono res.body to the ctx.body if the ctx.body is empty. I assume that won't be a breaking change but 🤷.