### PR TITLE
Add support for React Compiler

### DIFF
--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -2,6 +2,11 @@ import type { Middleware } from './lib/middleware/types.js';
 
 export type { Middleware };
 
+export interface ReactCompilerOptions {
+  compilationMode?: 'infer' | 'annotation' | 'all'
+  panicThreshold?: 'ALL_ERRORS' | 'CRITICAL_ERRORS' | 'NONE'
+}
+
 export interface Config {
   /**
    * The base path for serve HTTP.
@@ -37,6 +42,13 @@ export interface Config {
    * Defaults to "RSC".
    */
   rscPath?: string;
+  /**
+   * Enable experimental React compiler optimization.
+   * Configuration accepts partial config object to the compiler, if provided
+   * compiler will be enabled.
+   * Defaults to false.
+   */
+  reactCompiler?: boolean | ReactCompilerOptions
   /**
    * Middleware to use
    * Defaults to:

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -387,20 +387,26 @@ const buildClientBundle = async (
     type === 'asset' && !fileName.endsWith('.js') ? [fileName] : [],
   );
   const cssAssets = nonJsAssets.filter((asset) => asset.endsWith('.css'));
-  const compilerOptions = typeof config.reactCompiler === 'boolean' ? {} : config.reactCompiler
+  const compilerOptions =
+    typeof config.reactCompiler === 'boolean' ? {} : config.reactCompiler;
   const clientBuildOutput = await buildVite({
     base: config.basePath,
     plugins: [
-      viteReact({
-        babel: {
-          plugins: [
-            config.reactCompiler ? ["babel-plugin-react-compiler", {
-              panicThreshold: 'NONE',
-              ...compilerOptions
-            }] : []
-          ]
-        }
-      }),
+      config.reactCompiler
+        ? viteReact({
+            babel: {
+              plugins: [
+                [
+                  'babel-plugin-react-compiler',
+                  {
+                    panicThreshold: 'NONE',
+                    ...compilerOptions,
+                  },
+                ],
+              ],
+            },
+          })
+        : viteReact(),
       rscRsdwPlugin(),
       rscIndexPlugin({
         ...config,

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -387,10 +387,20 @@ const buildClientBundle = async (
     type === 'asset' && !fileName.endsWith('.js') ? [fileName] : [],
   );
   const cssAssets = nonJsAssets.filter((asset) => asset.endsWith('.css'));
+  const compilerOptions = typeof config.reactCompiler === 'boolean' ? {} : config.reactCompiler
   const clientBuildOutput = await buildVite({
     base: config.basePath,
     plugins: [
-      viteReact(),
+      viteReact({
+        babel: {
+          plugins: [
+            config.reactCompiler ? ["babel-plugin-react-compiler", {
+              panicThreshold: 'NONE',
+              ...compilerOptions
+            }] : []
+          ]
+        }
+      }),
       rscRsdwPlugin(),
       rscIndexPlugin({
         ...config,

--- a/packages/waku/src/lib/config.ts
+++ b/packages/waku/src/lib/config.ts
@@ -24,6 +24,9 @@ export async function resolveConfig(config: Config) {
     preserveModuleDirs: ['pages', 'templates', 'routes', 'components'],
     privateDir: 'private',
     rscPath: 'RSC',
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    reactCompiler: false,
     middleware: DEFAULT_MIDDLEWARE,
     ...config,
   };

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -96,15 +96,15 @@ const createMainViteServer = (
       base: config.basePath,
       plugins: [
         patchReactRefresh(
-          viteReact({
-            babel: {
-              plugins: [
-                config.reactCompiler
-                  ? ['babel-plugin-react-compiler', reactCompilerOptions]
-                  : [],
-              ],
-            },
-          }),
+          config.reactCompiler
+            ? viteReact({
+                babel: {
+                  plugins: [
+                    ['babel-plugin-react-compiler', reactCompilerOptions],
+                  ],
+                },
+              })
+            : viteReact(),
         ),
         nonjsResolvePlugin(),
         devCommonJsPlugin({

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -88,12 +88,24 @@ const createMainViteServer = (
   configPromise: ReturnType<typeof resolveConfig>,
 ) => {
   const vitePromise = configPromise.then(async (config) => {
+    const reactCompilerOptions =
+      typeof config.reactCompiler === 'boolean' ? {} : config.reactCompiler;
     const mergedViteConfig = await mergeUserViteConfig({
       // Since we have multiple instances of vite, different ones might overwrite the others' cache.
       cacheDir: 'node_modules/.vite/waku-dev-server-main',
       base: config.basePath,
       plugins: [
-        patchReactRefresh(viteReact()),
+        patchReactRefresh(
+          viteReact({
+            babel: {
+              plugins: [
+                config.reactCompiler
+                  ? ['babel-plugin-react-compiler', reactCompilerOptions]
+                  : [],
+              ],
+            },
+          }),
+        ),
         nonjsResolvePlugin(),
         devCommonJsPlugin({
           filter: (id) => {


### PR DESCRIPTION
Now the users can enable the react compiler by adding a new field `reactCompiler: true` in the `waku.config.ts` file.

Let's take a look at the effects before and after enabling react compiler optimization.

```
const Child = () => {
  console.log("render");
  return <div>Child</div>;
};

export const Counter = () => {
  const [count, setCount] = useState(0);

  const handleIncrement = () => setCount((c) => c + 1);

  return (
    <section className="border-blue-400 -mx-4 mt-4 rounded border border-dashed p-4">
      <div>Count: {count}</div>
      <button
        onClick={handleIncrement}
        className="rounded-sm bg-black px-2 py-0.5 text-sm text-white"
      >
        Increment
      </button>
      <Child />
    </section>
  );
};
```

When the Child component re-renders, it will console "render".

before enabling the react compiler:
![20240828231420_rec_](https://github.com/user-attachments/assets/141f408b-3a27-4388-b7be-4186a103b06f)

after enabling the react compiler:
![20240828230748_rec_](https://github.com/user-attachments/assets/8a65ba71-119e-4409-9d62-d154b5557628)
