### PR TITLE
chore: add nvmrc and node-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 .vscode
 *.tsbuildinfo
 .cache
+.nvmrc
+.node-version


### PR DESCRIPTION
Feel free to just close this if there's a preference to not have this. 

My motivation for adding this is just that with [fnm](https://github.com/Schniz/fnm) (and other node version managers) - they look for this file or .nvmrc to automatically set the node version. Adding this would make it more convenient to swap between different projects that use different node versions.

I chose 20.8.0 because it is enforced in the `packages/waku/package.json` engines field.