### PR TITLE
fix: load module for actions

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-entries.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-entries.ts
@@ -34,6 +34,7 @@ export function loadModule(id) {
     default: throw new Error('Cannot find module: ' + id);
   }
 }
+globalThis.__WAKU_SERVER_HACK_IMPORT__ = loadModule;
 `;
   let entriesFile = '';
   return {

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -112,13 +112,10 @@ export async function renderRsc(
     {
       get(_target, encodedId: string) {
         const [fileId, name] = encodedId.split('#') as [string, string];
-        const id = filePathToFileURL(fileId);
-        if (fileId.startsWith('@id/assets/')) {
-          const id = fileId.slice('@id/'.length);
-          return { id, chunks: [id], name, async: true };
-        } else {
-          return { id, chunks: [id], name, async: true };
-        }
+        const id = fileId.startsWith('@id/')
+          ? fileId.slice('@id/'.length)
+          : filePathToFileURL(fileId);
+        return { id, chunks: [id], name, async: true };
       },
     },
   );

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -114,7 +114,7 @@ export async function renderRsc(
         const [fileId, name] = encodedId.split('#') as [string, string];
         const id = filePathToFileURL(fileId);
         if (fileId.startsWith('@id/assets/')) {
-          const id = '.' + fileId.slice('@id'.length);
+          const id = fileId.slice('@id/'.length);
           return { id, chunks: [id], name, async: true };
         } else {
           return { id, chunks: [id], name, async: true };


### PR DESCRIPTION
oh, boy, this is huge.

There must be huge room for improvement with `vite-plugin-rsc-rsdw.ts`. We should never use `import` on the server in PRD.