### PR TITLE
chore: add noErrorTruncation to the base tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "waku": ["./packages/waku/src/main.ts"],
       "waku/*": ["./packages/waku/src/*.ts"]
-    }
+    },
+    "noErrorTruncation": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
This results in the ts preview of vscode not truncating the hovered information of a type or error. Helpful for inspecting long types.

Follow up to: https://github.com/dai-shi/waku/pull/854#issuecomment-2336516245