### PR TITLE
feat: deploy aws / add streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,7 @@ npm run build -- --with-aws-lambda
 ```
 
 The handler entrypoint is `dist/serve-asw-lambda.js`: see [Hono AWS Lambda Deploy Docs](https://hono.dev/getting-started/aws-lambda#_3-deploy).
+Streaming can be activated by setting environment variable `DEPLOY_AWS_LAMBDA_STREAMING=true npm run build -- --with-aws-lambda`
 
 ## Community
 

--- a/docs/builder/aws-lambda.mdx
+++ b/docs/builder/aws-lambda.mdx
@@ -259,34 +259,35 @@ This example requires a build with activated streaming.
 use this as an example to run WAKU as Lamda Function:
 
 sst.config.ts
+
 ```ts
 /// <reference path="./.sst/platform/config.d.ts" />
 
 export default $config({
   app(input) {
     return {
-      name: "waku03demo",
-      removal: input?.stage === "production" ? "retain" : "remove",
-      home: "aws",
+      name: 'waku03demo',
+      removal: input?.stage === 'production' ? 'retain' : 'remove',
+      home: 'aws',
     };
   },
   async run() {
-    const WakuDemoApp = new sst.aws.Function("WakuDemoApp", {
+    const WakuDemoApp = new sst.aws.Function('WakuDemoApp', {
       url: true,
       streaming: true,
       //timeout: "15 minutes",
-      handler: "dist/serve-aws-lambda.handler",
-      bundle: "bundle", // disable bundling with esbuild
+      handler: 'dist/serve-aws-lambda.handler',
+      bundle: 'bundle', // disable bundling with esbuild
       copyFiles: [
         {
-          from: "dist"
+          from: 'dist',
         },
         {
-          from: "private"
-        }
+          from: 'private',
+        },
       ],
       environment: {
-        NODE_ENV: "production",
+        NODE_ENV: 'production',
       },
     });
     return {
@@ -294,7 +295,6 @@ export default $config({
     };
   },
 });
-
 ```
 
 ### deploy

--- a/docs/builder/aws-lambda.mdx
+++ b/docs/builder/aws-lambda.mdx
@@ -94,7 +94,7 @@ Initialize your project with the `cdk` CLI
 
 ```sh
 mkdir cdk &&  cd "$_"
-pnpmx cdk init app -l typescript --generate-only
+pnpx cdk init app -l typescript --generate-only
 cd ..
 cp cdk/cdk.json .
 ```
@@ -251,7 +251,7 @@ This example requires a build with activated streaming.
 
 ### Setup
 
-1. add `pnpd sst@latest init`
+1. add `pnpm sst@latest init`
 
 ### configuration
 
@@ -299,7 +299,7 @@ export default $config({
 ### deploy
 
 ```sh
-ssh deploy
+pnpx sst deploy
 ```
 
 [sst.dev documentation](https://sst.dev/docs)

--- a/docs/builder/aws-lambda.mdx
+++ b/docs/builder/aws-lambda.mdx
@@ -11,6 +11,8 @@ The entry handler for the Lambda is `dist/serve-aws-lambda.handler`.
 
 > Folder which require directly access - eg. `fs.readFile("./private/data.json")` needs to be manual added to the deployment configuration.
 
+> **activate Streaming support:** `DEPLOY_AWS_LAMBDA_STREAMING=true pnpm build --with-aws-lambda`
+
 ## [Serverless Framework](https://www.serverless.com)
 
 ### Installation
@@ -67,7 +69,7 @@ This configuration will include all files from the `./private` directory in the 
 ### Deploy
 
 ```sh
-pnpm dlx serverless deploy
+pnpx serverless deploy
 ```
 
 Output:
@@ -92,7 +94,7 @@ Initialize your project with the `cdk` CLI
 
 ```sh
 mkdir cdk &&  cd "$_"
-pnpm dlx cdk init app -l typescript --generate-only
+pnpmx cdk init app -l typescript --generate-only
 cd ..
 cp cdk/cdk.json .
 ```
@@ -242,3 +244,62 @@ pnpm cdk deploy WakuStack
 ```
 
 For more configuration options and how to use a custom domain visit the AWS CDK [documentation](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
+
+## sst.dev V3
+
+This example requires a build with activated streaming.
+
+### Setup
+
+1. add `pnpd sst@latest init`
+
+### configuration
+
+use this as an example to run WAKU as Lamda Function:
+
+sst.config.ts
+```ts
+/// <reference path="./.sst/platform/config.d.ts" />
+
+export default $config({
+  app(input) {
+    return {
+      name: "waku03demo",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const WakuDemoApp = new sst.aws.Function("WakuDemoApp", {
+      url: true,
+      streaming: true,
+      //timeout: "15 minutes",
+      handler: "dist/serve-aws-lambda.handler",
+      bundle: "bundle", // disable bundling with esbuild
+      copyFiles: [
+        {
+          from: "dist"
+        },
+        {
+          from: "private"
+        }
+      ],
+      environment: {
+        NODE_ENV: "production",
+      },
+    });
+    return {
+      api: WakuDemoApp.url,
+    };
+  },
+});
+
+```
+
+### deploy
+
+```sh
+ssh deploy
+```
+
+[sst.dev documentation](https://sst.dev/docs)

--- a/docs/builder/aws-lambda.mdx
+++ b/docs/builder/aws-lambda.mdx
@@ -248,6 +248,7 @@ For more configuration options and how to use a custom domain visit the AWS CDK 
 ## sst.dev V3
 
 This example requires a build with activated streaming.
+`DEPLOY_AWS_LAMBDA_STREAMING=true pnpm build --with-aws-lambda`
 
 ### Setup
 

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -21,7 +21,7 @@ import { runner, importHono, importHonoNodeServerServeStatic, importHonoAwsLambd
 
 const { Hono } = await importHono();
 const { serveStatic } = await importHonoNodeServerServeStatic();
-const { ${lambda_streaming ? 'streamHandle as' : ''} handle } = await importHonoAwsLambda();
+const { ${lambda_streaming ? 'streamHandle:' : ''}handle } = await importHonoAwsLambda();
 let contextStorage;
 try {
  ({ contextStorage } = await import('hono/context-storage'));

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -21,7 +21,7 @@ import { runner, importHono, importHonoNodeServerServeStatic, importHonoAwsLambd
 
 const { Hono } = await importHono();
 const { serveStatic } = await importHonoNodeServerServeStatic();
-const { ${lambda_streaming ? 'streamHandle:' : ''}handle } = await importHonoAwsLambda();
+const { ${lambdaStreaming ? 'streamHandle:' : ''}handle } = await importHonoAwsLambda();
 let contextStorage;
 try {
  ({ contextStorage } = await import('hono/context-storage'));

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -8,7 +8,7 @@ import { DIST_PUBLIC } from '../builder/constants.js';
 
 const SERVE_JS = 'serve-aws-lambda.js';
 
-const lambda_streaming = process.env.DEPLOY_AWS_LAMBDA_STREAMING === 'true';
+const lambdaStreaming = process.env.DEPLOY_AWS_LAMBDA_STREAMING === 'true';
 
 const getServeJsContent = (
   distDir: string,

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -8,6 +8,8 @@ import { DIST_PUBLIC } from '../builder/constants.js';
 
 const SERVE_JS = 'serve-aws-lambda.js';
 
+const lambda_streaming = process.env.DEPLOY_AWS_LAMBDA_STREAMING === 'true';
+
 const getServeJsContent = (
   distDir: string,
   distPublic: string,
@@ -19,7 +21,7 @@ import { runner, importHono, importHonoNodeServerServeStatic, importHonoAwsLambd
 
 const { Hono } = await importHono();
 const { serveStatic } = await importHonoNodeServerServeStatic();
-const { handle } = await importHonoAwsLambda();
+const { ${lambda_streaming ? 'streamHandle as' : ''} handle } = await importHonoAwsLambda();
 let contextStorage;
 try {
  ({ contextStorage } = await import('hono/context-storage'));


### PR DESCRIPTION
adds streaming by using [`streamHandle`](https://hono.dev/docs/getting-started/aws-lambda#lambda-response-streaming) from Hono.

To switch the handler use the environment variable `DEPLOY_AWS_LAMBDA_STREAMING=true`:
```sh
DEPLOY_AWS_LAMBDA_STREAMING=true pnpm build --with-aws-lambda
```