### PR TITLE
feat(dev): cloudflare dev server adapter

### DIFF
--- a/packages/waku/src/lib/hono/adapter.ts
+++ b/packages/waku/src/lib/hono/adapter.ts
@@ -1,0 +1,8 @@
+import type { ExecutionContext, Hono } from 'hono';
+
+export type FetchAdapter = (app: Hono) => Promise<FetchHandler | undefined>;
+export type FetchHandler = (
+  req: Request,
+  env?: unknown,
+  executionCtx?: ExecutionContext,
+) => Promise<Response> | Response;

--- a/packages/waku/src/lib/hono/cloudflare-dev-server.ts
+++ b/packages/waku/src/lib/hono/cloudflare-dev-server.ts
@@ -1,0 +1,36 @@
+/* eslint import/no-unresolved: 0 */
+import type { Hono } from 'hono';
+
+export const cloudflareDevServer = (app: Hono, cfOptions?: any) => {
+  try {
+    // @ts-expect-error: miniflare is a peer dependency (provided by miniflare)
+    const wsAssign = import('miniflare').then(({ WebSocketPair }) => {
+      Object.assign(globalThis, { WebSocketPair });
+    });
+
+    // @ts-expect-error: wrangler is a peer dependency
+    const proxy = import('wrangler').then(({ getPlatformProxy }) =>
+      getPlatformProxy({
+        ...(cfOptions || {}),
+      }).then((proxy: any) => {
+        return proxy;
+      }),
+    );
+
+    return async (req: Request) => {
+      await wsAssign;
+      const awaitedProxy = await proxy;
+      Object.assign(req, { cf: awaitedProxy.cf });
+      Object.assign(globalThis, {
+        caches: awaitedProxy.caches,
+      });
+      return app.fetch(req, awaitedProxy.env, awaitedProxy.ctx);
+    };
+  } catch (e) {
+    console.warn(
+      'Unable to set up Cloudflare dev server. Try installing wrangler to your dev dependencies.',
+      e,
+    );
+    return undefined;
+  }
+};


### PR DESCRIPTION
Related to #891. This is a better implementation than using a waku plugin.

See https://github.com/honojs/vite-plugins/blob/main/packages/dev-server/src/dev-server.ts#L124-L137 for similar work.

Here is the plugin implementation for comparison - https://gist.github.com/rmarscher/9bb6ed54dc9535f4b81bed147204c7e9