### PR TITLE
feat: redesign RSC protocol without URLSearchParams

### DIFF
--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -85,7 +85,7 @@ const SET_ELEMENTS = 's';
 const ON_FETCH_DATA = 'o';
 
 type FetchCache = {
-  [ENTRY]?: [input: string, searchParamsString: string, elements: Elements];
+  [ENTRY]?: [input: string, params: unknown, elements: Elements];
   [SET_ELEMENTS]?: SetElements;
   [ON_FETCH_DATA]?: OnFetchData | undefined;
 };
@@ -98,13 +98,14 @@ const defaultFetchCache: FetchCache = {};
  */
 export const callServerRSC = async (
   actionId: string,
-  args: unknown[],
+  args?: unknown[],
   fetchCache = defaultFetchCache,
 ) => {
-  const response = fetch(BASE_PATH + encodeInput(encodeActionId(actionId)), {
-    method: 'POST',
-    body: await encodeReply(args),
-  });
+  const url = BASE_PATH + encodeInput(encodeActionId(actionId));
+  const response =
+    args === undefined
+      ? fetch(url)
+      : encodeReply(args).then((body) => fetch(url, { method: 'POST', body }));
   const data = createFromFetch<Awaited<Elements>>(checkStatus(response), {
     callServer: (actionId: string, args: unknown[]) =>
       callServerRSC(actionId, args, fetchCache),
@@ -117,21 +118,27 @@ export const callServerRSC = async (
   return (await data)._value;
 };
 
+const prefetchedParams = new WeakMap<Promise<unknown>, unknown>();
+
 export const fetchRSC = (
   input: string,
-  searchParamsString: string,
+  params?: unknown,
   fetchCache = defaultFetchCache,
 ): Elements => {
   const entry = fetchCache[ENTRY];
-  if (entry && entry[0] === input && entry[1] === searchParamsString) {
+  if (entry && entry[0] === input && entry[1] === params) {
     return entry[2];
   }
   const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
-  const url =
-    BASE_PATH +
-    encodeInput(input) +
-    (searchParamsString ? '?' + searchParamsString : '');
-  const response = prefetched[url] || fetch(url);
+  const url = BASE_PATH + encodeInput(input);
+  const response =
+    prefetched[url] && prefetchedParams.get(prefetched[url]) === params
+      ? prefetched[url]
+      : params === undefined
+        ? fetch(url)
+        : encodeReply(params).then((body) =>
+            fetch(url, { method: 'POST', body }),
+          );
   delete prefetched[url];
   const data = createFromFetch<Awaited<Elements>>(checkStatus(response), {
     callServer: (actionId: string, args: unknown[]) =>
@@ -139,56 +146,56 @@ export const fetchRSC = (
   });
   fetchCache[ON_FETCH_DATA]?.(data);
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  fetchCache[ENTRY] = [input, searchParamsString, data];
+  fetchCache[ENTRY] = [input, params, data];
   return data;
 };
 
-export const prefetchRSC = (
-  input: string,
-  searchParamsString: string,
-): void => {
+export const prefetchRSC = (input: string, params?: unknown): void => {
   const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
-  const url =
-    BASE_PATH +
-    encodeInput(input) +
-    (searchParamsString ? '?' + searchParamsString : '');
+  const url = BASE_PATH + encodeInput(input);
   if (!(url in prefetched)) {
-    prefetched[url] = fetch(url);
+    prefetched[url] =
+      params === undefined
+        ? fetch(url)
+        : encodeReply(params).then((body) =>
+            fetch(url, { method: 'POST', body }),
+          );
+    prefetchedParams.set(prefetched[url], params);
   }
 };
 
-const RefetchContext = createContext<
-  (input: string, searchParams?: URLSearchParams) => void
->(() => {
-  throw new Error('Missing Root component');
-});
+const RefetchContext = createContext<(input: string, params?: unknown) => void>(
+  () => {
+    throw new Error('Missing Root component');
+  },
+);
 const ElementsContext = createContext<Elements | null>(null);
 
 export const Root = ({
   initialInput,
-  initialSearchParamsString,
+  initialParams,
   fetchCache = defaultFetchCache,
   unstable_onFetchData,
   children,
 }: {
   initialInput?: string;
-  initialSearchParamsString?: string;
+  initialParams?: unknown;
   fetchCache?: FetchCache;
   unstable_onFetchData?: (data: unknown) => void;
   children: ReactNode;
 }) => {
   fetchCache[ON_FETCH_DATA] = unstable_onFetchData;
   const [elements, setElements] = useState(() =>
-    fetchRSC(initialInput || '', initialSearchParamsString || '', fetchCache),
+    fetchRSC(initialInput || '', initialParams, fetchCache),
   );
   useEffect(() => {
     fetchCache[SET_ELEMENTS] = setElements;
   }, [fetchCache, setElements]);
   const refetch = useCallback(
-    (input: string, searchParams?: URLSearchParams) => {
+    (input: string, params?: unknown) => {
       // clear cache entry before fetching
       delete fetchCache[ENTRY];
-      const data = fetchRSC(input, searchParams?.toString() || '', fetchCache);
+      const data = fetchRSC(input, params, fetchCache);
       startTransition(() => {
         setElements((prev) => mergeElements(prev, data));
       });

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -472,8 +472,6 @@ const emitRscFiles = async (
         const readable = await renderRsc(
           {
             input,
-            searchParams: new URLSearchParams(),
-            method: 'GET',
             config,
             context,
             moduleIdCallback: (id) => addClientModule(input, id),
@@ -603,14 +601,13 @@ const emitHtmlFiles = async (
           pathname,
           searchParams: new URLSearchParams(),
           htmlHead,
-          renderRscForHtml: (input, searchParams) =>
+          renderRscForHtml: (input, params) =>
             renderRsc(
               {
                 config,
                 input,
-                searchParams,
-                method: 'GET',
                 context,
+                decodedBody: params,
               },
               {
                 isDev: false,

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -25,10 +25,7 @@ export const rsc: Middleware = (options) => {
     ]);
     const basePrefix = config.basePath + config.rscPath + '/';
     if (ctx.req.url.pathname.startsWith(basePrefix)) {
-      const { method, headers } = ctx.req;
-      if (method !== 'GET' && method !== 'POST') {
-        throw new Error(`Unsupported method '${method}'`);
-      }
+      const { headers } = ctx.req;
       try {
         const input = decodeInput(
           ctx.req.url.pathname.slice(basePrefix.length),
@@ -36,8 +33,6 @@ export const rsc: Middleware = (options) => {
         const args: RenderRscArgs = {
           config,
           input,
-          searchParams: ctx.req.url.searchParams,
-          method,
           context: ctx.context,
           body: ctx.req.body,
           contentType: headers['content-type'] || '',

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -1,7 +1,7 @@
 import { resolveConfig } from '../config.js';
 import { getPathMapping } from '../utils/path.js';
 import { renderHtml } from '../renderers/html-renderer.js';
-import { hasStatusCode, encodeInput } from '../renderers/utils.js';
+import { hasStatusCode } from '../renderers/utils.js';
 import { getSsrConfig, renderRsc } from '../renderers/rsc-renderer.js';
 import type { RenderRscArgs } from '../renderers/rsc-renderer.js';
 import type { Middleware } from './types.js';
@@ -39,17 +39,12 @@ export const ssr: Middleware = (options) => {
           pathname: ctx.req.url.pathname,
           searchParams: ctx.req.url.searchParams,
           htmlHead,
-          renderRscForHtml: async (input, searchParams) => {
-            ctx.req.url.pathname =
-              config.basePath + config.rscPath + '/' + encodeInput(input);
-            ctx.req.url.search = searchParams.toString();
+          renderRscForHtml: async (input, params) => {
             const args: RenderRscArgs = {
               config,
               input,
-              searchParams: ctx.req.url.searchParams,
-              method: 'GET',
               context: ctx.context,
-              body: ctx.req.body,
+              decodedBody: params,
               contentType: '',
             };
             const readable = await (devServer

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -180,14 +180,14 @@ export const renderHtml = async (
     htmlHead: string;
     renderRscForHtml: (
       input: string,
-      searchParams: URLSearchParams,
+      params?: unknown,
     ) => Promise<ReadableStream>;
     getSsrConfigForHtml: (
       pathname: string,
       searchParams: URLSearchParams,
     ) => Promise<{
       input: string;
-      searchParams?: URLSearchParams;
+      params: unknown;
       html: ReadableStream;
     } | null>;
   } & (
@@ -237,10 +237,7 @@ export const renderHtml = async (
   }
   let stream: ReadableStream;
   try {
-    stream = await renderRscForHtml(
-      ssrConfig.input,
-      ssrConfig.searchParams || searchParams,
-    );
+    stream = await renderRscForHtml(ssrConfig.input, ssrConfig.params);
   } catch (e) {
     if (hasStatusCode(e) && e.statusCode === 404) {
       return null;

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -187,7 +187,7 @@ export const renderHtml = async (
       searchParams: URLSearchParams,
     ) => Promise<{
       input: string;
-      params: unknown;
+      params?: unknown;
       html: ReadableStream;
     } | null>;
   } & (

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -27,9 +27,9 @@ const resolveClientEntryForPrd = (id: string, config: { basePath: string }) => {
 export type RenderRscArgs = {
   config: Omit<ResolvedConfig, 'middleware'>;
   input: string;
-  searchParams: URLSearchParams;
-  method: 'GET' | 'POST';
   context: Record<string, unknown> | undefined;
+  // TODO we hope to get only decoded one
+  decodedBody?: unknown;
   body?: ReadableStream | undefined;
   contentType?: string | undefined;
   moduleIdCallback?: ((id: string) => void) | undefined;
@@ -52,8 +52,6 @@ export async function renderRsc(
   const {
     config,
     input,
-    searchParams,
-    method,
     contentType,
     context,
     body,
@@ -122,7 +120,7 @@ export async function renderRsc(
   const renderWithContext = async (
     context: Record<string, unknown> | undefined,
     input: string,
-    searchParams: URLSearchParams,
+    params: unknown,
   ) => {
     const renderStore = {
       context: context || {},
@@ -132,7 +130,7 @@ export async function renderRsc(
     };
     return runWithRenderStore(renderStore, async () => {
       const elements = await renderEntries(input, {
-        searchParams,
+        params,
         buildConfig,
       });
       if (elements === null) {
@@ -160,13 +158,13 @@ export async function renderRsc(
     let rendered = false;
     const renderStore = {
       context: context || {},
-      rerender: async (input: string, searchParams = new URLSearchParams()) => {
+      rerender: async (input: string, params?: unknown) => {
         if (rendered) {
           throw new Error('already rendered');
         }
         elementsPromise = Promise.all([
           elementsPromise,
-          renderEntries(input, { searchParams, buildConfig }),
+          renderEntries(input, { params, buildConfig }),
         ]).then(([oldElements, newElements]) => ({
           ...oldElements,
           // FIXME we should actually check if newElements is null and send an error
@@ -191,24 +189,25 @@ export async function renderRsc(
     });
   };
 
-  if (method === 'POST') {
-    const rsfId = decodeActionId(input);
-    let args: unknown[] = [];
-    let bodyStr = '';
-    if (body) {
-      bodyStr = await streamToString(body);
-    }
+  let decodedBody: unknown | undefined = args.decodedBody;
+  if (body) {
+    const bodyStr = await streamToString(body);
     if (
       typeof contentType === 'string' &&
       contentType.startsWith('multipart/form-data')
     ) {
       // XXX This doesn't support streaming unlike busboy
       const formData = parseFormData(bodyStr, contentType);
-      args = await decodeReply(formData, serverBundlerConfig);
+      decodedBody = await decodeReply(formData, serverBundlerConfig);
     } else if (bodyStr) {
-      args = await decodeReply(bodyStr, serverBundlerConfig);
+      decodedBody = await decodeReply(bodyStr, serverBundlerConfig);
     }
-    const [fileId, name] = rsfId.split('#') as [string, string];
+  }
+
+  const actionId = decodeActionId(input);
+  if (actionId) {
+    const args = Array.isArray(decodedBody) ? decodedBody : [];
+    const [fileId, name] = actionId.split('#') as [string, string];
     let mod: any;
     if (isDev) {
       mod = await opts.loadServerModuleRsc(filePathToFileURL(fileId));
@@ -222,8 +221,7 @@ export async function renderRsc(
     return renderWithContextWithAction(context, fn, args);
   }
 
-  // method === 'GET'
-  return renderWithContext(context, input, searchParams);
+  return renderWithContext(context, input, decodedBody);
 }
 
 export async function getBuildConfig(opts: {
@@ -250,8 +248,6 @@ export async function getBuildConfig(opts: {
       {
         config,
         input,
-        searchParams: new URLSearchParams(),
-        method: 'GET',
         context: undefined,
         moduleIdCallback: (id) => idSet.add(id),
       },

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -28,17 +28,24 @@ export const decodeInput = (encodedInput: string) => {
   throw err;
 };
 
+const ACTION_PREFIX = 'ACTION_';
+
 export const encodeActionId = (actionId: string) => {
   const [file, name] = actionId.split('#') as [string, string];
   if (name.includes('/')) {
     throw new Error('Unsupported action name');
   }
-  return '_' + file + '/' + name;
+  return ACTION_PREFIX + file + '/' + name;
 };
 
 export const decodeActionId = (encoded: string) => {
+  if (!encoded.startsWith(ACTION_PREFIX)) {
+    return null;
+  }
   const index = encoded.lastIndexOf('/');
-  return encoded.slice(1, index) + '#' + encoded.slice(index + 1);
+  return (
+    encoded.slice(ACTION_PREFIX.length, index) + '#' + encoded.slice(index + 1)
+  );
 };
 
 export const hasStatusCode = (x: unknown): x is { statusCode: number } =>

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -253,7 +253,7 @@ const getSkipList = (
     if (shouldCheck[0] && route.path !== prevProps.path) {
       return false;
     }
-    if (shouldCheck[0] && route.query !== prevProps.query) {
+    if (shouldCheck[1] && route.query !== prevProps.query) {
       return false;
     }
     return true;
@@ -488,6 +488,7 @@ export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
         if (data && typeof data === 'object') {
           // We need to process SHOULD_SKIP_ID before LOCATION_ID
           if (SHOULD_SKIP_ID in data) {
+            // TODO replacing the whole array is not ideal
             routerData[0] = data[SHOULD_SKIP_ID] as ShouldSkip;
           }
           if (LOCATION_ID in data) {

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -29,8 +29,6 @@ export function parseInputString(input: string): string {
   return '/' + input;
 }
 
-export const PARAM_KEY_SKIP = 'waku_router_skip';
-
 // It starts with "/" to avoid conflicting with normal component ids.
 export const SHOULD_SKIP_ID = '/SHOULD_SKIP';
 

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -40,6 +40,6 @@ export type ShouldSkip = (readonly [
   componentId: string,
   readonly [
     path?: boolean, // if we compare path
-    keys?: string[], // searchParams keys to compare
+    query?: boolean, // if we compare query
   ],
 ])[];

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -111,7 +111,7 @@ export function unstable_defineRouter(
     const paramsSkip = (params as { skip?: unknown } | undefined)?.skip;
 
     const query = typeof paramsQuery === 'string' ? paramsQuery : '';
-    const skip = Array.isArray(paramsSkip) ? paramsSkip : [];
+    const skip = Array.isArray(paramsSkip) ? (paramsSkip as unknown[]) : [];
     const componentIds = getComponentIds(pathname);
     const entries: (readonly [string, ReactNode])[] = (
       await Promise.all(

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -13,7 +13,6 @@ import {
   getComponentIds,
   getInputString,
   parseInputString,
-  PARAM_KEY_SKIP,
   SHOULD_SKIP_ID,
   LOCATION_ID,
 } from './common.js';
@@ -98,7 +97,7 @@ export function unstable_defineRouter(
   };
   const renderEntries: RenderEntries = async (
     input,
-    { searchParams, buildConfig },
+    { params, buildConfig },
   ) => {
     const pathname = parseInputString(input);
     if ((await existsPath(pathname, buildConfig))[0] === 'NOT_FOUND') {
@@ -108,8 +107,11 @@ export function unstable_defineRouter(
       [componentId: ShouldSkip[number][0]]: ShouldSkip[number][1];
     } = {};
 
-    const skip = searchParams.getAll(PARAM_KEY_SKIP) || [];
-    searchParams.delete(PARAM_KEY_SKIP); // delete all
+    const paramsQuery = (params as { query?: unknown[] } | undefined)?.query;
+    const paramsSkip = (params as { skip?: unknown } | undefined)?.skip;
+
+    const query = typeof paramsQuery === 'string' ? paramsQuery : '';
+    const skip = Array.isArray(paramsSkip) ? paramsSkip : [];
     const componentIds = getComponentIds(pathname);
     const entries: (readonly [string, ReactNode])[] = (
       await Promise.all(
@@ -134,11 +136,11 @@ export function unstable_defineRouter(
           const element = createElement(
             component as FunctionComponent<{
               path: string;
-              searchParams?: URLSearchParams;
+              query?: string;
             }>,
             id.endsWith('/layout')
               ? { path: pathname }
-              : { path: pathname, searchParams },
+              : { path: pathname, query },
             createElement(Children),
           );
           return [[id, element]] as const;
@@ -146,7 +148,7 @@ export function unstable_defineRouter(
       )
     ).flat();
     entries.push([SHOULD_SKIP_ID, Object.entries(shouldSkipObj)]);
-    entries.push([LOCATION_ID, [pathname, searchParams.toString()]]);
+    entries.push([LOCATION_ID, [pathname, query]]);
     return Object.fromEntries(entries);
   };
 
@@ -225,7 +227,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         null,
       ),
     );
-    return { input, html };
+    return { input, params: { query: searchParams.toString() }, html };
   };
 
   return { renderEntries, getBuildConfig, getSsrConfig };
@@ -233,15 +235,9 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
 
 export function unstable_redirect(
   pathname: string,
-  searchParams?: URLSearchParams,
+  query?: string,
   skip?: string[],
 ) {
-  if (skip) {
-    searchParams = new URLSearchParams(searchParams);
-    for (const id of skip) {
-      searchParams.append(PARAM_KEY_SKIP, id);
-    }
-  }
   const input = getInputString(pathname);
-  rerender(input, searchParams);
+  rerender(input, { query, skip });
 }

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -40,7 +40,7 @@ export type GetSsrConfig = (
   },
 ) => Promise<{
   input: string;
-  params: unknown;
+  params?: unknown;
   html: ReactNode;
 } | null>;
 

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -23,7 +23,7 @@ export type BuildConfig = {
 export type RenderEntries = (
   input: string,
   options: {
-    searchParams: URLSearchParams;
+    params: unknown | undefined;
     buildConfig: BuildConfig | undefined;
   },
 ) => Promise<Elements | null>;
@@ -40,7 +40,7 @@ export type GetSsrConfig = (
   },
 ) => Promise<{
   input: string;
-  searchParams?: URLSearchParams;
+  params: unknown;
   html: ReactNode;
 } | null>;
 
@@ -70,7 +70,7 @@ export function getEnv(key: string): string | undefined {
 }
 
 type RenderStore<> = {
-  rerender: (input: string, searchParams?: URLSearchParams) => void;
+  rerender: (input: string, params?: unknown) => void;
   context: Record<string, unknown>;
 };
 
@@ -117,12 +117,12 @@ export const runWithRenderStore = <T>(
   }
 };
 
-export function rerender(input: string, searchParams?: URLSearchParams) {
+export function rerender(input: string, params?: unknown) {
   const renderStore = renderStorage?.getStore() ?? currentRenderStore;
   if (!renderStore) {
     throw new Error('Render store is not available');
   }
-  renderStore.rerender(input, searchParams);
+  renderStore.rerender(input, params);
 }
 
 export function unstable_getCustomContext<


### PR DESCRIPTION
Related previous PR: #799

- Previously, it distinguish whether it's RSC or RSF (server actions) with HTTP method. Now, it's distinguished with path.
- Both RSC and RSF accept GET and POST.
- RSC no longer uses `URLSearchParams` but just any `params`.