### PR TITLE
feat: infer types for waku router

### DIFF
--- a/docs/create-pages.mdx
+++ b/docs/create-pages.mdx
@@ -19,22 +19,64 @@ import { createPages } from 'waku';
 import { RootLayout } from './templates/root-layout';
 import { HomePage } from './templates/home-page';
 
-export default createPages(async ({ createPage, createLayout }) => {
+const pages = createPages(async ({ createPage, createLayout }) => [
   // Create root layout
   createLayout({
     render: 'static',
     path: '/',
     component: RootLayout,
-  });
+  }),
 
   // Create home page
   createPage({
     render: 'dynamic',
     path: '/',
     component: HomePage,
-  });
-});
+  }),
+]);
+
+export default pages;
 ```
+
+### Router Paths Type Safety
+
+Waku provides inference for the router paths when created pages are returned from the callback passed into `createPages`. The following example shows how a minimal example for how to setup the router paths type safety.
+
+```tsx
+// ./src/entries.tsx
+import { createPages } from 'waku';
+import type { PathsForPages } from 'waku/router';
+
+import { HomePage } from './templates/home-page';
+
+const pages = createPages(async ({ createPage, createLayout }) => [
+  // Create root layout
+  createLayout({
+    render: 'static',
+    path: '/',
+    component: RootLayout,
+  }),
+
+  // Create home page
+  createPage({
+    render: 'dynamic',
+    path: '/',
+    component: HomePage,
+  }),
+]);
+
+declare module 'waku/router' {
+  interface RouteConfig {
+    paths: PathsForPages<typeof pages>;
+  }
+}
+
+export default pages;
+```
+
+Once this is done, any `<Link />` component or hook from `waku/router` that uses paths in your app will use this type. In this case, the one valid use would be `<Link to="/" />`, but as you add more pages to the router, this type will grow to include them.
+
+Note: The file-based router paths will be supported in the future with some form of code-generation to get the types from your local page files.
 
 ### Pages
 
@@ -49,21 +91,21 @@ import { createPages } from 'waku';
 import { AboutPage } from './templates/about-page';
 import { BlogIndexPage } from './templates/blog-index-page';
 
-export default createPages(async ({ createPage }) => {
+export default createPages(async ({ createPage }) => [
   // Create about page
   createPage({
     render: 'static',
     path: '/about',
     component: AboutPage,
-  });
+  }),
 
   // Create blog index page
   createPage({
     render: 'static',
     path: '/blog',
     component: BlogIndexPage,
-  });
-});
+  }),
+]);
 ```
 
 #### Segment routes
@@ -79,7 +121,7 @@ import { createPages } from 'waku';
 import { BlogArticlePage } from './templates/blog-article-page';
 import { ProductCategoryPage } from './templates/product-category-page';
 
-export default createPages(async ({ createPage }) => {
+export default createPages(async ({ createPage }) => [
   // Create blog article pages
   // `<BlogArticlePage>` receives `slug` prop
   createPage({
@@ -87,7 +129,7 @@ export default createPages(async ({ createPage }) => {
     path: '/blog/[slug]',
     staticPaths: ['introducing-waku', 'introducing-create-pages'],
     component: BlogArticlePage,
-  });
+  }),
 
   // Create product category pages
   // `<ProductCategoryPage>` receives `category` prop
@@ -95,8 +137,8 @@ export default createPages(async ({ createPage }) => {
     render: 'dynamic',
     path: '/shop/[category]',
     component: ProductCategoryPage,
-  });
-});
+  }),
+]);
 ```
 
 Static paths (or other values) could also be generated programmatically.
@@ -111,12 +153,14 @@ import { BlogArticlePage } from './templates/blog-article-page';
 export default createPages(async ({ createPage }) => {
   const blogPaths = await getBlogPaths();
 
-  createPage({
-    render: 'static',
-    path: '/blog/[slug]',
-    staticPaths: blogPaths,
-    component: BlogArticlePage,
-  });
+  return [
+    createPage({
+      render: 'static',
+      path: '/blog/[slug]',
+      staticPaths: blogPaths,
+      component: BlogArticlePage,
+    }),
+  ];
 });
 ```
 
@@ -130,15 +174,15 @@ import { createPages } from 'waku';
 
 import { ProductDetailPage } from './templates/product-detail-page';
 
-export default createPages(async ({ createPage }) => {
+export default createPages(async ({ createPage }) => [
   // Create product detail pages
   // `<ProductDetailPage>` receives `category` and `product` props
   createPage({
     render: 'dynamic',
     path: '/shop/[category]/[product]',
     component: ProductDetailPage,
-  });
-});
+  }),
+]);
 ```
 
 For static prerendering of nested segment routes, the `staticPaths` array is instead composed of ordered arrays.
@@ -149,7 +193,7 @@ import { createPages } from 'waku';
 
 import { ProductDetailPage } from './templates/product-detail-page';
 
-export default createPages(async ({ createPage }) => {
+export default createPages(async ({ createPage }) => [
   // Create product detail pages
   // `<ProductDetailPage>` receives `category` and `product` props
   createPage({
@@ -160,8 +204,8 @@ export default createPages(async ({ createPage }) => {
       ['some-category', 'another-product'],
     ],
     component: ProductDetailPage,
-  });
-});
+  }),
+]);
 ```
 
 #### Catch-all routes
@@ -176,7 +220,7 @@ import { createPages } from 'waku';
 
 import { DashboardPage } from './templates/dashboard-page';
 
-export default createPages(async ({ createPage }) => {
+export default createPages(async ({ createPage }) => [
   // Create account dashboard
   // `<DashboardPage>` receives `catchAll` prop (string[])
   createPage({
@@ -184,7 +228,7 @@ export default createPages(async ({ createPage }) => {
     path: '/app/[...catchAll]',
     component: DashboardPage,
   });
-});
+]);
 ```
 
 ### Layouts
@@ -201,14 +245,14 @@ import { createPages } from 'waku';
 
 import { RootLayout } from './templates/root-layout';
 
-export default createPages(async ({ createLayout }) => {
+export default createPages(async ({ createLayout }) => [
   // Add a global header and footer
   createLayout({
     render: 'static',
     path: '/',
     component: RootLayout,
-  });
-});
+  }),
+]);
 ```
 
 ```tsx
@@ -255,14 +299,14 @@ import { createPages } from 'waku';
 
 import { BlogLayout } from './templates/blog-layout';
 
-export default createPages(async ({ createLayout }) => {
+export default createPages(async ({ createLayout }) => [
   // Add a sidebar to the blog index and blog article pages
   createLayout({
     render: 'static',
     path: '/blog',
     component: BlogLayout,
-  });
-});
+  }),
+]);
 ```
 
 ```tsx

--- a/e2e/fixtures/render-type/src/entries.tsx
+++ b/e2e/fixtures/render-type/src/entries.tsx
@@ -3,27 +3,33 @@ import { createPages } from 'waku/router/server';
 import { ServerEcho } from './ServerEcho.js';
 import { ClientEcho } from './ClientEcho.js';
 
-export default createPages(async ({ createPage }) => {
-  createPage({
-    render: 'dynamic',
-    path: '/server/dynamic/[echo]',
-    component: ServerEcho,
-  });
-  createPage({
-    render: 'static',
-    path: '/server/static/[echo]',
-    staticPaths: ['static-echo'],
-    component: ServerEcho,
-  });
-  createPage({
-    render: 'dynamic',
-    path: '/client/dynamic/[echo]',
-    component: ClientEcho,
-  });
-  createPage({
-    render: 'static',
-    path: '/client/static/[echo]',
-    staticPaths: ['static-echo'],
-    component: ClientEcho,
-  });
-});
+// This needs type annotations for the return type of createPages
+// @see https://github.com/microsoft/TypeScript/issues/42873#issuecomment-2065572017
+const router: ReturnType<typeof createPages> = createPages(
+  async ({ createPage }) => [
+    createPage({
+      render: 'dynamic',
+      path: '/server/dynamic/[echo]',
+      component: ServerEcho,
+    }),
+    createPage({
+      render: 'static',
+      path: '/server/static/[echo]',
+      staticPaths: ['static-echo'],
+      component: ServerEcho,
+    }),
+    createPage({
+      render: 'dynamic',
+      path: '/client/dynamic/[echo]',
+      component: ClientEcho,
+    }),
+    createPage({
+      render: 'static',
+      path: '/client/static/[echo]',
+      staticPaths: ['static-echo'],
+      component: ClientEcho,
+    }),
+  ],
+);
+
+export default router;

--- a/examples/07_router/src/entries.tsx
+++ b/examples/07_router/src/entries.tsx
@@ -1,5 +1,6 @@
 import { lazy } from 'react';
 import { createPages } from 'waku';
+import type { PathsForPages } from 'waku/router';
 
 import FooPage from './components/FooPage';
 
@@ -10,51 +11,51 @@ const BarPage = lazy(() => import('./components/BarPage'));
 const NestedBazPage = lazy(() => import('./components/NestedBazPage'));
 const NestedQuxPage = lazy(() => import('./components/NestedQuxPage'));
 
-export default createPages(async ({ createPage, createLayout }) => {
+const pages = createPages(async ({ createPage, createLayout }) => [
   createLayout({
     render: 'static',
     path: '/',
     component: HomeLayout,
-  });
+  }),
 
   createPage({
     render: 'static',
     // render: 'dynamic',
     path: '/',
     component: HomePage,
-  });
+  }),
 
   createPage({
     render: 'static',
     // render: 'dynamic',
     path: '/foo',
     component: FooPage,
-  });
+  }),
 
   createPage({
     render: 'static',
     path: '/bar',
     component: BarPage,
-  });
+  }),
 
   createPage({
     render: 'dynamic',
     path: '/baz',
     // Inline component is also possible.
     component: () => <h2>Dynamic: Baz</h2>,
-  });
+  }),
 
   createPage({
     render: 'static',
     path: '/nested/baz',
     component: NestedBazPage,
-  });
+  }),
 
   createPage({
     render: 'static',
     path: '/nested/qux',
     component: NestedQuxPage,
-  });
+  }),
 
   createPage({
     render: 'static',
@@ -66,7 +67,7 @@ export default createPages(async ({ createPage, createLayout }) => {
         <h3>Static: {id}</h3>
       </>
     ),
-  });
+  }),
 
   createPage({
     render: 'dynamic',
@@ -77,7 +78,7 @@ export default createPages(async ({ createPage, createLayout }) => {
         <h3>Dynamic: {id}</h3>
       </>
     ),
-  });
+  }),
 
   createPage({
     render: 'dynamic',
@@ -85,12 +86,20 @@ export default createPages(async ({ createPage, createLayout }) => {
     component: ({ all }: { all: string[] }) => (
       <h2>Catch-all: {all.join('/')}</h2>
     ),
-  });
+  }),
 
   // Custom Not Found page
   createPage({
     render: 'static',
     path: '/404',
     component: () => <h2>Not Found</h2>,
-  });
-});
+  }),
+]);
+
+declare module 'waku/router' {
+  interface RouteConfig {
+    paths: PathsForPages<typeof pages>;
+  }
+}
+
+export default pages;

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/server.d.ts",
       "default": "./dist/server.js"
     },
+    "./router": {
+      "types": "./dist/router/base-types.d.ts",
+      "default": "./dist/router/base-types.js"
+    },
     "./router/client": {
       "types": "./dist/router/client.d.ts",
       "default": "./dist/router/client.js"

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -1,0 +1,6 @@
+export type { PathsForPages } from './create-pages-utils/inferred-path-types.js';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RouteConfig {
+  // routes to be overridden by users
+}

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -31,6 +31,11 @@ import {
   LOCATION_ID,
 } from './common.js';
 import type { RouteProps, ShouldSkip } from './common.js';
+import type { RouteConfig } from './base-types.js';
+
+type InferredPaths = RouteConfig extends { paths: infer UserPaths }
+  ? UserPaths
+  : string;
 
 declare global {
   interface ImportMeta {
@@ -82,7 +87,7 @@ export function useRouter_UNSTABLE() {
   }
   const { route, changeRoute, prefetchRoute } = router;
   const push = useCallback(
-    (to: string) => {
+    (to: InferredPaths) => {
       const url = new URL(to, window.location.href);
       window.history.pushState(
         {
@@ -97,7 +102,7 @@ export function useRouter_UNSTABLE() {
     [changeRoute],
   );
   const replace = useCallback(
-    (to: string) => {
+    (to: InferredPaths) => {
       const url = new URL(to, window.location.href);
       window.history.replaceState(window.history.state, '', url);
       changeRoute(parseRoute(url));
@@ -135,7 +140,7 @@ export function useRouter_UNSTABLE() {
 }
 
 export type LinkProps = {
-  to: string;
+  to: InferredPaths;
   pending?: ReactNode;
   notPending?: ReactNode;
   children: ReactNode;

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -1,0 +1,142 @@
+import type { PathWithoutSlug } from '../create-pages.js';
+import type { Join, ReplaceAll, Split } from '../util-types.js';
+
+type StaticSlugPage = {
+  path: string;
+  render: 'static';
+  staticPaths: (string | string[])[];
+};
+
+type DynamicPage = {
+  path: string;
+  render: 'dynamic';
+};
+
+type IsPageWithSlug<Page extends AnyPage> = Page extends {
+  path: infer P;
+}
+  ? P extends PathWithoutSlug<P>
+    ? false
+    : true
+  : never;
+
+/** Used to replace a single slug param [mySlug] with a union of possible slugs 'foo' | 'bar' */
+type ReplaceSlugSet<
+  Path extends string,
+  Slugs extends string,
+> = Slugs extends unknown ? ReplaceAll<Path, `[${string}]`, Slugs> : never;
+
+/**
+ * This will replace slugs in the path with each entry to a string[][] passed to staticPaths.
+ *
+ * For example, if the path is `/foo/[...slug]` and the staticPaths is [['a', 'b'], ['c']],
+ * the result will be `/foo/a/b` | `/foo/c`.
+ *
+ * And if the path is `/foo/[slug1]/[slug2]` and the staticPaths is [['a', 'b'], ['c', 'd']],
+ * the result will be `/foo/a/b` | `/foo/c/d`.
+ */
+type ReplaceHelper<
+  SplitPath extends string[],
+  StaticSlugs extends string[],
+  // SlugCountArr is a counter for the number of slugs added to result so far
+  SlugCountArr extends null[] = [],
+  Result extends string[] = [],
+> = SplitPath extends [
+  infer PathPart extends string,
+  ...infer Rest extends string[],
+]
+  ? PathPart extends `[...${string}]`
+    ? [...Result, ...StaticSlugs] // Wildcard always comes last
+    : PathPart extends `[${string}]`
+      ? ReplaceHelper<
+          Rest,
+          StaticSlugs,
+          [...SlugCountArr, null],
+          [...Result, StaticSlugs[SlugCountArr['length']]]
+        >
+      : ReplaceHelper<Rest, StaticSlugs, SlugCountArr, [...Result, PathPart]>
+  : Result;
+
+/**
+ * Entry point to ReplaceHelper that Splits the path to start and Joins the final result.
+ * This also loops over each possible StaticPathSet for when staticPaths is a string[][].
+ * The looping is done by `StaticPathSet extends unknown`.
+ */
+type ReplaceTupleStaticPaths<
+  Path extends string,
+  StaticPathSet extends string[],
+> = StaticPathSet extends unknown
+  ? Join<ReplaceHelper<Split<Path, '/'>, StaticPathSet>, '/'>
+  : never;
+
+/** staticPaths could be a string or a string[][]. This type acts as an if else to handle each type of staticPaths. */
+type CollectPathsForStaticSlugPage<Page extends StaticSlugPage> = Page extends {
+  path: infer Path extends string;
+  render: 'static';
+  staticPaths: infer StaticPaths extends string[] | string[][];
+}
+  ? StaticPaths extends string[]
+    ? ReplaceSlugSet<Path, StaticPaths[number]>
+    : StaticPaths extends string[][]
+      ? ReplaceTupleStaticPaths<Path, StaticPaths[number]>
+      : never
+  : never;
+
+/** Simply replace all slugs with any string for dynamic pages.*/
+type CollectPathsForDynamicSlugPage<Page extends DynamicPage> = Page extends {
+  path: infer Path extends string;
+}
+  ? ReplaceAll<Path, `[${string}]`, string>
+  : never;
+
+/**
+ * CollectPaths takes each page of type AnyPage and maps over them to get the paths for that page.
+ *
+ * You can consider this the entry point to each of the page => path mappings.
+ *
+ * - Pages with no slugs will return the path as is.
+ * - Static pages with slugs will return the path with the slugs replaced with the staticPaths.
+ * - Dynamic pages with slugs will return the path with the slugs replaced with any string.
+ *   (e.g., `/[slug]` => `/${string}`)
+ */
+export type CollectPaths<EachPage extends AnyPage> = EachPage extends unknown
+  ? IsPageWithSlug<EachPage> extends true
+    ? EachPage extends StaticSlugPage
+      ? CollectPathsForStaticSlugPage<EachPage>
+      : EachPage extends DynamicPage
+        ? CollectPathsForDynamicSlugPage<EachPage>
+        : never
+    : EachPage['path']
+  : never;
+
+/** Generic type that represents any page. This is used to infer the return type of createPages. */
+export type AnyPage = {
+  path: string;
+  render: 'static' | 'dynamic';
+  staticPaths?: string[] | string[][];
+};
+
+/**
+ * PathsForPages will take the response of createPages and return the paths for all user defined pages.
+ *
+ * @example
+ * const pages = createPages(async ({ createPage }) => [
+ *   createPage({
+ *     render: 'static',
+ *     path: '/foo',
+ *     component: Foo,
+ *   }),
+ *   createPage({
+ *     render: 'static',
+ *     path: '/bar',
+ *     component: Bar,
+ *   }),
+ * ]);
+ *
+ * type MyPaths = PathsForPages<typeof pages>;
+ * // type MyPaths = '/foo' | '/bar';
+ */
+export type PathsForPages<PagesResult extends { DO_NOT_USE_pages: AnyPage }> =
+  CollectPaths<PagesResult['DO_NOT_USE_pages']> extends never
+    ? string
+    : CollectPaths<PagesResult['DO_NOT_USE_pages']> & {};

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -80,5 +80,6 @@ export function fsRouter(
         });
       }
     }
+    return []; // TODO this type support for fsRouter pages
   });
 }

--- a/packages/waku/src/router/util-types.ts
+++ b/packages/waku/src/router/util-types.ts
@@ -1,0 +1,184 @@
+/**
+ * Type version of `String.prototype.split()`. Splits the first string argument by the second string argument
+ * @example
+ * ```ts
+ * // ['a', 'b', 'c']
+ * type Case1 = Split<'abc', ''>
+ * // ['a', 'b', 'c']
+ * type Case2 = Split<'a,b,c', ','>
+ * ```
+ */
+export type Split<
+  Str extends string,
+  Del extends string | number,
+> = string extends Str
+  ? string[]
+  : '' extends Str
+    ? []
+    : Str extends `${infer T}${Del}${infer U}`
+      ? [T, ...Split<U, Del>]
+      : [Str];
+
+/**
+ * Accepts a boolean and returns `true` if the passed type is `false`, otherwise returns `true`
+ * @example
+ * ```ts
+ * // false
+ * type Case1 = Not<true>
+ * // true
+ * type Case2 = Not<false>
+ * ```
+ */
+type Not<T extends boolean> = T extends true ? false : true;
+
+/**
+ * Returns boolean whether the first argument extends the second argument
+ * @example
+ * ```ts
+ * // true
+ * type Case1 = Extends<1, number>
+ * // false
+ * type Case2 = Extends<number, 1>
+ * ```
+ */
+type Extends<T, Base> = [T] extends [Base] ? true : false;
+
+/**
+ * Returns boolean whether the first argument doesn't extend the second argument
+ * @example
+ * ```ts
+ * // false
+ * type Case1 = Extends<1, number>
+ * // true
+ * type Case2 = Extends<number, 1>
+ * ```
+ */
+type NotExtends<T, Base> = Not<Extends<T, Base>>;
+
+/**
+ * Returns a boolean whether the first array argument is fixed length tuple
+ * @example
+ * ```ts
+ * // true
+ * type Case1 = IsTuple<[1, 2, 3]>
+ * // false
+ * type Case2 = IsTuple<number[]>
+ * ```
+ */
+type IsTuple<T extends readonly unknown[]> = NotExtends<number, T['length']>;
+
+/**
+ * Returns the second argument if the first argument is `true` (defaults to `true`), otherwise returns the third argument (defaults to `false`)
+ * ```ts
+ * // valid
+ * type Case1 = If<true, 'valid'>
+ * // invalid
+ * type Case2 = If<false, 'valid', 'invalid'>
+ * ```
+ */
+type If<Condition, IfTrue = true, IfFalse = false> = Condition extends true
+  ? IfTrue
+  : IfFalse;
+
+/**
+ * Returns the first argument if it is an empty array, otherwise returns `never`
+ * @example
+ * ```ts
+ * // never
+ * type Result = EmptyArray<[1]>
+ * ```
+ */
+type EmptyArray<T extends readonly unknown[]> = T extends readonly [
+  unknown,
+  ...unknown[],
+]
+  ? never
+  : T;
+
+/**
+ * Returns a boolean if the passed type is `never`
+ * @example
+ * ```ts
+ * // true
+ * type Case1 = IsNever<never>
+ * // false
+ * type Case2 = IsNever<true>
+ * ```
+ */
+type IsNever<T> = [T] extends [never] ? true : false;
+
+/**
+ * Returns a boolean whether the passed argument is an empty array
+ * @example
+ * ```ts
+ * // false
+ * type Result - IsEmptyArray<[1]>
+ */
+type IsEmptyArray<T extends readonly unknown[]> = If<
+  IsNever<EmptyArray<T>>,
+  false,
+  true
+>;
+
+/**
+ *  Returns the second argument if the first argument is an empty array (defaults to `true`), otherwise returns the third argument (defaults to `false`)
+ * @example
+ * ```ts
+ * // string
+ * type Result = IfEmptyArray<[], string, number>
+ * ```
+ */
+type IfEmptyArray<
+  T extends readonly unknown[],
+  IfTrue = true,
+  IfFalse = false,
+> = If<IsEmptyArray<T>, IfTrue, IfFalse>;
+
+/**
+ * Type version of `Array.prototype.join()`. Joins the first array argument by the second argument
+ * @example
+ * ```ts
+ * // 'a-p-p-l-e'
+ * type Case1 = Join<["a", "p", "p", "l", "e"], "-">
+ * // '21212'
+ * type Case2 = Join<["2", "2", "2"], 1>
+ * // 'o'
+ * type Case3 = Join<["o"], "u">
+ * ```
+ */
+export type Join<
+  T extends readonly (string | number)[],
+  Glue extends string | number,
+> =
+  IsTuple<T> extends true
+    ? T extends readonly [
+        infer First extends string | number,
+        ...infer Rest extends readonly (string | number)[],
+      ]
+      ? IfEmptyArray<Rest, First, `${First}${Glue}${Join<Rest, Glue>}`>
+      : never
+    : never;
+
+/**
+ * Replaces all occurrences of the second string argument with the third string argument in the first string argument
+ * @example
+ * ```ts
+ * // 'remove him him'
+ * type Case1 = ReplaceAll<'remove me me', 'me', 'him'>
+ * // 'remove me me'
+ * type Case2 = ReplaceAll<'remove me me', 'us', 'him'>
+ * ```
+ */
+export type ReplaceAll<
+  T extends string,
+  Pivot extends string,
+  ReplaceBy extends string,
+> = T extends `${infer A}${Pivot}${infer B}`
+  ? ReplaceAll<`${A}${ReplaceBy}${B}`, Pivot, ReplaceBy>
+  : T;
+
+/**
+ * This helper makes types more readable
+ * @see https://www.totaltypescript.com/concepts/the-prettify-helper
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -18,6 +18,87 @@ import { createElement } from 'react';
 import type { PropsWithChildren } from 'react';
 import { renderToString } from 'react-dom/server';
 import { expectType } from 'ts-expect';
+import type { TypeEqual } from 'ts-expect';
+import type { PathsForPages } from '../src/router/base-types.js';
+
+function Fake() {
+  return null;
+}
+const complexTestRouter = (fn: typeof createPages, component = Fake) => {
+  return fn(async ({ createPage }) => {
+    // Dynamic pages
+    const dynamicNoSlug = createPage({
+      render: 'dynamic',
+      path: '/client/dynamic',
+      component,
+    });
+    const dynamicOneSlugPage = createPage({
+      render: 'dynamic',
+      path: '/server/one/[echo]',
+      component,
+    });
+    const dynamicTwoSlugPage = createPage({
+      render: 'dynamic',
+      path: '/server/two/[echo]/[echo2]',
+      component,
+    });
+    const dynamicWildcardPage = createPage({
+      render: 'dynamic',
+      path: '/server/wild/[...wild]',
+      component,
+    });
+    const dynamicSlugAndWildcardPage = createPage({
+      render: 'dynamic',
+      path: '/server/oneAndWild/[slug]/[...wild]',
+      component,
+    });
+
+    // Static pages
+    const staticNoSlug = createPage({
+      render: 'static',
+      path: '/client/static',
+      component,
+    });
+    const staticOneSlugPage = createPage({
+      render: 'static',
+      path: '/server/static/[echo]',
+      staticPaths: ['static-echo', 'static-echo-2'] as const,
+      component,
+    });
+    const staticTwoSlugPage = createPage({
+      render: 'static',
+      path: '/server/static/[echo]/[echo2]',
+      staticPaths: [
+        ['static-echo', 'static-echo-2'],
+        ['hello', 'hello-2'],
+      ] as const,
+      component,
+    });
+    const staticWildcardPage = createPage({
+      render: 'static',
+      path: '/static/wild/[...wild]',
+      staticPaths: [
+        ['bar'],
+        ['hello', 'hello-2'],
+        ['foo', 'foo-2', 'foo-3'],
+      ] as const,
+      component,
+    });
+
+    return [
+      dynamicNoSlug,
+      dynamicOneSlugPage,
+      dynamicTwoSlugPage,
+      dynamicWildcardPage,
+      dynamicSlugAndWildcardPage,
+
+      staticNoSlug,
+      staticOneSlugPage,
+      staticTwoSlugPage,
+      staticWildcardPage,
+    ];
+  });
+};
 
 describe('type tests', () => {
   it('PathWithoutSlug', () => {
@@ -184,6 +265,139 @@ describe('type tests', () => {
       createLayout({ render: 'dynamic', path: '/', component: () => 'Hello' });
     });
   });
+
+  describe('createPages', () => {
+    it('empty', () => {
+      const mockedCreatePages: typeof createPages = vi.fn();
+
+      // @ts-expect-error: null is not a valid return type
+      mockedCreatePages(async () => null);
+
+      // @ts-expect-error: page result is not returned
+      const _emptyRouterDynamic = mockedCreatePages(async ({ createPage }) => {
+        createPage({ render: 'dynamic', path: '/', component: () => 'Hello' });
+      });
+
+      // @ts-expect-error: page result is not returned
+      const _emptyRouterStatic = mockedCreatePages(async ({ createPage }) => {
+        createPage({ render: 'static', path: '/', component: () => 'Hello' });
+      });
+
+      // good and empty
+      const _emptyRouter = mockedCreatePages(async () => []);
+      expectType<TypeEqual<PathsForPages<typeof _emptyRouter>, string>>(true);
+    });
+
+    it('static', () => {
+      const mockedCreatePages: typeof createPages = vi.fn();
+
+      // good and single page
+      const _singlePageRouter = mockedCreatePages(async ({ createPage }) => [
+        createPage({ render: 'static', path: '/', component: () => 'Hello' }),
+      ]);
+      expectType<TypeEqual<PathsForPages<typeof _singlePageRouter>, '/'>>(true);
+
+      // good with multiple pages
+      const _multiplePageRouter = mockedCreatePages(async ({ createPage }) => [
+        createPage({ render: 'static', path: '/', component: () => 'Hello' }),
+        createPage({ render: 'static', path: '/foo', component: () => 'Foo' }),
+        createPage({
+          render: 'static',
+          path: '/bar/[slug]',
+          staticPaths: ['a', 'b'] as const,
+          component: () => 'Bar',
+        }),
+        createPage({
+          render: 'static',
+          path: '/buzz/[...slug]',
+          staticPaths: [['a'], ['b', 'c'], ['hello', 'world']] as const,
+          component: () => 'Bar',
+        }),
+      ]);
+      expectType<
+        TypeEqual<
+          PathsForPages<typeof _multiplePageRouter>,
+          | '/'
+          | '/foo'
+          | '/bar/a'
+          | '/bar/b'
+          | '/buzz/a'
+          | '/buzz/b/c'
+          | '/buzz/hello/world'
+        >
+      >(true);
+    });
+
+    it('dynamic', () => {
+      const mockedCreatePages: typeof createPages = vi.fn();
+
+      // good and single page
+      const _singlePageRouter = mockedCreatePages(async ({ createPage }) => [
+        createPage({ render: 'dynamic', path: '/', component: () => 'Hello' }),
+      ]);
+      expectType<TypeEqual<PathsForPages<typeof _singlePageRouter>, '/'>>(true);
+
+      // good with multiple pages
+      const _multiplePageRouter = mockedCreatePages(async ({ createPage }) => [
+        createPage({ render: 'dynamic', path: '/', component: () => 'Hello' }),
+        createPage({ render: 'dynamic', path: '/foo', component: () => 'Foo' }),
+        createPage({
+          render: 'dynamic',
+          path: '/bar/[slug]',
+          component: () => 'Bar',
+        }),
+        createPage({
+          render: 'dynamic',
+          path: '/buzz/thing/[...slug]',
+          component: () => 'Bar',
+        }),
+      ]);
+      expectType<
+        TypeEqual<
+          PathsForPages<typeof _multiplePageRouter>,
+          '/' | '/foo' | `/bar/${string}` | `/buzz/thing/${string}`
+        >
+      >(true);
+    });
+
+    it('static + dynamic mixed', () => {
+      const mockedCreatePages: typeof createPages = vi.fn();
+
+      // good and simple
+      const _simpleRouter = mockedCreatePages(async ({ createPage }) => [
+        createPage({ render: 'dynamic', path: '/', component: () => 'Hello' }),
+        createPage({
+          render: 'static',
+          path: '/about',
+          component: () => 'about me',
+        }),
+      ]);
+      expectType<
+        TypeEqual<PathsForPages<typeof _simpleRouter>, '/' | '/about'>
+      >(true);
+
+      // good and complex
+      const _complexRouter = complexTestRouter(mockedCreatePages);
+      expectType<
+        TypeEqual<
+          PathsForPages<typeof _complexRouter>,
+          | '/client/dynamic'
+          | '/client/static'
+          | `/server/one/${string}`
+          | `/server/two/${string}/${string}`
+          | `/server/wild/${string}`
+          | `/server/oneAndWild/${string}/${string}`
+          | '/server/static/static-echo'
+          | '/server/static/static-echo-2'
+          | '/server/static/static-echo/static-echo-2'
+          | '/server/static/hello/hello-2'
+          | '/static/wild/hello/hello-2'
+          | '/static/wild/bar'
+          | '/static/wild/foo/foo-2/foo-3'
+        >
+      >(true);
+    });
+  });
 });
 
 const defineRouterMock = unstable_defineRouter as MockedFunction<
@@ -211,16 +425,16 @@ function injectedFunctions() {
 describe('createPages', () => {
   it('creates a simple static page', async () => {
     const TestPage = () => null;
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
 
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: true,
@@ -238,7 +452,7 @@ describe('createPages', () => {
     const setShouldSkip = vi.fn();
 
     expect(
-      await getComponent!('test/page', {
+      await getComponent('test/page', {
         unstable_setShouldSkip: setShouldSkip,
       }),
     ).toBe(TestPage);
@@ -248,15 +462,15 @@ describe('createPages', () => {
 
   it('creates a simple dynamic page', async () => {
     const TestPage = () => null;
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'dynamic',
         path: '/test',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: false,
@@ -283,21 +497,21 @@ describe('createPages', () => {
   it('creates a simple static page with a layout', async () => {
     const TestPage = () => null;
     const TestLayout = ({ children }: PropsWithChildren) => children;
-    createPages(async ({ createPage, createLayout }) => {
+    createPages(async ({ createPage, createLayout }) => [
       createLayout({
         render: 'static',
         path: '/',
         component: TestLayout,
-      });
+      }),
       createPage({
         render: 'static',
         path: '/test',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
 
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: true,
@@ -334,21 +548,21 @@ describe('createPages', () => {
   it('creates a simple dynamic page with a layout', async () => {
     const TestPage = () => null;
     const TestLayout = ({ children }: PropsWithChildren) => children;
-    createPages(async ({ createPage, createLayout }) => {
+    createPages(async ({ createPage, createLayout }) => [
       createLayout({
         render: 'dynamic',
         path: '/',
         component: TestLayout,
-      });
+      }),
       createPage({
         render: 'dynamic',
         path: '/test',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
 
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: false,
@@ -384,15 +598,15 @@ describe('createPages', () => {
 
   it('creates a nested static page', async () => {
     const TestPage = () => null;
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test/nested',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: true,
@@ -422,15 +636,15 @@ describe('createPages', () => {
 
   it('creates a nested dynamic page', async () => {
     const TestPage = () => null;
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'dynamic',
         path: '/test/nested',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: false,
@@ -460,7 +674,7 @@ describe('createPages', () => {
 
   it('creates a static page with slugs', async () => {
     const TestPage = vi.fn();
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test/[a]/[b]',
@@ -469,10 +683,10 @@ describe('createPages', () => {
           ['y', 'z'],
         ],
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: true,
@@ -528,15 +742,15 @@ describe('createPages', () => {
 
   it('creates a dynamic page with slugs', async () => {
     const TestPage = vi.fn();
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'dynamic',
         path: '/test/[a]/[b]',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: false,
@@ -572,16 +786,16 @@ describe('createPages', () => {
 
   it('creates a static page with wildcards', async () => {
     const TestPage = vi.fn();
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test/[...path]',
         staticPaths: [['a', 'b']],
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: true,
@@ -617,15 +831,15 @@ describe('createPages', () => {
 
   it('creates a dynamic page with wildcards', async () => {
     const TestPage = vi.fn();
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'dynamic',
         path: '/test/[...path]',
         component: TestPage,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig, getComponent } = injectedFunctions();
-    expect(await getPathConfig!()).toEqual([
+    expect(await getPathConfig()).toEqual([
       {
         data: undefined,
         isStatic: false,
@@ -656,15 +870,15 @@ describe('createPages', () => {
   });
 
   it('fails if static paths do not match the slug pattern', async () => {
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test/[a]/[b]',
         // @ts-expect-error: staticPaths should be an array of strings or [string, string][]
         staticPaths: [['w']],
         component: () => null,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig } = injectedFunctions();
     await expect(getPathConfig).rejects.toThrowError(
       'staticPaths does not match with slug pattern',
@@ -672,20 +886,20 @@ describe('createPages', () => {
   });
 
   it('allows to disable SSR on static and dynamic pages', async () => {
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/static',
         component: () => null,
         unstable_disableSSR: true,
-      });
+      }),
       createPage({
         render: 'dynamic',
         path: '/dynamic',
         component: () => null,
         unstable_disableSSR: true,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig } = injectedFunctions();
     expect(await getPathConfig()).toEqual([
       {
@@ -716,18 +930,18 @@ describe('createPages', () => {
   });
 
   it('fails if duplicated dynamic paths are registered', async () => {
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'dynamic',
         path: '/test',
         component: () => null,
-      });
+      }),
       createPage({
         render: 'dynamic',
         path: '/test',
         component: () => null,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig } = injectedFunctions();
     await expect(getPathConfig).rejects.toThrowError(
       'Duplicated dynamic path: /test',
@@ -735,44 +949,330 @@ describe('createPages', () => {
   });
 
   it('fails if duplicated static paths are registered', async () => {
-    createPages(async ({ createPage }) => {
+    createPages(async ({ createPage }) => [
       createPage({
         render: 'static',
         path: '/test',
         component: () => null,
-      });
+      }),
       createPage({
         render: 'static',
         path: '/test',
         component: () => null,
-      });
-    });
+      }),
+    ]);
     const { getPathConfig } = injectedFunctions();
     await expect(getPathConfig).rejects.toThrowError(
       'Duplicated component for: test/page',
     );
   });
 
-  // TODO: Should this not fail as well?
   it.fails(
     'fails if duplicated static and dynamic paths override each other',
     async () => {
-      createPages(async ({ createPage }) => {
+      createPages(async ({ createPage }) => [
         createPage({
           render: 'dynamic',
           path: '/test',
           component: () => null,
-        });
+        }),
         createPage({
           render: 'static',
           path: '/test',
           component: () => null,
-        });
-      });
+        }),
+      ]);
       const { getPathConfig } = injectedFunctions();
       await expect(getPathConfig).rejects.toThrowError(
         'Duplicated component for: test/page',
       );
     },
   );
+
+  it('creates a complex router', async () => {
+    const TestPage = vi.fn();
+    complexTestRouter(createPages, TestPage);
+
+    const { getPathConfig, getComponent } = injectedFunctions();
+
+    expect(await getPathConfig()).toEqual([
+      {
+        pattern: '^/client/static$',
+        path: [
+          {
+            type: 'literal',
+            name: 'client',
+          },
+          {
+            type: 'literal',
+            name: 'static',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/static/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'static-echo',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/static/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'static-echo-2',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/static/([^/]+)/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'static-echo',
+          },
+          {
+            type: 'literal',
+            name: 'static-echo-2',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/static/([^/]+)/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'hello',
+          },
+          {
+            type: 'literal',
+            name: 'hello-2',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/static/wild/(.*)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'wild',
+          },
+          {
+            type: 'literal',
+            name: 'bar',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/static/wild/(.*)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'wild',
+          },
+          {
+            type: 'literal',
+            name: 'hello',
+          },
+          {
+            type: 'literal',
+            name: 'hello-2',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/static/wild/(.*)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'static',
+          },
+          {
+            type: 'literal',
+            name: 'wild',
+          },
+          {
+            type: 'literal',
+            name: 'foo',
+          },
+          {
+            type: 'literal',
+            name: 'foo-2',
+          },
+          {
+            type: 'literal',
+            name: 'foo-3',
+          },
+        ],
+        isStatic: true,
+        noSsr: false,
+      },
+      {
+        pattern: '^/client/dynamic$',
+        path: [
+          {
+            type: 'literal',
+            name: 'client',
+          },
+          {
+            type: 'literal',
+            name: 'dynamic',
+          },
+        ],
+        isStatic: false,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/one/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'one',
+          },
+          {
+            type: 'group',
+            name: 'echo',
+          },
+        ],
+        isStatic: false,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/two/([^/]+)/([^/]+)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'two',
+          },
+          {
+            type: 'group',
+            name: 'echo',
+          },
+          {
+            type: 'group',
+            name: 'echo2',
+          },
+        ],
+        isStatic: false,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/wild/(.*)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'wild',
+          },
+          {
+            type: 'wildcard',
+            name: 'wild',
+          },
+        ],
+        isStatic: false,
+        noSsr: false,
+      },
+      {
+        pattern: '^/server/oneAndWild/([^/]+)/(.*)$',
+        path: [
+          {
+            type: 'literal',
+            name: 'server',
+          },
+          {
+            type: 'literal',
+            name: 'oneAndWild',
+          },
+          {
+            type: 'group',
+            name: 'slug',
+          },
+          {
+            type: 'wildcard',
+            name: 'wild',
+          },
+        ],
+        isStatic: false,
+        noSsr: false,
+      },
+    ]);
+    const setShouldSkip = vi.fn();
+    const WrappedComponent = await getComponent('server/two/a/b/page', {
+      unstable_setShouldSkip: setShouldSkip,
+    });
+    assert(WrappedComponent);
+    expect(setShouldSkip).toHaveBeenCalledTimes(1);
+    expect(setShouldSkip).toHaveBeenCalledWith();
+    renderToString(createElement(WrappedComponent as any));
+    expect(TestPage).toHaveBeenCalledTimes(1);
+    expect(TestPage).toHaveBeenCalledWith({ echo: 'a', echo2: 'b' }, undefined);
+  });
 });


### PR DESCRIPTION
Currently this changeset gets `createPages` ready to return an inferred type for each response of `createPage`

TODO:

- [x] Create a union type of all possible paths given the pages
- [x] Pass this union to an override-able interface so waku projects can consume the pages type safety (same as tanstack router's approach)
- [x] Use that type in our `<Link />` component
- [x] Update tests and refactor examples to match new api