### PR TITLE
fix: store platformConfig in globalThis

### DIFF
--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -169,9 +169,9 @@ type PlatformObject = {
   };
 } & Record<string, unknown>;
 
-const platformObject: PlatformObject = {};
+(globalThis as any).__WAKU_PLATFORM_OBJECT__ ||= {};
 
 // TODO tentative name
 export function unstable_getPlatformObject(): PlatformObject {
-  return platformObject;
+  return (globalThis as any).__WAKU_PLATFORM_OBJECT__ as PlatformObject;
 }


### PR DESCRIPTION
close #871 

I would like to avoid depending on `globalThis`, but this is an easy fix for now.