### PR TITLE
docs: add example of dynamic layout with static page

### DIFF
--- a/examples/25_weave_render/package.json
+++ b/examples/25_weave_render/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "waku-example",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "waku dev",
+    "build": "waku build",
+    "start": "waku start"
+  },
+  "dependencies": {
+    "react": "19.0.0-rc-d6cb4e77-20240911",
+    "react-dom": "19.0.0-rc-d6cb4e77-20240911",
+    "react-server-dom-webpack": "19.0.0-rc-d6cb4e77-20240911",
+    "waku": "0.21.2"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.5",
+    "@types/react-dom": "18.3.0",
+    "server-only": "0.0.1",
+    "typescript": "5.6.2"
+  }
+}

--- a/examples/25_weave_render/src/components/BarLayout.tsx
+++ b/examples/25_weave_render/src/components/BarLayout.tsx
@@ -16,7 +16,7 @@ const Pending = ({ isPending }: { isPending: boolean }) => (
   </span>
 );
 
-const HomeLayout = ({ children }: { children: ReactNode }) => {
+const BarLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html>
       <head>
@@ -61,4 +61,4 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export default HomeLayout;
+export default BarLayout;

--- a/examples/25_weave_render/src/components/BarPage.tsx
+++ b/examples/25_weave_render/src/components/BarPage.tsx
@@ -1,0 +1,10 @@
+import { Counter } from './Counter';
+
+const Bar = () => (
+  <div>
+    <h2>Bar</h2>
+    <Counter />
+  </div>
+);
+
+export default Bar;

--- a/examples/25_weave_render/src/components/Counter.tsx
+++ b/examples/25_weave_render/src/components/Counter.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Link, useRouter_UNSTABLE as useRouter } from 'waku/router/client';
+
+export const Counter = () => {
+  const { path } = useRouter();
+  const [count, setCount] = useState(0);
+  return (
+    <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+      <h3>This is a client component.</h3>
+      <span>path: {path}</span>
+      <Link to="/">Go to Home</Link>
+    </div>
+  );
+};

--- a/examples/25_weave_render/src/components/FooLayout.tsx
+++ b/examples/25_weave_render/src/components/FooLayout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+const FooLayout = ({ children }: { children: ReactNode }) => {
+  return (
+    <html>
+      <body>
+        <div>
+          <h1>FOO layout</h1>
+          {children}
+        </div>
+      </body>
+    </html>
+  );
+};
+
+export default FooLayout;

--- a/examples/25_weave_render/src/components/FooPage.tsx
+++ b/examples/25_weave_render/src/components/FooPage.tsx
@@ -1,0 +1,12 @@
+import 'server-only';
+
+import { Counter } from './Counter';
+
+const Foo = () => (
+  <div>
+    <h2>Foo</h2>
+    <Counter />
+  </div>
+);
+
+export default Foo;

--- a/examples/25_weave_render/src/components/HomeLayout.tsx
+++ b/examples/25_weave_render/src/components/HomeLayout.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+
+import { Link } from 'waku/router/client';
+
+import '../styles.css';
+
+const Pending = ({ isPending }: { isPending: boolean }) => (
+  <span
+    style={{
+      marginLeft: 5,
+      transition: 'opacity 75ms 100ms',
+      opacity: isPending ? 1 : 0,
+    }}
+  >
+    Pending...
+  </span>
+);
+
+const getCurrentTime = () => new Date();
+
+const HomeLayout = ({ children }: { children: ReactNode }) => {
+  const currentTime = getCurrentTime();
+  return (
+    <html>
+      <head>
+        <title>Waku</title>
+      </head>
+      <body>
+        <div>
+          <p>Last render time: {currentTime.toISOString()}</p>
+          <ul>
+            <li>
+              <Link
+                to="/"
+                pending={<Pending isPending />}
+                notPending={<Pending isPending={false} />}
+              >
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link
+                to="/foo"
+                pending={<Pending isPending />}
+                notPending={<Pending isPending={false} />}
+              >
+                Foo
+              </Link>
+            </li>
+          </ul>
+          {children}
+        </div>
+      </body>
+    </html>
+  );
+};
+
+export default HomeLayout;

--- a/examples/25_weave_render/src/components/HomeLayout.tsx
+++ b/examples/25_weave_render/src/components/HomeLayout.tsx
@@ -27,6 +27,7 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
       </head>
       <body>
         <div>
+          <h1>Home layout</h1>
           <p>Last render time: {currentTime.toISOString()}</p>
           <ul>
             <li>

--- a/examples/25_weave_render/src/components/HomePage.tsx
+++ b/examples/25_weave_render/src/components/HomePage.tsx
@@ -1,0 +1,8 @@
+const Home = () => (
+  <div>
+    <h2>Home</h2>
+    <p>This is the home page.</p>
+  </div>
+);
+
+export default Home;

--- a/examples/25_weave_render/src/components/NestedBarLayout.tsx
+++ b/examples/25_weave_render/src/components/NestedBarLayout.tsx
@@ -16,10 +16,7 @@ const Pending = ({ isPending }: { isPending: boolean }) => (
   </span>
 );
 
-const getCurrentTime = () => new Date();
-
 const HomeLayout = ({ children }: { children: ReactNode }) => {
-  const currentTime = getCurrentTime();
   return (
     <html>
       <head>
@@ -27,7 +24,7 @@ const HomeLayout = ({ children }: { children: ReactNode }) => {
       </head>
       <body>
         <div>
-          <p>Last render time: {currentTime.toISOString()}</p>
+          <p>This Layout is expected to be static</p>
           <ul>
             <li>
               <Link

--- a/examples/25_weave_render/src/entries.tsx
+++ b/examples/25_weave_render/src/entries.tsx
@@ -2,6 +2,8 @@ import { lazy } from 'react';
 import { createPages } from 'waku';
 import type { PathsForPages } from 'waku/router';
 import FooPage from './components/FooPage';
+import BarPage from './components/BarPage';
+import NestedBarLayout from './components/NestedBarLayout';
 
 // The use of `lazy` is optional and you can use import statements too.
 const HomeLayout = lazy(() => import('./components/HomeLayout'));
@@ -24,6 +26,18 @@ const pages = createPages(async ({ createPage, createLayout }) => [
     render: 'static',
     path: '/foo',
     component: FooPage,
+  }),
+
+  createPage({
+    render: 'dynamic',
+    path: '/nested/bar',
+    component: BarPage,
+  }),
+
+  createLayout({
+    render: 'static',
+    path: '/nested',
+    component: NestedBarLayout,
   }),
 ]);
 

--- a/examples/25_weave_render/src/entries.tsx
+++ b/examples/25_weave_render/src/entries.tsx
@@ -3,7 +3,7 @@ import { createPages } from 'waku';
 import type { PathsForPages } from 'waku/router';
 import FooPage from './components/FooPage';
 import BarPage from './components/BarPage';
-import NestedBarLayout from './components/NestedBarLayout';
+import BarLayout from './components/BarLayout';
 import FooLayout from './components/FooLayout';
 
 // The use of `lazy` is optional and you can use import statements too.
@@ -12,7 +12,7 @@ const HomePage = lazy(() => import('./components/HomePage'));
 
 const pages = createPages(async ({ createPage, createLayout }) => [
   createLayout({
-    render: 'dynamic',
+    render: 'static',
     path: '/',
     component: HomeLayout,
   }),
@@ -23,12 +23,6 @@ const pages = createPages(async ({ createPage, createLayout }) => [
     component: HomePage,
   }),
 
-  createPage({
-    render: 'dynamic',
-    path: '/foo',
-    component: FooPage,
-  }),
-
   createLayout({
     render: 'static',
     path: '/foo',
@@ -37,14 +31,20 @@ const pages = createPages(async ({ createPage, createLayout }) => [
 
   createPage({
     render: 'dynamic',
-    path: '/nested/bar',
-    component: BarPage,
+    path: '/foo',
+    component: FooPage,
   }),
 
   createLayout({
+    render: 'dynamic',
+    path: '/bar',
+    component: BarLayout,
+  }),
+
+  createPage({
     render: 'static',
-    path: '/nested',
-    component: NestedBarLayout,
+    path: '/bar',
+    component: BarPage,
   }),
 ]);
 

--- a/examples/25_weave_render/src/entries.tsx
+++ b/examples/25_weave_render/src/entries.tsx
@@ -1,0 +1,36 @@
+import { lazy } from 'react';
+import { createPages } from 'waku';
+import type { PathsForPages } from 'waku/router';
+import FooPage from './components/FooPage';
+
+// The use of `lazy` is optional and you can use import statements too.
+const HomeLayout = lazy(() => import('./components/HomeLayout'));
+const HomePage = lazy(() => import('./components/HomePage'));
+
+const pages = createPages(async ({ createPage, createLayout }) => [
+  createLayout({
+    render: 'dynamic',
+    path: '/',
+    component: HomeLayout,
+  }),
+
+  createPage({
+    render: 'static',
+    path: '/',
+    component: HomePage,
+  }),
+
+  createPage({
+    render: 'static',
+    path: '/foo',
+    component: FooPage,
+  }),
+]);
+
+declare module 'waku/router' {
+  interface RouteConfig {
+    paths: PathsForPages<typeof pages>;
+  }
+}
+
+export default pages;

--- a/examples/25_weave_render/src/entries.tsx
+++ b/examples/25_weave_render/src/entries.tsx
@@ -4,6 +4,7 @@ import type { PathsForPages } from 'waku/router';
 import FooPage from './components/FooPage';
 import BarPage from './components/BarPage';
 import NestedBarLayout from './components/NestedBarLayout';
+import FooLayout from './components/FooLayout';
 
 // The use of `lazy` is optional and you can use import statements too.
 const HomeLayout = lazy(() => import('./components/HomeLayout'));
@@ -23,9 +24,15 @@ const pages = createPages(async ({ createPage, createLayout }) => [
   }),
 
   createPage({
-    render: 'static',
+    render: 'dynamic',
     path: '/foo',
     component: FooPage,
+  }),
+
+  createLayout({
+    render: 'static',
+    path: '/foo',
+    component: FooLayout,
   }),
 
   createPage({

--- a/examples/25_weave_render/src/main.tsx
+++ b/examples/25_weave_render/src/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { Router } from 'waku/router/client';
+
+const rootElement = (
+  <StrictMode>
+    <Router />
+  </StrictMode>
+);
+
+if ((globalThis as any).__WAKU_HYDRATE__) {
+  hydrateRoot(document, rootElement);
+} else {
+  createRoot(document as any).render(rootElement);
+}

--- a/examples/25_weave_render/src/styles.css
+++ b/examples/25_weave_render/src/styles.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #fefefe;
+}

--- a/examples/25_weave_render/tsconfig.json
+++ b/examples/25_weave_render/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "esnext",
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["react/experimental"],
+    "jsx": "react-jsx"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,6 +952,34 @@ importers:
         specifier: 5.6.2
         version: 5.6.2
 
+  examples/25_weave_render:
+    dependencies:
+      react:
+        specifier: 19.0.0-rc-d6cb4e77-20240911
+        version: 19.0.0-rc-d6cb4e77-20240911
+      react-dom:
+        specifier: 19.0.0-rc-d6cb4e77-20240911
+        version: 19.0.0-rc-d6cb4e77-20240911(react@19.0.0-rc-d6cb4e77-20240911)
+      react-server-dom-webpack:
+        specifier: 19.0.0-rc-d6cb4e77-20240911
+        version: 19.0.0-rc-d6cb4e77-20240911(react-dom@19.0.0-rc-d6cb4e77-20240911(react@19.0.0-rc-d6cb4e77-20240911))(react@19.0.0-rc-d6cb4e77-20240911)(webpack@5.94.0)
+      waku:
+        specifier: 0.21.2
+        version: link:../../packages/waku
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.5
+        version: 18.3.5
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
+
   packages/create-waku:
     devDependencies:
       '@types/fs-extra':


### PR DESCRIPTION
you can see the time change as navigating the site which shows that the layout is indeed dynamic

The rest of the home page stays unchanged and can be cached

Example for #885