### PR TITLE
ci: use hoisted mode for e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+      - run: echo "node-linker = hoisted" >> .npmrc
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}


### PR DESCRIPTION
hoisted mode will make e2e test has same node_modules sturcture with npm