### PR TITLE
feat(hono): enable context storage

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { createRequire } from 'node:module';
 import { Hono } from 'hono';
+import { contextStorage } from 'hono/context-storage';
 import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import * as dotenv from 'dotenv';
@@ -95,6 +96,7 @@ if (values.version) {
 async function runDev() {
   const config = await loadConfig();
   const app = new Hono();
+  app.use(contextStorage());
   app.use('*', runner({ cmd: 'dev', config, env: process.env as any }));
   app.notFound((c) => {
     // FIXME can we avoid hardcoding the public path?
@@ -138,6 +140,7 @@ async function runStart() {
   const loadEntries = () =>
     import(pathToFileURL(path.resolve(distDir, DIST_ENTRIES_JS)).toString());
   const app = new Hono();
+  app.use(contextStorage());
   app.use('*', serveStatic({ root: path.join(distDir, DIST_PUBLIC) }));
   app.use('*', runner({ cmd: 'start', loadEntries, env: process.env as any }));
   app.notFound((c) => {

--- a/packages/waku/src/lib/hono/runner.ts
+++ b/packages/waku/src/lib/hono/runner.ts
@@ -1,11 +1,7 @@
-import type { Context, MiddlewareHandler } from 'hono';
+import type { MiddlewareHandler } from 'hono';
 
-import { unstable_getCustomContext } from '../../server.js';
 import { resolveConfig } from '../config.js';
 import type { HandlerContext, MiddlewareOptions } from '../middleware/types.js';
-
-// Internal context key
-const HONO_CONTEXT = '__hono_context';
 
 const createEmptyReadableStream = () =>
   new ReadableStream({
@@ -42,9 +38,7 @@ export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
         headers: c.req.header(),
       },
       res: {},
-      context: {
-        [HONO_CONTEXT]: c,
-      },
+      context: {},
     };
     const handlers = await handlersPromise;
     const run = async (index: number) => {
@@ -69,12 +63,4 @@ export const runner = (options: MiddlewareOptions): MiddlewareHandler => {
     }
     await next();
   };
-};
-
-export const getHonoContext = <C extends Context = Context>() => {
-  const c = unstable_getCustomContext()[HONO_CONTEXT];
-  if (!c) {
-    throw new Error('Hono context is not available');
-  }
-  return c as C;
 };

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
@@ -21,6 +21,7 @@ const loadEntries = () => import('${srcEntriesFile}');
 const env = Deno.env.toObject();
 
 const app = new Hono();
+// app.use(contextStorage()); // Hono v4.6 is not available on deno.land
 app.use('*', serveStatic({ root: distDir + '/' + publicDir }));
 app.use('*', runner({ cmd: 'start', loadEntries, env }));
 app.notFound(async (c) => {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
@@ -9,13 +9,15 @@ import { DIST_PUBLIC } from '../builder/constants.js';
 const SERVE_JS = 'serve-netlify.js';
 
 const getServeJsContent = (srcEntriesFile: string) => `
-import { runner, importHono } from 'waku/unstable_hono';
+import { runner, importHono, importHonoContextStorage } from 'waku/unstable_hono';
 
 const { Hono } = await importHono();
+const { contextStorage } = await importHonoContextStorage();
 
 const loadEntries = () => import('${srcEntriesFile}');
 
 const app = new Hono();
+app.use(contextStorage());
 app.use('*', runner({ cmd: 'start', loadEntries, env: process.env }));
 app.notFound((c) => {
   const notFoundHtml = globalThis.__WAKU_NOT_FOUND_HTML__;

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
@@ -15,9 +15,10 @@ const getServeJsContent = (
 ) => `
 import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
-import { runner, importHono, importHonoNodeServer } from 'waku/unstable_hono';
+import { runner, importHono, importHonoContextStorage, importHonoNodeServer } from 'waku/unstable_hono';
 
 const { Hono } = await importHono();
+const { contextStorage } = await importHonoContextStorage();
 const { getRequestListener } = await importHonoNodeServer();
 
 const distDir = '${distDir}';
@@ -25,6 +26,7 @@ const publicDir = '${distPublic}';
 const loadEntries = () => import('${srcEntriesFile}');
 
 const app = new Hono();
+app.use(contextStorage());
 app.use('*', runner({ cmd: 'start', loadEntries, env: process.env }));
 app.notFound((c) => {
   // FIXME better implementation using node stream?

--- a/packages/waku/src/unstable_hono.ts
+++ b/packages/waku/src/unstable_hono.ts
@@ -1,8 +1,9 @@
 // These exports are for internal use only and subject to change without notice.
 
-export { runner, getHonoContext } from './lib/hono/runner.js';
+export { runner } from './lib/hono/runner.js';
 
 export const importHono = () => import('hono');
+export const importHonoContextStorage = () => import('hono/context-storage');
 export const importHonoNodeServer: any = () => import('@hono/node-server');
 export const importHonoNodeServerServeStatic = () =>
   import('@hono/node-server/serve-static');


### PR DESCRIPTION
Instead of #852 and #884, let's use Hono's `getContext` instead.