### PR TITLE
fix(create-waku): downgrade ncc

### DIFF
--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -29,7 +29,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/prompts": "^2.4.9",
     "@types/tar": "^6.1.13",
-    "@vercel/ncc": "^0.38.2",
+    "@vercel/ncc": "0.38.1",
     "fs-extra": "^11.2.0",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,8 +995,8 @@ importers:
         specifier: ^6.1.13
         version: 6.1.13
       '@vercel/ncc':
-        specifier: ^0.38.2
-        version: 0.38.2
+        specifier: 0.38.1
+        version: 0.38.1
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -2217,8 +2217,8 @@ packages:
     peerDependencies:
       vite: 5.4.8
 
-  '@vercel/ncc@0.38.2':
-    resolution: {integrity: sha512-3yel3jaxUg9pHBv4+KeC9qlbdZPug+UMtUOlhvpDYCMSgcNSrS2Hv1LoqMsOV7hf2lYscx+BESfJOIla1WsmMQ==}
+  '@vercel/ncc@0.38.1':
+    resolution: {integrity: sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==}
     hasBin: true
 
   '@vitejs/plugin-react@4.3.2':
@@ -6186,7 +6186,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@vercel/ncc@0.38.2': {}
+  '@vercel/ncc@0.38.1': {}
 
   '@vitejs/plugin-react@4.3.2(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))':
     dependencies:


### PR DESCRIPTION
`@vercel/ncc@0.38.2` seems to break create-waku's `notifyUpdate`.

Here's the error log:
```
TypeError: undefined is not a function
    at notifyUpdate (file:///.../node_modules/create-waku/dist/index.js:30:110825)
```

@himself65 @ojj1123 do you think it's fixable?

In the meantime, let's downgrade `ncc`.