### PR TITLE
fix(deploy): move saving the build config to deploy plugins

### DIFF
--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -776,8 +776,10 @@ export async function build(options: {
   await buildDeploy(rootDir, config);
   delete platformObject.buildOptions.unstable_phase;
 
-  await appendFile(
-    distEntriesFile,
-    `export const buildData = ${JSON.stringify(platformObject.buildData)};`,
-  );
+  if (existsSync(distEntriesFile)) {
+    await appendFile(
+      distEntriesFile,
+      `export const buildData = ${JSON.stringify(platformObject.buildData)};`,
+    );
+  }
 }

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -11,7 +12,7 @@ import type { Plugin } from 'vite';
 
 import { unstable_getPlatformObject } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
-import { DIST_PUBLIC } from '../builder/constants.js';
+import { DIST_ENTRIES_JS, DIST_PUBLIC } from '../builder/constants.js';
 
 const SERVE_JS = 'serve-cloudflare.js';
 
@@ -208,6 +209,11 @@ export default {
         force: true,
       });
 
+      appendFileSync(
+        path.join(outDir, WORKER_JS_NAME, DIST_ENTRIES_JS),
+        `export const buildData = ${JSON.stringify(platformObject.buildData)};`,
+      );
+
       const wranglerTomlFile = path.join(rootDir, 'wrangler.toml');
       if (!existsSync(wranglerTomlFile)) {
         writeFileSync(
@@ -215,7 +221,7 @@ export default {
           `
 # See https://developers.cloudflare.com/pages/functions/wrangler-configuration/
 name = "waku-project"
-compatibility_date = "2024-04-03"
+compatibility_date = "2024-09-02"
 compatibility_flags = [ "nodejs_als" ]
 pages_build_output_dir = "./dist"
 `,


### PR DESCRIPTION
This (along with the previous #874) resolves the issue in #871. The build config was being written to the wrong location for cloudflare pages This PR exports a function from the build module that appends the build config to the given entries file location. It uses a new unstable build config state variable (`unstable_buildConfigSave`) to track whether or not the build config has be saved to the entries file. This allows the cloudflare deploy plugin to write the build config into the worker function directory instead of the root.

We could merge #879 and then I can edit the base branch to main and continue with this PR. Or however you want to handle it. Thank you!