### PR TITLE
feat: make context available to middleware

### DIFF
--- a/packages/waku/src/lib/hono/engine.ts
+++ b/packages/waku/src/lib/hono/engine.ts
@@ -1,6 +1,9 @@
 import type { Context, Env, MiddlewareHandler } from 'hono';
 
-import { unstable_getCustomContext } from '../../server.js';
+import {
+  runWithRenderStoreInternal,
+  unstable_getCustomContext,
+} from '../../server.js';
 import { resolveConfig } from '../config.js';
 import type { HandlerContext, MiddlewareOptions } from '../middleware/types.js';
 
@@ -59,7 +62,13 @@ export const serverEngine = (options: MiddlewareOptions): MiddlewareHandler => {
         }
       });
     };
-    await run(0);
+    const renderStore = {
+      context: ctx.context,
+      rerender: () => {
+        throw new Error('Cannot rerender');
+      },
+    };
+    await runWithRenderStoreInternal(renderStore, () => run(0));
     if (ctx.res.body || ctx.res.status) {
       return c.body(
         ctx.res.body || null,


### PR DESCRIPTION
Re: #914  I noticed I had to use `ctx.context.__hono_context` to access the hono context from middleware. While that is ok, I thought it might be useful to try to make the `ctx.context` available to middleware from the `unstable_getCustomContext` API.