### PR TITLE
refactor(router): style/performance tweaks to logic and jsdoc added

### DIFF
--- a/packages/waku/src/lib/utils/path.ts
+++ b/packages/waku/src/lib/utils/path.ts
@@ -105,6 +105,21 @@ export const path2regexp = (path: PathSpec) => {
   return `^/${parts.join('/')}$`;
 };
 
+/**
+ * Helper function to get the path mapping from the path spec and the pathname.
+ *
+ * @param pathSpec
+ * @param pathname - route as a string
+ * @example
+ * getPathMapping(
+ *   [
+ *     { type: 'literal', name: 'foo' },
+ *     { type: 'group', name: 'a' },
+ *   ],
+ *   '/foo/bar',
+ * );
+ * // => { a: 'bar' }
+ */
 export const getPathMapping = (
   pathSpec: PathSpec,
   pathname: string,

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -4,9 +4,14 @@ import { createPages } from '../src/router/create-pages.js';
 import type {
   CreateLayout,
   CreatePage,
+  GetSlugs,
+  HasSlugInPath,
+  HasWildcardInPath,
+  IsValidPathInSlugPath,
   PathWithoutSlug,
   PathWithSlug,
   PathWithWildcard,
+  StaticSlugRoutePathsTuple,
 } from '../src/router/create-pages.js';
 import { unstable_defineRouter } from '../src/router/define-router.js';
 import { createElement } from 'react';
@@ -42,6 +47,51 @@ describe('type tests', () => {
       '/test/[a]/[...path]',
     );
   });
+  it('HasSlugInPath', () => {
+    expectType<HasSlugInPath<'/test/[a]/[b]', 'a'>>(true);
+    expectType<HasSlugInPath<'/test/[a]/[b]', 'b'>>(true);
+    expectType<HasSlugInPath<'/test/[a]/[b]', 'c'>>(false);
+    expectType<HasSlugInPath<'/test/[a]/[b]', 'd'>>(false);
+  });
+  it('IsValidPathInSlugPath', () => {
+    expectType<IsValidPathInSlugPath<'/test/[a]/[b]'>>(true);
+    expectType<IsValidPathInSlugPath<'/test/[a]/[b]'>>(true);
+    expectType<IsValidPathInSlugPath<'/test'>>(true);
+
+    expectType<IsValidPathInSlugPath<'foobar'>>(false);
+    expectType<IsValidPathInSlugPath<'/'>>(false);
+  });
+  it('HasWildcardInPath', () => {
+    expectType<HasWildcardInPath<'/test/[...path]'>>(true);
+    expectType<HasWildcardInPath<'/test/[a]/[...path]'>>(true);
+    expectType<HasWildcardInPath<'/test/[a]/[b]/[...path]'>>(true);
+
+    expectType<HasWildcardInPath<'/test/[a]/[b]'>>(false);
+    expectType<HasWildcardInPath<'/test'>>(false);
+    expectType<HasWildcardInPath<'/'>>(false);
+  });
+  it('GetSlugs', () => {
+    expectType<GetSlugs<'/test/[a]/[b]'>>(['a', 'b']);
+    expectType<GetSlugs<'/test/[a]/[b]'>>(['a', 'b']);
+    expectType<GetSlugs<'/test/[a]/[b]/[c]'>>(['a', 'b', 'c']);
+    expectType<GetSlugs<'/test/[a]/[b]/[c]/[d]'>>(['a', 'b', 'c', 'd']);
+  });
+  it('StaticSlugRoutePathsTuple', () => {
+    expectType<StaticSlugRoutePathsTuple<'/test/[a]/[b]'>>(['a', 'b']);
+    expectType<StaticSlugRoutePathsTuple<'/test/[a]/[b]/[c]'>>([
+      'foo',
+      'bar',
+      'buzz',
+    ]);
+    // @ts-expect-error: Too many slugs
+    expectType<StaticSlugRoutePathsTuple<'/test/[a]/[b]/[c]'>>([
+      'foo',
+      'bar',
+      'buzz',
+      'baz',
+    ]);
+  });
+
   describe('CreatePage', () => {
     it('static', () => {
       const createPage: CreatePage = vi.fn();
@@ -71,6 +121,21 @@ describe('type tests', () => {
         render: 'static',
         path: '/test/[a]',
         staticPaths: ['x', 'y', 'z'],
+        component: () => 'Hello',
+      });
+      createPage({
+        render: 'static',
+        path: '/test/[a]/[b]',
+        staticPaths: [
+          ['a', 'b'],
+          ['c', 'd'],
+        ],
+        component: () => 'Hello',
+      });
+      createPage({
+        render: 'static',
+        path: '/test/[...wild]',
+        staticPaths: ['c', 'd', 'e'],
         component: () => 'Hello',
       });
     });


### PR DESCRIPTION
What I have focused on so far: 

- Removing unnecessary creation of arrays for loops (using iterability of maps)
- jsdoc for functions that I am reading through to understand in the router
- moved some of the types around
  - Not sure how I feel about this yet... if splitting up the logic for each of these entry points ends up working out, it will be nice to have these types re-used for that. Otherwise, I will revert that part. (CreatePageStaticWithoutSlug & CreatePageStaticWithSlug)
 
Notes:

I think I will be adding some more docs and re-organizing a bit more before calling this PR ready.

I am interested to hear opinions and thoughts on the changes so far though, if any.