### PR TITLE
refactor: getEnv

### DIFF
--- a/examples/13_path-alias/src/components/App.tsx
+++ b/examples/13_path-alias/src/components/App.tsx
@@ -1,5 +1,8 @@
+import { getEnv } from 'waku';
 import { Counter } from '@/components/Counter';
 import { MyFragment } from '@/components/MyFragment';
+
+console.log('FOO', getEnv('FOO'));
 
 const App = ({ name }: { name: string }) => {
   return (

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -609,29 +609,13 @@ const emitHtmlFiles = async (
           htmlHead,
           renderRscForHtml: (input, params) =>
             renderRsc(
-              {
-                env,
-                config,
-                input,
-                context,
-                decodedBody: params,
-              },
-              {
-                isDev: false,
-                entries: distEntries,
-              },
+              { env, config, input, context, decodedBody: params },
+              { isDev: false, entries: distEntries },
             ),
           getSsrConfigForHtml: (pathname, searchParams) =>
             getSsrConfig(
-              {
-                config,
-                pathname,
-                searchParams,
-              },
-              {
-                isDev: false,
-                entries: distEntries,
-              },
+              { env, config, pathname, searchParams },
+              { isDev: false, entries: distEntries },
             ),
           isDev: false,
           loadModule: distEntries.loadModule,
@@ -723,11 +707,10 @@ export async function build(options: {
   const distEntries = await import(filePathToFileURL(distEntriesFile));
 
   // TODO: Add progress indication for static builds.
-  const buildConfig = await getBuildConfig({
-    env,
-    config,
-    entries: distEntries,
-  });
+  const buildConfig = await getBuildConfig(
+    { env, config },
+    { entries: distEntries },
+  );
   await appendFile(
     distEntriesFile,
     `export const buildConfig = ${JSON.stringify(buildConfig)};`,

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -686,7 +686,7 @@ export async function build(options: {
     await analyzeEntries(rootDir, config);
   const serverBuildOutput = await buildServerBundle(
     rootDir,
-    options.env || {},
+    env,
     config,
     clientEntryFiles,
     serverEntryFiles,
@@ -702,7 +702,7 @@ export async function build(options: {
   );
   await buildSsrBundle(
     rootDir,
-    options.env || {},
+    env,
     config,
     clientEntryFiles,
     serverEntryFiles,
@@ -712,7 +712,7 @@ export async function build(options: {
   );
   const clientBuildOutput = await buildClientBundle(
     rootDir,
-    options.env || {},
+    env,
     config,
     clientEntryFiles,
     serverEntryFiles,

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -4,7 +4,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { createServer as createViteServer } from 'vite';
 import viteReact from '@vitejs/plugin-react';
 
-import { setAllEnvInternal } from '../../server.js';
 import type { EntriesDev } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import {
@@ -312,7 +311,6 @@ export const devServer: Middleware = (options) => {
     return (_ctx, next) => next();
   }
 
-  setAllEnvInternal(options.env || {});
   const configPromise = resolveConfig(options.config);
 
   (globalThis as any).__WAKU_SERVER_HACK_IMPORT__ = (idOrFileURL: string) =>

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -311,6 +311,7 @@ export const devServer: Middleware = (options) => {
     return (_ctx, next) => next();
   }
 
+  const env = options.env || {};
   const configPromise = resolveConfig(options.config);
 
   (globalThis as any).__WAKU_SERVER_HACK_IMPORT__ = (idOrFileURL: string) =>
@@ -324,10 +325,10 @@ export const devServer: Middleware = (options) => {
     loadServerModuleMain,
     transformIndexHtml,
     willBeHandled,
-  } = createMainViteServer(options.env || {}, configPromise);
+  } = createMainViteServer(env, configPromise);
 
   const { loadServerModuleRsc, loadEntriesDev, resolveClientEntry } =
-    createRscViteServer(options.env || {}, configPromise);
+    createRscViteServer(env, configPromise);
 
   let initialModules: ClonableModuleNode[];
 

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -1,3 +1,4 @@
+import { setAllEnvInternal } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import { decodeInput, hasStatusCode } from '../renderers/utils.js';
 import { renderRsc } from '../renderers/rsc-renderer.js';
@@ -6,7 +7,7 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const rsc: Middleware = (options) => {
-  (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
+  setAllEnvInternal(options.env || {});
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -1,4 +1,3 @@
-import { setAllEnvInternal } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import { decodeInput, hasStatusCode } from '../renderers/utils.js';
 import { renderRsc } from '../renderers/rsc-renderer.js';
@@ -7,7 +6,6 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const rsc: Middleware = (options) => {
-  setAllEnvInternal(options.env || {});
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()
@@ -32,6 +30,7 @@ export const rsc: Middleware = (options) => {
           ctx.req.url.pathname.slice(basePrefix.length),
         );
         const args: RenderRscArgs = {
+          env: options.env || {},
           config,
           input,
           context: ctx.context,

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -6,6 +6,7 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const rsc: Middleware = (options) => {
+  const env = options.env || {};
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()
@@ -30,7 +31,7 @@ export const rsc: Middleware = (options) => {
           ctx.req.url.pathname.slice(basePrefix.length),
         );
         const args: RenderRscArgs = {
-          env: options.env || {},
+          env,
           config,
           input,
           context: ctx.context,

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -8,6 +8,7 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const ssr: Middleware = (options) => {
+  const env = options.env || {};
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()
@@ -40,7 +41,7 @@ export const ssr: Middleware = (options) => {
           htmlHead,
           renderRscForHtml: async (input, params) => {
             const args: RenderRscArgs = {
-              env: options.env || {},
+              env,
               config,
               input,
               context: ctx.context,
@@ -62,7 +63,7 @@ export const ssr: Middleware = (options) => {
                 isDev: true,
                 getSsrConfigForHtml: (pathname, searchParams) =>
                   getSsrConfig(
-                    { config, pathname, searchParams },
+                    { env, config, pathname, searchParams },
                     {
                       isDev: true,
                       loadServerModuleRsc: devServer.loadServerModuleRsc,
@@ -77,7 +78,7 @@ export const ssr: Middleware = (options) => {
                 isDev: false,
                 getSsrConfigForHtml: (pathname, searchParams) =>
                   getSsrConfig(
-                    { config, pathname, searchParams },
+                    { env, config, pathname, searchParams },
                     { isDev: false, entries },
                   ),
                 loadModule: entries.loadModule,

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -1,3 +1,4 @@
+import { setAllEnvInternal } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import { getPathMapping } from '../utils/path.js';
 import { renderHtml } from '../renderers/html-renderer.js';
@@ -8,7 +9,7 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const ssr: Middleware = (options) => {
-  (globalThis as any).__WAKU_PRIVATE_ENV__ = options.env || {};
+  setAllEnvInternal(options.env || {});
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -1,4 +1,3 @@
-import { setAllEnvInternal } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import { getPathMapping } from '../utils/path.js';
 import { renderHtml } from '../renderers/html-renderer.js';
@@ -9,7 +8,6 @@ import type { Middleware } from './types.js';
 import { stringToStream } from '../utils/stream.js';
 
 export const ssr: Middleware = (options) => {
-  setAllEnvInternal(options.env || {});
   const entriesPromise =
     options.cmd === 'start'
       ? options.loadEntries()
@@ -42,6 +40,7 @@ export const ssr: Middleware = (options) => {
           htmlHead,
           renderRscForHtml: async (input, params) => {
             const args: RenderRscArgs = {
+              env: options.env || {},
               config,
               input,
               context: ctx.context,

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
@@ -3,9 +3,11 @@ import * as dotenv from 'dotenv';
 
 export function rscEnvPlugin({
   isDev,
+  env,
   config,
 }: {
   isDev: boolean;
+  env: Record<string, string>;
   config?: {
     basePath: string;
     rscPath: string;
@@ -17,7 +19,7 @@ export function rscEnvPlugin({
       if (isDev) {
         dotenv.config({
           path: ['.env.local', '.env'],
-          processEnv: (globalThis as any).__WAKU_PRIVATE_ENV__,
+          processEnv: env,
           override: true,
         });
       }
@@ -37,18 +39,16 @@ export function rscEnvPlugin({
                 ],
               ]
             : []),
-          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
-            ([k, v]) =>
-              k.startsWith('WAKU_PUBLIC_')
-                ? [[`import.meta.env.${k}`, JSON.stringify(v)]]
-                : [],
+          ...Object.entries(env).flatMap(([k, v]) =>
+            k.startsWith('WAKU_PUBLIC_')
+              ? [[`import.meta.env.${k}`, JSON.stringify(v)]]
+              : [],
           ),
           // Node style `process.env` for traditional compatibility
-          ...Object.entries((globalThis as any).__WAKU_PRIVATE_ENV__).flatMap(
-            ([k, v]) =>
-              k.startsWith('WAKU_PUBLIC_')
-                ? [[`process.env.${k}`, JSON.stringify(v)]]
-                : [],
+          ...Object.entries(env).flatMap(([k, v]) =>
+            k.startsWith('WAKU_PUBLIC_')
+              ? [[`process.env.${k}`, JSON.stringify(v)]]
+              : [],
           ),
         ]),
       };

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -279,10 +279,7 @@ export async function getBuildConfig(
         context: undefined,
         moduleIdCallback: (id) => idSet.add(id),
       },
-      {
-        isDev: false,
-        entries: entries as EntriesPrd,
-      },
+      { isDev: false, entries },
     );
     await new Promise<void>((resolve, reject) => {
       const writable = new WritableStream({

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -4,7 +4,7 @@ import type { default as RSDWServerType } from 'react-server-dom-webpack/server.
 import type {
   EntriesDev,
   EntriesPrd,
-  runWithRenderStore as runWithRenderStoreType,
+  runWithRenderStoreInternal as runWithRenderStoreInternalType,
 } from '../../server.js';
 import type { ResolvedConfig } from '../config.js';
 import { filePathToFileURL } from '../utils/path.js';
@@ -81,12 +81,12 @@ export async function renderRsc(
     {
       default: { renderToReadableStream, decodeReply },
     },
-    { runWithRenderStore },
+    { runWithRenderStoreInternal },
   ] = await Promise.all([
     loadServerModule<{ default: typeof RSDWServerType }>('rsdw-server'),
-    loadServerModule<{ runWithRenderStore: typeof runWithRenderStoreType }>(
-      'waku-server',
-    ),
+    loadServerModule<{
+      runWithRenderStoreInternal: typeof runWithRenderStoreInternalType;
+    }>('waku-server'),
   ]);
 
   const clientBundlerConfig = new Proxy(
@@ -128,7 +128,7 @@ export async function renderRsc(
         throw new Error('Cannot rerender');
       },
     };
-    return runWithRenderStore(renderStore, async () => {
+    return runWithRenderStoreInternal(renderStore, async () => {
       const elements = await renderEntries(input, {
         params,
         buildConfig,
@@ -172,7 +172,7 @@ export async function renderRsc(
         }));
       },
     };
-    return runWithRenderStore(renderStore, async () => {
+    return runWithRenderStoreInternal(renderStore, async () => {
       const actionValue = await actionFn(...actionArgs);
       const elements = await elementsPromise;
       rendered = true;

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -247,7 +247,7 @@ export async function getBuildConfig(
   const {
     default: { getBuildConfig },
     loadModule,
-  } = entries
+  } = entries;
   if (!getBuildConfig) {
     console.warn(
       "getBuildConfig is undefined. It's recommended for optimization and sometimes required.",

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -64,9 +64,17 @@ export type EntriesPrd = EntriesDev & {
   publicIndexHtml: string;
 };
 
+let serverEnv: Record<string, string> = {};
+
+/**
+ * This is an internal function and not for public use.
+ */
+export function setAllEnvInternal(newEnv: typeof serverEnv) {
+  serverEnv = newEnv;
+}
+
 export function getEnv(key: string): string | undefined {
-  // HACK we may want to use a server-side context or something
-  return (globalThis as any).__WAKU_PRIVATE_ENV__[key];
+  return serverEnv[key];
 }
 
 type RenderStore<> = {
@@ -101,7 +109,7 @@ let currentRenderStore: RenderStore | undefined;
 /**
  * This is an internal function and not for public use.
  */
-export const runWithRenderStore = <T>(
+export const runWithRenderStoreInternal = <T>(
   renderStore: RenderStore,
   fn: () => T,
 ): T => {

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -64,17 +64,16 @@ export type EntriesPrd = EntriesDev & {
   publicIndexHtml: string;
 };
 
-let serverEnv: Record<string, string> = {};
-
 /**
  * This is an internal function and not for public use.
  */
-export function setAllEnvInternal(newEnv: typeof serverEnv) {
-  serverEnv = newEnv;
+export function setAllEnvInternal(newEnv: Record<string, string>) {
+  (globalThis as any).__WAKU_PRIVATE_ENV__ = newEnv;
 }
 
 export function getEnv(key: string): string | undefined {
-  return serverEnv[key];
+  // HACK for now. we may want to use module state or render store.
+  return (globalThis as any).__WAKU_PRIVATE_ENV__[key];
 }
 
 type RenderStore<> = {

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -64,16 +64,17 @@ export type EntriesPrd = EntriesDev & {
   publicIndexHtml: string;
 };
 
+let serverEnv: Record<string, string> = {};
+
 /**
  * This is an internal function and not for public use.
  */
-export function setAllEnvInternal(newEnv: Record<string, string>) {
-  (globalThis as any).__WAKU_PRIVATE_ENV__ = newEnv;
+export function setAllEnvInternal(newEnv: typeof serverEnv) {
+  serverEnv = newEnv;
 }
 
 export function getEnv(key: string): string | undefined {
-  // HACK for now. we may want to use module state or render store.
-  return (globalThis as any).__WAKU_PRIVATE_ENV__[key];
+  return serverEnv[key];
 }
 
 type RenderStore<> = {


### PR DESCRIPTION
using module variable instead of global variable. Now, possible without any workers.
