### PR TITLE
refactor: hono app.use usage

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -103,7 +103,7 @@ async function runDev() {
   if (values['experimental-compress']) {
     app.use(compress());
   }
-  app.use('*', runner({ cmd: 'dev', config, env: process.env as any }));
+  app.use(runner({ cmd: 'dev', config, env: process.env as any }));
   app.notFound((c) => {
     // FIXME can we avoid hardcoding the public path?
     const file = path.join('public', '404.html');
@@ -151,8 +151,8 @@ async function runStart() {
   if (values['experimental-compress']) {
     app.use(compress());
   }
-  app.use('*', serveStatic({ root: path.join(distDir, DIST_PUBLIC) }));
-  app.use('*', runner({ cmd: 'start', loadEntries, env: process.env as any }));
+  app.use(serveStatic({ root: path.join(distDir, DIST_PUBLIC) }));
+  app.use(runner({ cmd: 'start', loadEntries, env: process.env as any }));
   app.notFound((c) => {
     // FIXME better implementation using node stream?
     const file = path.join(distDir, DIST_PUBLIC, '404.html');

--- a/packages/waku/src/lib/builder/serve-partykit.ts
+++ b/packages/waku/src/lib/builder/serve-partykit.ts
@@ -6,7 +6,7 @@ const loadEntries = () => import(import.meta.env.WAKU_ENTRIES_FILE!);
 let serveWaku: ReturnType<typeof runner> | undefined;
 
 const app = new Hono();
-app.use('*', (c, next) => serveWaku!(c, next));
+app.use((c, next) => serveWaku!(c, next));
 app.notFound(async (c) => {
   // @ts-expect-error partykit's types aren't available
   const assetsFetcher = c.env.assets as {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -28,8 +28,8 @@ const publicDir = '${distPublic}';
 const loadEntries = () => import('${srcEntriesFile}');
 
 const app = new Hono();
-app.use('*', serveStatic({ root: distDir + '/' + publicDir }));
-app.use('*', runner({ cmd: 'start', loadEntries, env: process.env }));
+app.use(serveStatic({ root: distDir + '/' + publicDir }));
+app.use(runner({ cmd: 'start', loadEntries, env: process.env }));
 app.notFound(async (c) => {
   const file = path.join(distDir, publicDir, '404.html');
   if (existsSync(file)) {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -25,7 +25,7 @@ const loadEntries = () => import('${srcEntriesFile}');
 let serveWaku;
 
 const app = new Hono();
-app.use('*', (c, next) => serveWaku(c, next));
+app.use((c, next) => serveWaku(c, next));
 app.notFound(async (c) => {
   const assetsFetcher = c.env.ASSETS;
   const url = new URL(c.req.raw.url);

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
@@ -21,8 +21,8 @@ const loadEntries = () => import('${srcEntriesFile}');
 const env = Deno.env.toObject();
 
 const app = new Hono();
-app.use('*', serveStatic({ root: distDir + '/' + publicDir }));
-app.use('*', runner({ cmd: 'start', loadEntries, env }));
+app.use(serveStatic({ root: distDir + '/' + publicDir }));
+app.use(runner({ cmd: 'start', loadEntries, env }));
 app.notFound(async (c) => {
   const file = distDir + '/' + publicDir + '/404.html';
   try {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
@@ -16,7 +16,7 @@ const { Hono } = await importHono();
 const loadEntries = () => import('${srcEntriesFile}');
 
 const app = new Hono();
-app.use('*', runner({ cmd: 'start', loadEntries, env: process.env }));
+app.use(runner({ cmd: 'start', loadEntries, env: process.env }));
 app.notFound((c) => {
   const notFoundHtml = globalThis.__WAKU_NOT_FOUND_HTML__;
   if (typeof notFoundHtml === 'string') {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
@@ -25,7 +25,7 @@ const publicDir = '${distPublic}';
 const loadEntries = () => import('${srcEntriesFile}');
 
 const app = new Hono();
-app.use('*', runner({ cmd: 'start', loadEntries, env: process.env }));
+app.use(runner({ cmd: 'start', loadEntries, env: process.env }));
 app.notFound((c) => {
   // FIXME better implementation using node stream?
   const file = path.join(distDir, publicDir, '404.html');


### PR DESCRIPTION
We can omit `'*'` in `app.use()`.

https://github.com/honojs/hono/blob/f1ec415be03784ab8c321577cf35005afd3bea09/src/hono-base.ts#L157-L164

