### PR TITLE
fix(create-waku): pnpm run compile

### DIFF
--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "node ./dist/index.js",
     "dev": "ncc build ./src/index.ts -w -o ./dist/",
-    "compile": "rm -rf template dist *.tsbuildinfo && pnpm run template && pnpm run build",
+    "compile": "(rm -rf template dist *.tsbuildinfo || true) && pnpm run template && pnpm run build",
     "template": "mkdir template && cd ../../examples && tar -cf - --exclude='node_modules' --exclude='dist' . | tar -xf - -C ../packages/create-waku/template && cd ../packages/create-waku && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)",
     "build": "ncc build ./src/index.ts -o ./dist/ --minify --no-cache --no-source-map-register"
   },

--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -22,7 +22,7 @@
     "start": "node ./dist/index.js",
     "dev": "ncc build ./src/index.ts -w -o ./dist/",
     "compile": "rm -rf template dist *.tsbuildinfo && pnpm run template && pnpm run build",
-    "template": "cp -r ../../examples template && rm -rf template/*/dist && rm -rf template/*/node_modules && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)",
+    "template": "mkdir template && cd ../../examples && tar -cf - --exclude='node_modules' --exclude='dist' . | tar -xf - -C ../packages/create-waku/template && cd ../packages/create-waku && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)",
     "build": "ncc build ./src/index.ts -o ./dist/ --minify --no-cache --no-source-map-register"
   },
   "devDependencies": {

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -61,7 +61,7 @@
     "dev": "swc src -d dist -w --strip-leading-paths",
     "test": "vitest run",
     "test:watch": "vitest",
-    "compile": "rm -rf dist *.tsbuildinfo && pnpm run compile:code && pnpm run compile:types && cp ../../README.md .",
+    "compile": "(rm -rf dist *.tsbuildinfo || true) && pnpm run compile:code && pnpm run compile:types && cp ../../README.md .",
     "compile:code": "swc src -d dist --strip-leading-paths",
     "compile:types": "tsc --project tsconfig.json"
   },


### PR DESCRIPTION
I tried to run `pnpm run compile` in the `create-waku` package but it didn't work for me. 

```shell
❯ pnpm run compile

> create-waku@0.9.2-beta.3 compile /Users/tobbe/dev/waku/packages/create-waku
> rm -rf template dist *.tsbuildinfo && pnpm run template && pnpm run build


> create-waku@0.9.2-beta.3 template /Users/tobbe/dev/waku/packages/create-waku
> cp -r ../../examples template && rm -rf template/*/dist && rm -rf template/*/node_modules && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)

cp: ../../examples/06_nesting/node_modules/@types/react-dom: No such file or directory
cp: ../../examples/06_nesting/node_modules/@types/react: No such file or directory
cp: ../../examples/06_nesting/node_modules/typescript: No such file or directory
cp: ../../examples/06_nesting/node_modules/react-dom: No such file or directory
cp: ../../examples/06_nesting/node_modules/react-server-dom-webpack: No such file or directory
cp: ../../examples/06_nesting/node_modules/react: No such file or directory
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

It never gets past the `pnpm run template` step, so nothing is built.

Using `tar` instead of `cp` fixes the problem for me, and also prevents copying a bunch of node_modules and dist folders over 🙂 

Tested with zsh and bash on MacOS