### PR TITLE
feat: Add hono enhancer to cloudflare and aws lambda

### DIFF
--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -100,7 +100,7 @@ async function runDev() {
   const config = await loadConfig();
   const honoEnhancer = config.unstable_honoEnhancer
     ? config.unstable_honoEnhancer
-    : async (createApp: (app: Hono) => Hono) => createApp;
+    : (createApp: (app: Hono) => Hono) => createApp;
   const createApp = (app: Hono) => {
     if (values['experimental-compress']) {
       app.use(compress());
@@ -123,7 +123,7 @@ async function runDev() {
     return app;
   };
   const port = parseInt(values.port || '3000', 10);
-  await startServer((await honoEnhancer(createApp))!(new Hono()), port);
+  await startServer(honoEnhancer(createApp)(new Hono()), port);
 }
 
 async function runBuild() {
@@ -156,7 +156,7 @@ async function runStart() {
   const { distDir = 'dist' } = config;
   const honoEnhancer = config.unstable_honoEnhancer
     ? config.unstable_honoEnhancer
-    : async (createApp: (app: Hono) => Hono) => (app: Hono) => createApp(app);
+    : (createApp: (app: Hono) => Hono) => (app: Hono) => createApp(app);
   const loadEntries = () =>
     import(pathToFileURL(path.resolve(distDir, DIST_ENTRIES_JS)).toString());
   const createApp = (app: Hono) => {
@@ -182,7 +182,7 @@ async function runStart() {
     return app;
   };
   const port = parseInt(values.port || '8080', 10);
-  await startServer((await honoEnhancer(createApp))!(new Hono()), port);
+  await startServer(honoEnhancer(createApp)(new Hono()), port);
 }
 
 function startServer(app: Hono, port: number) {

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -98,20 +98,13 @@ if (values.version) {
 
 async function runDev() {
   const config = await loadConfig();
-  const honoEnhancer = config.unstable_honoEnhancer
-    ? config.unstable_honoEnhancer
-    : (createApp: (app: Hono) => Hono) => createApp;
+  const honoEnhancer =
+    config.unstable_honoEnhancer || ((createApp) => createApp);
   const createApp = (app: Hono) => {
     if (values['experimental-compress']) {
       app.use(compress());
     }
-    app.use(
-      serverEngine({
-        cmd: 'dev',
-        config,
-        env: process.env as any,
-      }),
-    );
+    app.use(serverEngine({ cmd: 'dev', config, env: process.env as any }));
     app.notFound((c) => {
       // FIXME can we avoid hardcoding the public path?
       const file = path.join('public', '404.html');
@@ -154,9 +147,8 @@ async function runBuild() {
 async function runStart() {
   const config = await loadConfig();
   const { distDir = 'dist' } = config;
-  const honoEnhancer = config.unstable_honoEnhancer
-    ? config.unstable_honoEnhancer
-    : (createApp: (app: Hono) => Hono) => (app: Hono) => createApp(app);
+  const honoEnhancer =
+    config.unstable_honoEnhancer || ((createApp) => createApp);
   const loadEntries = () =>
     import(pathToFileURL(path.resolve(distDir, DIST_ENTRIES_JS)).toString());
   const createApp = (app: Hono) => {
@@ -165,11 +157,7 @@ async function runStart() {
     }
     app.use(serveStatic({ root: path.join(distDir, DIST_PUBLIC) }));
     app.use(
-      serverEngine({
-        cmd: 'start',
-        loadEntries,
-        env: process.env as any,
-      }),
+      serverEngine({ cmd: 'start', loadEntries, env: process.env as any }),
     );
     app.notFound((c) => {
       // FIXME better implementation using node stream?

--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -52,9 +52,9 @@ export interface Config {
    * Enhancer for Hono
    * Defaults to `undefined`
    */
-  unstable_honoEnhancer?: <Hono>(
-    createApp: (app: Hono) => Hono,
-  ) => Promise<(app: Hono) => Hono> | undefined;
+  unstable_honoEnhancer?:
+    | (<Hono>(createApp: (app: Hono) => Hono) => (app: Hono) => Hono)
+    | undefined;
 }
 
 export function defineConfig(config: Config) {

--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -49,12 +49,12 @@ export interface Config {
    */
   middleware?: () => Promise<{ default: Middleware }>[];
   /**
-   * Enhander for Hono
+   * Enhancer for Hono
    * Defaults to `undefined`
    */
-  unstable_honoEnhancer?:
-    | (<Hono>(createApp: (app: Hono) => Hono) => (app: Hono) => Hono)
-    | undefined;
+  unstable_honoEnhancer?: <Hono>(
+    createApp: (app: Hono) => Hono,
+  ) => Promise<(app: Hono) => Hono> | undefined;
 }
 
 export function defineConfig(config: Config) {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -15,34 +15,34 @@ const getServeJsContent = (
   distPublic: string,
   srcEntriesFile: string,
 ) => `
-import path from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import path from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
 import {
   serverEngine,
   importHono,
   importHonoNodeServerServeStatic,
   importHonoAwsLambda,
-} from "waku/unstable_hono";
+} from 'waku/unstable_hono';
 
 const { Hono } = await importHono();
 const { serveStatic } = await importHonoNodeServerServeStatic();
 const { ${lambdaStreaming ? 'streamHandle:' : ''}handle } = await importHonoAwsLambda();
 
-const distDir = "${distDir}";
-const publicDir = "${distPublic}";
-const loadEntries = () => import("${srcEntriesFile}");
+const distDir = '${distDir}';
+const publicDir = '${distPublic}';
+const loadEntries = () => import('${srcEntriesFile}');
 
 const configPromise = loadEntries().then((entries) => entries.loadConfig());
 
 const createApp = (app) => {
-  app.use(serveStatic({ root: distDir + "/" + publicDir }));
-  app.use(serverEngine({ cmd: "start", loadEntries, env: process.env }));
+  app.use(serveStatic({ root: distDir + '/' + publicDir }));
+  app.use(serverEngine({ cmd: 'start', loadEntries, env: process.env }));
   app.notFound(async (c) => {
-    const file = path.join(distDir, publicDir, "404.html");
+    const file = path.join(distDir, publicDir, '404.html');
     if (existsSync(file)) {
-      return c.html(readFileSync(file, "utf8"), 404);
+      return c.html(readFileSync(file, 'utf8'), 404);
     }
-    return c.text("404 Not Found", 404);
+    return c.text('404 Not Found', 404);
   });
   return app;
 };

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -44,9 +44,9 @@ const createApp = (app) => {
 
 const honoEnhancer =
   (await configPromise).unstable_honoEnhancer ||
-  (async (createApp) => createApp);
+  ((createApp) => createApp);
 
-export const handler = handle((await honoEnhancer(createApp))(new Hono()));
+export const handler = handle((honoEnhancer(createApp))(new Hono()));
 `;
 
 export function deployAwsLambdaPlugin(opts: {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -23,6 +23,7 @@ const { Hono } = await importHono();
 
 const loadEntries = () => import("${srcEntriesFile}");
 let serve;
+let app
 
 const createApp = (app) => {
   app.use((c, next) => serve(c, next));
@@ -43,8 +44,6 @@ const createApp = (app) => {
   });
   return app;
 };
-
-let app;
 
 export default {
   async fetch(request, env, ctx) {

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -44,10 +44,18 @@ const createApp = (app) => {
   return app;
 };
 
+let app;
+
 export default {
   async fetch(request, env, ctx) {
     if (!serve) {
       serve = serverEngine({ cmd: "start", loadEntries, env });
+    }
+    if (!app) {
+      const entries = await loadEntries();
+      const config = await entries.loadConfig();
+      const honoEnhancer = config.unstable_honoEnhancer || ((createApp) => createApp);
+      app = honoEnhancer(createApp)(new Hono());
     }
     return app.fetch(request, env, ctx);
   },

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -17,22 +17,22 @@ import { DIST_ENTRIES_JS, DIST_PUBLIC } from '../builder/constants.js';
 const SERVE_JS = 'serve-cloudflare.js';
 
 const getServeJsContent = (srcEntriesFile: string) => `
-import { serverEngine, importHono } from "waku/unstable_hono";
+import { serverEngine, importHono } from 'waku/unstable_hono';
 
 const { Hono } = await importHono();
 
-const loadEntries = () => import("${srcEntriesFile}");
+const loadEntries = () => import('${srcEntriesFile}');
 let serve;
-let app
+let app;
 
 const createApp = (app) => {
   app.use((c, next) => serve(c, next));
   app.notFound(async (c) => {
     const assetsFetcher = c.env.ASSETS;
     const url = new URL(c.req.raw.url);
-    const errorHtmlUrl = url.origin + "/404.html";
+    const errorHtmlUrl = url.origin + '/404.html';
     const notFoundStaticAssetResponse = await assetsFetcher.fetch(
-      new URL(errorHtmlUrl)
+      new URL(errorHtmlUrl),
     );
     if (
       notFoundStaticAssetResponse &&
@@ -40,7 +40,7 @@ const createApp = (app) => {
     ) {
       return c.body(notFoundStaticAssetResponse.body, 404);
     }
-    return c.text("404 Not Found", 404);
+    return c.text('404 Not Found', 404);
   });
   return app;
 };
@@ -48,12 +48,13 @@ const createApp = (app) => {
 export default {
   async fetch(request, env, ctx) {
     if (!serve) {
-      serve = serverEngine({ cmd: "start", loadEntries, env });
+      serve = serverEngine({ cmd: 'start', loadEntries, env });
     }
     if (!app) {
       const entries = await loadEntries();
       const config = await entries.loadConfig();
-      const honoEnhancer = config.unstable_honoEnhancer || ((createApp) => createApp);
+      const honoEnhancer =
+        config.unstable_honoEnhancer || ((createApp) => createApp);
       app = honoEnhancer(createApp)(new Hono());
     }
     return app.fetch(request, env, ctx);

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -56,8 +56,8 @@ export default {
     if (!honoEnhanced) {
       const honoEnhancer =
         (await configPromise).unstable_honoEnhancer ||
-        (async (createApp) => createApp);
-      honoEnhanced = (await honoEnhancer(createApp))(new Hono());
+        ((createApp) => createApp);
+      honoEnhanced = honoEnhancer(createApp)(new Hono());
     }
     return honoEnhanced.fetch(request, env, ctx);
   },

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
@@ -15,29 +15,38 @@ const { Hono } = await importHono();
 
 const loadEntries = () => import('${srcEntriesFile}');
 let serve;
+let app
 
-const app = new Hono();
-app.use((c, next) => serve(c, next));
-app.notFound(async (c) => {
-  const assetsFetcher = c.env.assets;
-  // check if there's a 404.html in the static assets
-  const notFoundStaticAssetResponse = await assetsFetcher.fetch('/404.html');
-  // if there is, return it
-  if (notFoundStaticAssetResponse) {
-    return new Response(notFoundStaticAssetResponse.body, {
-      status: 404,
-      statusText: 'Not Found',
-      headers: notFoundStaticAssetResponse.headers,
-    });
-  }
-  // otherwise, return a simple 404 response
-  return c.text('404 Not Found', 404);
-});
+const createApp = (app) => {
+  app.use((c, next) => serve(c, next));
+  app.notFound(async (c) => {
+    const assetsFetcher = c.env.ASSETS;
+    const url = new URL(c.req.raw.url);
+    const errorHtmlUrl = url.origin + "/404.html";
+    const notFoundStaticAssetResponse = await assetsFetcher.fetch(
+      new URL(errorHtmlUrl)
+    );
+    if (
+      notFoundStaticAssetResponse &&
+      notFoundStaticAssetResponse.status < 400
+    ) {
+      return c.body(notFoundStaticAssetResponse.body, 404);
+    }
+    return c.text("404 Not Found", 404);
+  });
+  return app;
+};
 
 export default {
-  onFetch(request, lobby, ctx) {
+  async onFetch(request, lobby, ctx) {
     if (!serve) {
       serve = serverEngine({ cmd: 'start', loadEntries, env: lobby });
+    }
+    if (!app) {
+      const entries = await loadEntries();
+      const config = await entries.loadConfig();
+      const honoEnhancer = config.unstable_honoEnhancer || ((createApp) => createApp);
+      app = honoEnhancer(createApp)(new Hono());
     }
     return app.fetch(request, lobby, ctx);
   },

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
@@ -15,16 +15,16 @@ const { Hono } = await importHono();
 
 const loadEntries = () => import('${srcEntriesFile}');
 let serve;
-let app
+let app;
 
 const createApp = (app) => {
   app.use((c, next) => serve(c, next));
   app.notFound(async (c) => {
     const assetsFetcher = c.env.ASSETS;
     const url = new URL(c.req.raw.url);
-    const errorHtmlUrl = url.origin + "/404.html";
+    const errorHtmlUrl = url.origin + '/404.html';
     const notFoundStaticAssetResponse = await assetsFetcher.fetch(
-      new URL(errorHtmlUrl)
+      new URL(errorHtmlUrl),
     );
     if (
       notFoundStaticAssetResponse &&
@@ -32,7 +32,7 @@ const createApp = (app) => {
     ) {
       return c.body(notFoundStaticAssetResponse.body, 404);
     }
-    return c.text("404 Not Found", 404);
+    return c.text('404 Not Found', 404);
   });
   return app;
 };
@@ -45,7 +45,8 @@ export default {
     if (!app) {
       const entries = await loadEntries();
       const config = await entries.loadConfig();
-      const honoEnhancer = config.unstable_honoEnhancer || ((createApp) => createApp);
+      const honoEnhancer =
+        config.unstable_honoEnhancer || ((createApp) => createApp);
       app = honoEnhancer(createApp)(new Hono());
     }
     return app.fetch(request, lobby, ctx);


### PR DESCRIPTION
Update `unstable_honoEnhancer` to accept an async function to support dynamic imports.

Update `unstable_honoEnhancer` to pass in the Hono app and the `serveWaku` Hono middleware handler.

Load waku config and invoke `unstable_honoEnhancer` in cloudflare build. If this looks good, we should all this too all of the deploy options.

With these changes, I am able to update my waku.config.ts to this in my Cloudflare Pages project: 

```ts
import type { Hono, MiddlewareHandler } from "hono";
import type { Config, unstable_HonoEnhancer } from "waku/config";

const addApiRoutes = (app: Hono) => {
  app.get("/api/hello", (c) => {
    return c.json({ hello: "world" });
  });
  return app;
};

// @ts-expect-error TODO figure out the right way to cast types here
const wakuConfig: Config = {
  ...(import.meta.env && !import.meta.env.PROD
    ? {
        unstable_honoEnhancer: async (createApp) => {
          const devServer = (await import("./waku.cloudflare-dev-server")).cloudflareDevServer({
            // Optional config settings for the Cloudflare dev server (wrangler proxy)
            // https://developers.cloudflare.com/workers/wrangler/api/#parameters-1
            persist: {
              path: ".wrangler/state/v3",
            },
          });
          return (app: Hono) => {
            // @ts-ignore ignoring types here for now
            return createApp(addApiRoutes(app));
          }
        },
      }
    : {
      // @ts-ignore ignoring types here for now
      unstable_honoEnhancer: (createApp) => (app) => createApp(addApiRoutes(app)),
    }),
  middleware: () => {
    return [
      import("waku/middleware/dev-server"),
      import("waku/middleware/headers"),
      import("waku/middleware/ssr"),
      import("waku/middleware/rsc"),
    ];
  },
};

export default wakuConfig;
```

I use `waku dev` for local development and my API route is accessible.

I use `NODE_ENV=production npm run build -- --with-cloudflare` to build.

Unfortunately... when I deploy to cloudflare, I am getting a strange error when trying to access the API route:

```
Cannot access 'loadConfig' before initialization
```

for the line with `const configPromise = loadEntries().then((entries) => entries.loadConfig());`

It works without error when I run the build using `npx wrangler pages dev` so that is strange.

