### PR TITLE
refactor: rename various things

### DIFF
--- a/docs/minimal-api.mdx
+++ b/docs/minimal-api.mdx
@@ -16,9 +16,9 @@ import App from './components/App.js';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
 );
@@ -47,7 +47,7 @@ const rootElement = (
 createRoot(document.getElementById('root')!).render(rootElement);
 ```
 
-The `initialInput` prop can be passed to the `Root` Component, overriding the default input which is `""`. You can also re-render a React Server Component with new input.
+The `initialRscPath` prop can be passed to the `Root` Component, overriding the default rscPath which is `""`. You can also re-render a React Server Component with new rscPath.
 
 ```tsx
 import { useRefetch } from 'waku/client';
@@ -71,9 +71,9 @@ import { defineEntries } from 'waku/server';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig

--- a/e2e/fixtures/rsc-basic/src/entries.tsx
+++ b/e2e/fixtures/rsc-basic/src/entries.tsx
@@ -5,13 +5,13 @@ const App = lazy(() => import('./components/App.js'));
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   () => {
     throw new Error('SSR is should not be used in this test.');

--- a/e2e/fixtures/rsc-css-modules/src/entries.tsx
+++ b/e2e/fixtures/rsc-css-modules/src/entries.tsx
@@ -5,13 +5,13 @@ const App = lazy(() => import('./components/App.js'));
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   () => {
     throw new Error('SSR should not be used in this test.');

--- a/e2e/fixtures/ssr-basic/src/entries.tsx
+++ b/e2e/fixtures/ssr-basic/src/entries.tsx
@@ -6,19 +6,19 @@ const App = lazy(() => import('./components/App.js'));
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
+++ b/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
@@ -1,7 +1,7 @@
 import type { Middleware } from 'waku/config';
 import wakuConfig from '../../waku.config.js';
 
-const { rscPath } = wakuConfig;
+const { rscBase } = wakuConfig;
 
 const stringToStream = (str: string): ReadableStream => {
   const encoder = new TextEncoder();
@@ -17,7 +17,7 @@ const validateMiddleware: Middleware = () => {
   return async (ctx, next) => {
     if (
       ctx.req.url.pathname === '/invalid' ||
-      ctx.req.url.pathname.startsWith(`/${rscPath}/invalid`)
+      ctx.req.url.pathname.startsWith(`/${rscBase}/invalid`)
     ) {
       ctx.res.status = 401;
       ctx.res.body = stringToStream('Unauthorized');

--- a/e2e/fixtures/ssr-catch-error/waku.config.ts
+++ b/e2e/fixtures/ssr-catch-error/waku.config.ts
@@ -7,8 +7,8 @@ export default {
     import('waku/middleware/fallback'),
   ],
   /**
-   * Prefix for HTTP requests to indicate RSC requests.
+   * Base path for HTTP requests to indicate RSC requests.
    * Defaults to "RSC".
    */
-  rscPath: 'RSC', // Just for clarification in tests
+  rscBase: 'RSC', // Just for clarification in tests
 };

--- a/e2e/fixtures/ssr-context-provider/src/entries.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/entries.tsx
@@ -13,13 +13,13 @@ export default defineEntries(
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/e2e/fixtures/ssr-swr/src/entries.tsx
+++ b/e2e/fixtures/ssr-swr/src/entries.tsx
@@ -6,19 +6,19 @@ const App = lazy(() => import('./components/App.js'));
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/e2e/fixtures/ssr-target-bundle/src/entries.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/entries.tsx
@@ -8,19 +8,19 @@ const App = lazy(() => import('./components/App.js'));
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/08_cookies/src/entries.tsx
+++ b/examples/08_cookies/src/entries.tsx
@@ -11,7 +11,7 @@ import App from './components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     const context = getCustomContext<{ count: number }>();
     ++context.count;
     const items = JSON.parse(
@@ -24,19 +24,19 @@ export default defineEntries(
       ),
     );
     return {
-      App: <App name={input || 'Waku'} items={items} />,
+      App: <App name={rscPath || 'Waku'} items={items} />,
     };
   },
   // getBuildConfig
   async () => [
-    { pathname: '/', entries: [{ input: '' }], context: { count: 0 } },
+    { pathname: '/', entries: [{ rscPath: '' }], context: { count: 0 } },
   ],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/09_api/src/entries.tsx
+++ b/examples/09_api/src/entries.tsx
@@ -5,19 +5,19 @@ import App from './components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/11_form/src/entries.tsx
+++ b/examples/11_form/src/entries.tsx
@@ -4,19 +4,19 @@ import App from './components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/12_css/src/entries.tsx
+++ b/examples/12_css/src/entries.tsx
@@ -6,23 +6,23 @@ import App from './components/app';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
       App: (
         <Layout>
-          <App name={input || 'Waku'} />
+          <App name={rscPath || 'Waku'} />
         </Layout>
       ),
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/13_path-alias/src/entries.tsx
+++ b/examples/13_path-alias/src/entries.tsx
@@ -4,19 +4,19 @@ import App from '@/components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/20_minimal/src/entries.tsx
+++ b/examples/20_minimal/src/entries.tsx
@@ -5,19 +5,19 @@ import App from './components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/21_minimal_js/src/entries.jsx
+++ b/examples/21_minimal_js/src/entries.jsx
@@ -5,19 +5,19 @@ import App from './components/app';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/22_promise/src/entries.tsx
+++ b/examples/22_promise/src/entries.tsx
@@ -4,23 +4,23 @@ import App from './components/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
       App: (
-        <App name={input || 'Waku'}>
+        <App name={rscPath || 'Waku'}>
           <Children />
         </App>
       ),
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: (
             <Slot id="App">
               <h3>A client element</h3>

--- a/examples/23_actions/src/entries.tsx
+++ b/examples/23_actions/src/entries.tsx
@@ -5,19 +5,19 @@ import App from './components2/App';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
+  async (rscPath) => {
     return {
-      App: <App name={input || 'Waku'} />,
+      App: <App name={rscPath || 'Waku'} />,
     };
   },
   // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ input: '' }] }],
+  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
   // getSsrConfig
   async (pathname) => {
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       default:

--- a/examples/24_nesting/src/entries.tsx
+++ b/examples/24_nesting/src/entries.tsx
@@ -8,8 +8,8 @@ import AppWithoutSsr from './components/AppWithoutSsr';
 
 export default defineEntries(
   // renderEntries
-  async (input) => {
-    const params = new URLSearchParams(input || 'App=Waku&InnerApp=0');
+  async (rscPath) => {
+    const params = new URLSearchParams(rscPath || 'App=Waku&InnerApp=0');
     const result: Record<string, ReactNode> = {};
     if (params.has('App')) {
       result.App = <App name={params.get('App')!} />;
@@ -27,17 +27,17 @@ export default defineEntries(
     {
       pathname: '/',
       entries: [
-        { input: '' },
-        { input: 'InnerApp=1', skipPrefetch: true },
-        { input: 'InnerApp=2', skipPrefetch: true },
-        { input: 'InnerApp=3', skipPrefetch: true },
-        { input: 'InnerApp=4', skipPrefetch: true },
-        { input: 'InnerApp=5', skipPrefetch: true },
+        { rscPath: '' },
+        { rscPath: 'InnerApp=1', skipPrefetch: true },
+        { rscPath: 'InnerApp=2', skipPrefetch: true },
+        { rscPath: 'InnerApp=3', skipPrefetch: true },
+        { rscPath: 'InnerApp=4', skipPrefetch: true },
+        { rscPath: 'InnerApp=5', skipPrefetch: true },
       ],
     },
     {
       pathname: '/no-ssr',
-      entries: [{ input: 'AppWithoutSsr' }],
+      entries: [{ rscPath: 'AppWithoutSsr' }],
       isStatic: true,
     },
   ],
@@ -46,7 +46,7 @@ export default defineEntries(
     switch (pathname) {
       case '/':
         return {
-          input: '',
+          rscPath: '',
           html: <Slot id="App" />,
         };
       case '/no-ssr':

--- a/examples/24_nesting/src/main.tsx
+++ b/examples/24_nesting/src/main.tsx
@@ -11,7 +11,7 @@ const rootElement = (
         <Slot id="App" />
       </Root>
     ) : pathname === '/no-ssr' ? (
-      <Root initialInput="AppWithoutSsr">
+      <Root initialRscPath="AppWithoutSsr">
         <Slot id="AppWithoutSsr" />
       </Root>
     ) : (

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -99,7 +99,7 @@ const defaultFetchCache: FetchCache = {};
  * callServer callback
  * This is not a public API.
  */
-export const callServerRSC = async (
+export const callServerRsc = async (
   actionId: string,
   args?: unknown[],
   fetchCache = defaultFetchCache,
@@ -108,7 +108,7 @@ export const callServerRSC = async (
   const createData = (responsePromise: Promise<Response>) =>
     createFromFetch<Awaited<Elements>>(checkStatus(responsePromise), {
       callServer: (actionId: string, args: unknown[]) =>
-        callServerRSC(actionId, args, fetchCache),
+        callServerRsc(actionId, args, fetchCache),
     });
   const url = BASE_PATH + encodeInput(encodeActionId(actionId));
   const responsePromise =
@@ -123,7 +123,7 @@ export const callServerRSC = async (
 
 const prefetchedParams = new WeakMap<Promise<unknown>, unknown>();
 
-const fetchRSCInternal = (url: string, params: unknown) =>
+const fetchRscInternal = (url: string, params: unknown) =>
   params === undefined
     ? fetch(url)
     : typeof params === 'string'
@@ -132,7 +132,7 @@ const fetchRSCInternal = (url: string, params: unknown) =>
           fetch(url, { method: 'POST', body }),
         );
 
-export const fetchRSC = (
+export const fetchRsc = (
   input: string,
   params?: unknown,
   fetchCache = defaultFetchCache,
@@ -145,7 +145,7 @@ export const fetchRSC = (
   const createData = (responsePromise: Promise<Response>) =>
     createFromFetch<Awaited<Elements>>(checkStatus(responsePromise), {
       callServer: (actionId: string, args: unknown[]) =>
-        callServerRSC(actionId, args, fetchCache),
+        callServerRsc(actionId, args, fetchCache),
     });
   const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
   const url = BASE_PATH + encodeInput(input);
@@ -157,7 +157,7 @@ export const fetchRSC = (
       prefetchedParams.get(prefetched[url]) === params);
   const responsePromise = hasValidPrefetchedResponse
     ? prefetched[url]
-    : fetchRSCInternal(url, params);
+    : fetchRscInternal(url, params);
   delete prefetched[url];
   const data = enhanceCreateData(createData)(responsePromise);
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -165,11 +165,11 @@ export const fetchRSC = (
   return data;
 };
 
-export const prefetchRSC = (input: string, params?: unknown): void => {
+export const prefetchRsc = (input: string, params?: unknown): void => {
   const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
   const url = BASE_PATH + encodeInput(input);
   if (!(url in prefetched)) {
-    prefetched[url] = fetchRSCInternal(url, params);
+    prefetched[url] = fetchRscInternal(url, params);
     prefetchedParams.set(prefetched[url], params);
   }
 };
@@ -196,7 +196,7 @@ export const Root = ({
 }) => {
   fetchCache[ENHANCE_CREATE_DATA] = unstable_enhanceCreateData;
   const [elements, setElements] = useState(() =>
-    fetchRSC(initialInput || '', initialParams, fetchCache),
+    fetchRsc(initialInput || '', initialParams, fetchCache),
   );
   useEffect(() => {
     fetchCache[SET_ELEMENTS] = setElements;
@@ -205,7 +205,7 @@ export const Root = ({
     (input: string, params?: unknown) => {
       // clear cache entry before fetching
       delete fetchCache[ENTRY];
-      const data = fetchRSC(input, params, fetchCache);
+      const data = fetchRsc(input, params, fetchCache);
       setElements((prev) => mergeElements(prev, data));
     },
     [fetchCache],

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -25,7 +25,7 @@ declare global {
 }
 
 const BASE_PATH = `${import.meta.env?.WAKU_CONFIG_BASE_PATH}${
-  import.meta.env?.WAKU_CONFIG_RSC_PATH
+  import.meta.env?.WAKU_CONFIG_RSC_BASE
 }/`;
 
 const checkStatus = async (

--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -14,7 +14,7 @@ import {
 import type { ReactNode } from 'react';
 import RSDWClient from 'react-server-dom-webpack/client';
 
-import { encodeInput, encodeActionId } from './lib/renderers/utils.js';
+import { encodeInput, encodeFuncId } from './lib/renderers/utils.js';
 
 const { createFromFetch, encodeReply } = RSDWClient;
 
@@ -100,17 +100,17 @@ const defaultFetchCache: FetchCache = {};
  * This is not a public API.
  */
 export const callServerRsc = async (
-  actionId: string,
+  funcId: string,
   args?: unknown[],
   fetchCache = defaultFetchCache,
 ) => {
   const enhanceCreateData = fetchCache[ENHANCE_CREATE_DATA] || ((d) => d);
   const createData = (responsePromise: Promise<Response>) =>
     createFromFetch<Awaited<Elements>>(checkStatus(responsePromise), {
-      callServer: (actionId: string, args: unknown[]) =>
-        callServerRsc(actionId, args, fetchCache),
+      callServer: (funcId: string, args: unknown[]) =>
+        callServerRsc(funcId, args, fetchCache),
     });
-  const url = BASE_PATH + encodeInput(encodeActionId(actionId));
+  const url = BASE_PATH + encodeInput(encodeFuncId(funcId));
   const responsePromise =
     args === undefined
       ? fetch(url)
@@ -144,8 +144,8 @@ export const fetchRsc = (
   const enhanceCreateData = fetchCache[ENHANCE_CREATE_DATA] || ((d) => d);
   const createData = (responsePromise: Promise<Response>) =>
     createFromFetch<Awaited<Elements>>(checkStatus(responsePromise), {
-      callServer: (actionId: string, args: unknown[]) =>
-        callServerRsc(actionId, args, fetchCache),
+      callServer: (funcId: string, args: unknown[]) =>
+        callServerRsc(funcId, args, fetchCache),
     });
   const prefetched = ((globalThis as any).__WAKU_PREFETCHED__ ||= {});
   const url = BASE_PATH + encodeInput(input);

--- a/packages/waku/src/config.ts
+++ b/packages/waku/src/config.ts
@@ -33,10 +33,10 @@ export interface Config {
    */
   privateDir?: string;
   /**
-   * Prefix for HTTP requests to indicate RSC requests.
+   * Bse path for HTTP requests to indicate RSC requests.
    * Defaults to "RSC".
    */
-  rscPath?: string;
+  rscBase?: string;
   /**
    * Middleware to use
    * Defaults to:

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -607,9 +607,9 @@ const emitHtmlFiles = async (
           pathname,
           searchParams: new URLSearchParams(),
           htmlHead,
-          renderRscForHtml: (input, params) =>
+          renderRscForHtml: (input, rscParams) =>
             renderRsc(
-              { env, config, input, context, decodedBody: params },
+              { env, config, input, context, decodedBody: rscParams },
               { isDev: false, entries: distEntries },
             ),
           getSsrConfigForHtml: (pathname, searchParams) =>

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -438,7 +438,7 @@ const emitRscFiles = async (
           rootDir,
           config.distDir,
           DIST_PUBLIC,
-          config.rscPath,
+          config.rscBase,
           encodeInput(input),
         );
         // Skip if the file already exists.
@@ -523,7 +523,7 @@ const emitHtmlFiles = async (
     type === 'asset' && !fileName.endsWith('.js') ? [fileName] : [],
   );
   const cssAssets = nonJsAssets.filter((asset) => asset.endsWith('.css'));
-  const basePrefix = config.basePath + config.rscPath + '/';
+  const basePrefix = config.basePath + config.rscBase + '/';
   const publicIndexHtmlFile = joinPath(
     rootDir,
     config.distDir,

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -31,7 +31,7 @@ import {
   unlink,
   writeFile,
 } from '../utils/node-fs.js';
-import { encodeInput, generatePrefetchCode } from '../renderers/utils.js';
+import { encodeRscPath, generatePrefetchCode } from '../renderers/utils.js';
 import {
   getBuildConfig,
   getSsrConfig,
@@ -411,35 +411,35 @@ const emitRscFiles = async (
   buildConfig: BuildConfig,
 ) => {
   const clientModuleMap = new Map<string, Set<string>>();
-  const addClientModule = (input: string, id: string) => {
-    let idSet = clientModuleMap.get(input);
+  const addClientModule = (rscPath: string, id: string) => {
+    let idSet = clientModuleMap.get(rscPath);
     if (!idSet) {
       idSet = new Set();
-      clientModuleMap.set(input, idSet);
+      clientModuleMap.set(rscPath, idSet);
     }
     idSet.add(id);
   };
-  const getClientModules = (input: string) => {
-    const idSet = clientModuleMap.get(input);
+  const getClientModules = (rscPath: string) => {
+    const idSet = clientModuleMap.get(rscPath);
     return Array.from(idSet || []);
   };
   const staticInputSet = new Set<string>();
   await Promise.all(
     Array.from(buildConfig).map(async ({ entries, context }) => {
-      for (const { input, isStatic } of entries || []) {
+      for (const { rscPath, isStatic } of entries || []) {
         if (!isStatic) {
           continue;
         }
-        if (staticInputSet.has(input)) {
+        if (staticInputSet.has(rscPath)) {
           continue;
         }
-        staticInputSet.add(input);
+        staticInputSet.add(rscPath);
         const destRscFile = joinPath(
           rootDir,
           config.distDir,
           DIST_PUBLIC,
           config.rscBase,
-          encodeInput(input),
+          encodeRscPath(rscPath),
         );
         // Skip if the file already exists.
         if (existsSync(destRscFile)) {
@@ -450,9 +450,9 @@ const emitRscFiles = async (
           {
             env,
             config,
-            input,
+            rscPath,
             context,
-            moduleIdCallback: (id) => addClientModule(input, id),
+            moduleIdCallback: (id) => addClientModule(rscPath, id),
           },
           {
             isDev: false,
@@ -516,7 +516,7 @@ const emitHtmlFiles = async (
   distEntriesFile: string,
   distEntries: EntriesPrd,
   buildConfig: BuildConfig,
-  getClientModules: (input: string) => string[],
+  getClientModules: (rscPath: string) => string[],
   clientBuildOutput: Awaited<ReturnType<typeof buildClientBundle>>,
 ) => {
   const nonJsAssets = clientBuildOutput.output.flatMap(({ type, fileName }) =>
@@ -559,12 +559,12 @@ const emitHtmlFiles = async (
           htmlStr = htmlStr.replace(/<\/head>/, cssStr);
           htmlHead += cssStr;
         }
-        const inputsForPrefetch = new Set<string>();
+        const rscPathsForPrefetch = new Set<string>();
         const moduleIdsForPrefetch = new Set<string>();
-        for (const { input, skipPrefetch } of entries || []) {
+        for (const { rscPath, skipPrefetch } of entries || []) {
           if (!skipPrefetch) {
-            inputsForPrefetch.add(input);
-            for (const id of getClientModules(input)) {
+            rscPathsForPrefetch.add(rscPath);
+            for (const id of getClientModules(rscPath)) {
               moduleIdsForPrefetch.add(id);
             }
           }
@@ -572,7 +572,7 @@ const emitHtmlFiles = async (
         const code =
           generatePrefetchCode(
             basePrefix,
-            inputsForPrefetch,
+            rscPathsForPrefetch,
             moduleIdsForPrefetch,
           ) + (customCode || '');
         if (code) {
@@ -607,9 +607,9 @@ const emitHtmlFiles = async (
           pathname,
           searchParams: new URLSearchParams(),
           htmlHead,
-          renderRscForHtml: (input, rscParams) =>
+          renderRscForHtml: (rscPath, rscParams) =>
             renderRsc(
-              { env, config, input, context, decodedBody: rscParams },
+              { env, config, rscPath, context, decodedBody: rscParams },
               { isDev: false, entries: distEntries },
             ),
           getSsrConfigForHtml: (pathname, searchParams) =>

--- a/packages/waku/src/lib/config.ts
+++ b/packages/waku/src/lib/config.ts
@@ -23,7 +23,7 @@ export async function resolveConfig(config: Config) {
     distDir: 'dist',
     preserveModuleDirs: ['pages', 'templates', 'routes', 'components'],
     privateDir: 'private',
-    rscPath: 'RSC',
+    rscBase: 'RSC',
     middleware: DEFAULT_MIDDLEWARE,
     unstable_honoEnhancer: undefined,
     ...config,

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -393,9 +393,9 @@ export const devServer: Middleware = (options) => {
     };
 
     if (
-      // HACK depending on `rscPath` is a bad idea
+      // HACK depending on `rscBase` is a bad idea
       // FIXME This hack should be removed as well as `willBeHandled`
-      ctx.req.url.pathname.startsWith(config.basePath + config.rscPath + '/') ||
+      ctx.req.url.pathname.startsWith(config.basePath + config.rscBase + '/') ||
       !(await willBeHandled(ctx.req.url.pathname))
     ) {
       await next();

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -1,5 +1,5 @@
 import { resolveConfig } from '../config.js';
-import { decodeInput, hasStatusCode } from '../renderers/utils.js';
+import { decodeRscPath, hasStatusCode } from '../renderers/utils.js';
 import { renderRsc } from '../renderers/rsc-renderer.js';
 import type { RenderRscArgs } from '../renderers/rsc-renderer.js';
 import type { Middleware } from './types.js';
@@ -27,13 +27,13 @@ export const rsc: Middleware = (options) => {
     if (ctx.req.url.pathname.startsWith(basePrefix)) {
       const { headers } = ctx.req;
       try {
-        const input = decodeInput(
+        const rscPath = decodeRscPath(
           decodeURI(ctx.req.url.pathname.slice(basePrefix.length)),
         );
         const args: RenderRscArgs = {
           env,
           config,
-          input,
+          rscPath,
           context: ctx.context,
           decodedBody: headers['x-waku-params'],
           body: ctx.req.body,

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -23,7 +23,7 @@ export const rsc: Middleware = (options) => {
       configPromise,
       entriesPromise,
     ]);
-    const basePrefix = config.basePath + config.rscPath + '/';
+    const basePrefix = config.basePath + config.rscBase + '/';
     if (ctx.req.url.pathname.startsWith(basePrefix)) {
       const { headers } = ctx.req;
       try {

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -39,11 +39,11 @@ export const ssr: Middleware = (options) => {
           pathname: ctx.req.url.pathname,
           searchParams: ctx.req.url.searchParams,
           htmlHead,
-          renderRscForHtml: async (input, rscParams) => {
+          renderRscForHtml: async (rscPath, rscParams) => {
             const args: RenderRscArgs = {
               env,
               config,
-              input,
+              rscPath,
               context: ctx.context,
               decodedBody: rscParams,
               contentType: '',

--- a/packages/waku/src/lib/middleware/ssr.ts
+++ b/packages/waku/src/lib/middleware/ssr.ts
@@ -39,13 +39,13 @@ export const ssr: Middleware = (options) => {
           pathname: ctx.req.url.pathname,
           searchParams: ctx.req.url.searchParams,
           htmlHead,
-          renderRscForHtml: async (input, params) => {
+          renderRscForHtml: async (input, rscParams) => {
             const args: RenderRscArgs = {
               env,
               config,
               input,
               context: ctx.context,
-              decodedBody: params,
+              decodedBody: rscParams,
               contentType: '',
             };
             const readable = await (devServer

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -84,7 +84,6 @@ type StaticRoutes = { version: number; include: string[]; exclude: string[] };
 export function deployCloudflarePlugin(opts: {
   srcDir: string;
   distDir: string;
-  rscPath: string;
   privateDir: string;
 }): Plugin {
   const platformObject = unstable_getPlatformObject();

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
@@ -42,7 +42,7 @@ export function deployVercelPlugin(opts: {
   srcDir: string;
   distDir: string;
   basePath: string;
-  rscPath: string;
+  rscBase: string;
   privateDir: string;
 }): Plugin {
   const platformObject = unstable_getPlatformObject();
@@ -95,7 +95,7 @@ export function deployVercelPlugin(opts: {
         const serverlessDir = path.join(
           outputDir,
           'functions',
-          opts.rscPath + '.func',
+          opts.rscBase + '.func',
         );
         mkdirSync(path.join(serverlessDir, opts.distDir), {
           recursive: true,
@@ -133,7 +133,7 @@ export function deployVercelPlugin(opts: {
               { handle: 'filesystem' },
               {
                 src: opts.basePath + '(.*)',
-                dest: opts.basePath + opts.rscPath + '/',
+                dest: opts.basePath + opts.rscBase + '/',
               },
             ]
           : undefined;

--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -3,7 +3,7 @@ import { readdir, writeFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { SRC_ENTRIES, EXTENSIONS } from '../constants.js';
 import { joinPath } from '../utils/path.js';
-import { getInputString } from '../../router/common.js';
+import { getRscPath } from '../../router/common.js';
 
 const SRC_PAGES = 'pages';
 
@@ -44,7 +44,7 @@ export function getImportModuleNames(filePaths: string[]): {
       identifier = `${identifier}_${moduleNameCount[identifier]}`;
     }
     try {
-      moduleNames[getInputString(filePath)] = identifier;
+      moduleNames[getRscPath(filePath)] = identifier;
     } catch (e) {
       console.log(e);
     }
@@ -128,7 +128,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
 
         for (const filePath of filePaths) {
           // where to import the component from
-          const src = getInputString(filePath);
+          const src = getRscPath(filePath);
           const hasGetConfig = fileExportsGetConfig(filePath);
 
           if (filePath.endsWith('/_layout.tsx')) {

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-analyze.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-analyze.ts
@@ -18,7 +18,7 @@ const hash = async (code: string): Promise<string> => {
     .slice(0, 9);
 };
 
-const isServerAction = (
+const isServerFunction = (
   node:
     | swc.FunctionDeclaration
     | swc.FunctionExpression
@@ -32,7 +32,7 @@ const isServerAction = (
       s.expression.value === 'use server',
   );
 
-const containsServerAction = (mod: swc.Module): boolean => {
+const containsServerFunction = (mod: swc.Module): boolean => {
   const walk = (node: swc.Node): boolean => {
     if (
       node.type === 'FunctionDeclaration' ||
@@ -40,7 +40,7 @@ const containsServerAction = (mod: swc.Module): boolean => {
       node.type === 'ArrowFunctionExpression'
     ) {
       if (
-        isServerAction(
+        isServerFunction(
           node as
             | swc.FunctionDeclaration
             | swc.FunctionExpression
@@ -107,7 +107,7 @@ export function rscAnalyzePlugin(
           !opts.clientFileSet.has(id) &&
           !opts.serverFileSet.has(id) &&
           code.includes('use server') &&
-          containsServerAction(mod)
+          containsServerFunction(mod)
         ) {
           opts.serverFileSet.add(id);
         }

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-env.ts
@@ -10,7 +10,7 @@ export function rscEnvPlugin({
   env: Record<string, string>;
   config?: {
     basePath: string;
-    rscPath: string;
+    rscBase: string;
   };
 }): Plugin {
   return {
@@ -34,8 +34,8 @@ export function rscEnvPlugin({
                   JSON.stringify(config.basePath),
                 ],
                 [
-                  'import.meta.env.WAKU_CONFIG_RSC_PATH',
-                  JSON.stringify(config.rscPath),
+                  'import.meta.env.WAKU_CONFIG_RSC_BASE',
+                  JSON.stringify(config.rscBase),
                 ],
               ]
             : []),

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -77,14 +77,14 @@ export function rscHmrPlugin(): Plugin {
       if (id.startsWith(wakuClientDist)) {
         // FIXME this is fragile. Can we do it better?
         return code.replace(
-          /\nexport const fetchRSC = \(.*?\)=>\{/,
+          /\nexport const fetchRsc = \(.*?\)=>\{/,
           (m) =>
             m +
             `
 {
   const refetchRsc = () => {
     delete fetchCache[ENTRY];
-    const data = fetchRSC(input, params, fetchCache);
+    const data = fetchRsc(input, params, fetchCache);
     fetchCache[SET_ELEMENTS](() => data);
   };
   globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -84,7 +84,7 @@ export function rscHmrPlugin(): Plugin {
 {
   const refetchRsc = () => {
     delete fetchCache[ENTRY];
-    const data = fetchRsc(input, params, fetchCache);
+    const data = fetchRsc(input, rscParams, fetchCache);
     fetchCache[SET_ELEMENTS](() => data);
   };
   globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -84,7 +84,7 @@ export function rscHmrPlugin(): Plugin {
 {
   const refetchRsc = () => {
     delete fetchCache[ENTRY];
-    const data = fetchRsc(input, rscParams, fetchCache);
+    const data = fetchRsc(rscPath, rscParams, fetchCache);
     fetchCache[SET_ELEMENTS](() => data);
   };
   globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];
@@ -107,8 +107,8 @@ export function rscHmrPlugin(): Plugin {
             `
 {
   const refetchRoute = () => {
-    const input = getInputString(loc.path);
-    refetch(input, loc.searchParams);
+    const rscPath = getInputString(loc.path);
+    refetch(rscPath, loc.searchParams);
   };
   globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];
   const index = globalThis.__WAKU_RSC_RELOAD_LISTENERS__.indexOf(globalThis.__WAKU_REFETCH_ROUTE__);

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -125,7 +125,7 @@ const replaceNode = <T extends swc.Node>(origNode: swc.Node, newNode: T): T => {
   return Object.assign(origNode, newNode);
 };
 
-const transformExportedServerActions = (
+const transformExportedServerFunctions = (
   mod: swc.Module,
   getFuncId: () => string,
 ): boolean => {
@@ -222,7 +222,9 @@ const isUseServerDirective = (node: swc.Node) =>
   ((node as swc.ExpressionStatement).expression as swc.StringLiteral).value ===
     'use server';
 
-const isInlineServerAction = (node: swc.Node): node is FunctionWithBlockBody =>
+const isInlineServerFunction = (
+  node: swc.Node,
+): node is FunctionWithBlockBody =>
   (node.type === 'FunctionDeclaration' ||
     node.type === 'FunctionExpression' ||
     node.type === 'ArrowFunctionExpression') &&
@@ -333,22 +335,22 @@ const collectClosureVars = (
   return varNames;
 };
 
-const transformInlineServerActions = (
+const transformInlineServerFunctions = (
   mod: swc.Module,
   getFuncId: () => string,
 ): boolean => {
-  let serverActionIndex = 0;
-  const serverActions = new Map<
+  let serverFunctionIndex = 0;
+  const serverFunctions = new Map<
     number,
     readonly [FunctionWithBlockBody, string[]]
   >();
-  const registerServerAction = (
+  const registerServerFunction = (
     parentFn: swc.Fn | swc.ArrowFunctionExpression | undefined,
     fn: FunctionWithBlockBody,
   ): swc.CallExpression => {
     const closureVars = collectClosureVars(parentFn, fn);
-    serverActions.set(++serverActionIndex, [fn, closureVars]);
-    const name = '__waku_action' + serverActionIndex;
+    serverFunctions.set(++serverFunctionIndex, [fn, closureVars]);
+    const name = '__waku_func' + serverFunctionIndex;
     if (fn.type === 'FunctionDeclaration') {
       fn.identifier = createIdentifier(name);
     }
@@ -369,8 +371,8 @@ const transformInlineServerActions = (
     parentFn: swc.Fn | swc.ArrowFunctionExpression | undefined,
     decl: swc.Declaration,
   ) => {
-    if (isInlineServerAction(decl)) {
-      const callExp = registerServerAction(parentFn, Object.assign({}, decl));
+    if (isInlineServerFunction(decl)) {
+      const callExp = registerServerFunction(parentFn, Object.assign({}, decl));
       const newDecl: swc.VariableDeclaration = {
         type: 'VariableDeclaration',
         kind: 'const',
@@ -396,8 +398,8 @@ const transformInlineServerActions = (
     parentFn: swc.Fn | swc.ArrowFunctionExpression | undefined,
     exp: swc.Expression,
   ): swc.CallExpression | undefined => {
-    if (isInlineServerAction(exp)) {
-      const callExp = registerServerAction(parentFn, Object.assign({}, exp));
+    if (isInlineServerFunction(exp)) {
+      const callExp = registerServerFunction(parentFn, Object.assign({}, exp));
       return replaceNode(exp, callExp);
     }
   };
@@ -452,15 +454,15 @@ const transformInlineServerActions = (
     }
   };
   walk(undefined, mod);
-  if (!serverActionIndex) {
+  if (!serverFunctionIndex) {
     return false;
   }
-  const serverActionsCode = Array.from(serverActions).flatMap(
-    ([actionIndex, [actionFn, closureVars]]) => {
-      if (actionFn.type === 'FunctionDeclaration') {
+  const serverFunctionsCode = Array.from(serverFunctions).flatMap(
+    ([funcIndex, [func, closureVars]]) => {
+      if (func.type === 'FunctionDeclaration') {
         const stmt1: swc.ExportDeclaration = {
           type: 'ExportDeclaration',
-          declaration: prependArgsToFn(actionFn, closureVars),
+          declaration: prependArgsToFn(func, closureVars),
           span: createEmptySpan(),
         };
         const stmt2: swc.ExpressionStatement = {
@@ -468,9 +470,9 @@ const transformInlineServerActions = (
           expression: createCallExpression(
             createIdentifier('__waku_registerServerReference'),
             [
-              createIdentifier(actionFn.identifier.value),
+              createIdentifier(func.identifier.value),
               createStringLiteral(getFuncId()),
-              createStringLiteral('__waku_action' + actionIndex),
+              createStringLiteral('__waku_func' + funcIndex),
             ],
           ),
           span: createEmptySpan(),
@@ -489,13 +491,13 @@ const transformInlineServerActions = (
             declarations: [
               {
                 type: 'VariableDeclarator',
-                id: createIdentifier('__waku_action' + actionIndex),
+                id: createIdentifier('__waku_func' + funcIndex),
                 init: createCallExpression(
                   createIdentifier('__waku_registerServerReference'),
                   [
-                    prependArgsToFn(actionFn, closureVars),
+                    prependArgsToFn(func, closureVars),
                     createStringLiteral(getFuncId()),
-                    createStringLiteral('__waku_action' + actionIndex),
+                    createStringLiteral('__waku_func' + funcIndex),
                   ],
                 ),
                 definite: false,
@@ -510,7 +512,7 @@ const transformInlineServerActions = (
       }
     },
   );
-  mod.body.splice(findLastImportIndex(mod), 0, ...serverActionsCode);
+  mod.body.splice(findLastImportIndex(mod), 0, ...serverFunctionsCode);
   return true;
 };
 
@@ -558,9 +560,10 @@ export ${name === 'default' ? name : `const ${name} =`} registerClientReference(
     return newCode;
   }
   let transformed =
-    hasUseServer && transformExportedServerActions(mod, () => getServerId(id));
+    hasUseServer &&
+    transformExportedServerFunctions(mod, () => getServerId(id));
   transformed =
-    transformInlineServerActions(mod, () => getServerId(id)) || transformed;
+    transformInlineServerFunctions(mod, () => getServerId(id)) || transformed;
   if (transformed) {
     mod.body.splice(findLastImportIndex(mod), 0, ...serverInitCode);
     const newCode = swc.printSync(mod).code;

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -127,7 +127,7 @@ const replaceNode = <T extends swc.Node>(origNode: swc.Node, newNode: T): T => {
 
 const transformExportedServerActions = (
   mod: swc.Module,
-  getActionId: () => string,
+  getFuncId: () => string,
 ): boolean => {
   let changed = false;
   for (let i = 0; i < mod.body.length; ++i) {
@@ -145,7 +145,7 @@ const transformExportedServerActions = (
           createIdentifier('__waku_registerServerReference'),
           [
             createIdentifier(name),
-            createStringLiteral(getActionId()),
+            createStringLiteral(getFuncId()),
             createStringLiteral(name),
           ],
         ),
@@ -167,7 +167,7 @@ const transformExportedServerActions = (
         createIdentifier('__waku_registerServerReference'),
         [
           Object.assign({}, fn),
-          createStringLiteral(getActionId()),
+          createStringLiteral(getFuncId()),
           createStringLiteral(name),
         ],
       );
@@ -335,7 +335,7 @@ const collectClosureVars = (
 
 const transformInlineServerActions = (
   mod: swc.Module,
-  getActionId: () => string,
+  getFuncId: () => string,
 ): boolean => {
   let serverActionIndex = 0;
   const serverActions = new Map<
@@ -469,7 +469,7 @@ const transformInlineServerActions = (
             createIdentifier('__waku_registerServerReference'),
             [
               createIdentifier(actionFn.identifier.value),
-              createStringLiteral(getActionId()),
+              createStringLiteral(getFuncId()),
               createStringLiteral('__waku_action' + actionIndex),
             ],
           ),
@@ -494,7 +494,7 @@ const transformInlineServerActions = (
                   createIdentifier('__waku_registerServerReference'),
                   [
                     prependArgsToFn(actionFn, closureVars),
-                    createStringLiteral(getActionId()),
+                    createStringLiteral(getFuncId()),
                     createStringLiteral('__waku_action' + actionIndex),
                   ],
                 ),

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -60,11 +60,11 @@ const transformClient = (
     const exportNames = collectExportNames(mod);
     let newCode = `
 import { createServerReference } from 'react-server-dom-webpack/client';
-import { callServerRSC } from 'waku/client';
+import { callServerRsc } from 'waku/client';
 `;
     for (const name of exportNames) {
       newCode += `
-export ${name === 'default' ? name : `const ${name} =`} createServerReference('${getServerId(id)}#${name}', callServerRSC);
+export ${name === 'default' ? name : `const ${name} =`} createServerReference('${getServerId(id)}#${name}', callServerRsc);
 `;
     }
     return newCode;

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -15,7 +15,7 @@ import {
   fileURLToFilePath,
   encodeFilePathToAbsolute,
 } from '../utils/path.js';
-import { encodeInput, hasStatusCode } from './utils.js';
+import { encodeRscPath, hasStatusCode } from './utils.js';
 
 // HACK depending on these constants is not ideal
 import { DEFAULT_HTML_HEAD } from '../plugins/vite-plugin-rsc-index.js';
@@ -173,14 +173,14 @@ export const renderHtml = async (
     searchParams: URLSearchParams;
     htmlHead: string;
     renderRscForHtml: (
-      input: string,
+      rscPath: string,
       rscParams?: unknown,
     ) => Promise<ReadableStream>;
     getSsrConfigForHtml: (
       pathname: string,
       searchParams: URLSearchParams,
     ) => Promise<{
-      input: string;
+      rscPath: string;
       rscParams?: unknown;
       html: ReadableStream;
     } | null>;
@@ -228,7 +228,7 @@ export const renderHtml = async (
   }
   let stream: ReadableStream;
   try {
-    stream = await renderRscForHtml(ssrConfig.input, ssrConfig.rscParams);
+    stream = await renderRscForHtml(ssrConfig.rscPath, ssrConfig.rscParams);
   } catch (e) {
     if (hasStatusCode(e) && e.statusCode === 404) {
       return null;
@@ -309,7 +309,10 @@ export const renderHtml = async (
     .pipeThrough(rectifyHtml())
     .pipeThrough(
       injectHtmlHead(
-        config.basePath + config.rscBase + '/' + encodeInput(ssrConfig.input),
+        config.basePath +
+          config.rscBase +
+          '/' +
+          encodeRscPath(ssrConfig.rscPath),
         htmlHead,
         isDev ? `${config.basePath}${config.srcDir}/${SRC_MAIN}` : '',
       ),

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -174,14 +174,14 @@ export const renderHtml = async (
     htmlHead: string;
     renderRscForHtml: (
       input: string,
-      params?: unknown,
+      rscParams?: unknown,
     ) => Promise<ReadableStream>;
     getSsrConfigForHtml: (
       pathname: string,
       searchParams: URLSearchParams,
     ) => Promise<{
       input: string;
-      params?: unknown;
+      rscParams?: unknown;
       html: ReadableStream;
     } | null>;
   } & (
@@ -228,7 +228,7 @@ export const renderHtml = async (
   }
   let stream: ReadableStream;
   try {
-    stream = await renderRscForHtml(ssrConfig.input, ssrConfig.params);
+    stream = await renderRscForHtml(ssrConfig.input, ssrConfig.rscParams);
   } catch (e) {
     if (hasStatusCode(e) && e.statusCode === 404) {
       return null;

--- a/packages/waku/src/lib/renderers/html-renderer.ts
+++ b/packages/waku/src/lib/renderers/html-renderer.ts
@@ -309,7 +309,7 @@ export const renderHtml = async (
     .pipeThrough(rectifyHtml())
     .pipeThrough(
       injectHtmlHead(
-        config.basePath + config.rscPath + '/' + encodeInput(ssrConfig.input),
+        config.basePath + config.rscBase + '/' + encodeInput(ssrConfig.input),
         htmlHead,
         isDev ? `${config.basePath}${config.srcDir}/${SRC_MAIN}` : '',
       ),

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -151,10 +151,10 @@ export async function renderRsc(
     });
   };
 
-  const renderWithContextWithAction = async (
+  const renderWithContextWithFunc = async (
     context: Record<string, unknown> | undefined,
-    actionFn: (...args: unknown[]) => unknown,
-    actionArgs: unknown[],
+    fn: (...args: unknown[]) => unknown,
+    args: unknown[],
   ) => {
     let elementsPromise: Promise<Record<string, ReactNode>> = Promise.resolve(
       {},
@@ -177,14 +177,14 @@ export async function renderRsc(
       },
     };
     return runWithRenderStoreInternal(renderStore, async () => {
-      const actionValue = await actionFn(...actionArgs);
+      const value = await fn(...args);
       const elements = await elementsPromise;
       rendered = true;
       if (Object.keys(elements).some((key) => key.startsWith('_'))) {
         throw new Error('"_" prefix is reserved');
       }
       return renderToReadableStream(
-        { ...elements, _value: actionValue },
+        { ...elements, _value: value },
         clientBundlerConfig,
         {
           onError,
@@ -223,7 +223,7 @@ export async function renderRsc(
       mod = await loadModule(fileId.slice('@id/'.length));
     }
     const fn = mod[name] || mod;
-    return renderWithContextWithAction(context, fn, args);
+    return renderWithContextWithFunc(context, fn, args);
   }
 
   return renderWithContext(context, input, decodedBody);

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -11,7 +11,7 @@ import type {
 import type { ResolvedConfig } from '../config.js';
 import { filePathToFileURL } from '../utils/path.js';
 import { streamToArrayBuffer } from '../utils/stream.js';
-import { decodeActionId } from '../renderers/utils.js';
+import { decodeFuncId } from '../renderers/utils.js';
 import { bufferToString, parseFormData } from '../utils/buffer.js';
 
 export const SERVER_MODULE_MAP = {
@@ -209,10 +209,10 @@ export async function renderRsc(
     }
   }
 
-  const actionId = decodeActionId(input);
-  if (actionId) {
+  const funcId = decodeFuncId(input);
+  if (funcId) {
     const args = Array.isArray(decodedBody) ? decodedBody : [];
-    const [fileId, name] = actionId.split('#') as [string, string];
+    const [fileId, name] = funcId.split('#') as [string, string];
     let mod: any;
     if (isDev) {
       mod = await opts.loadServerModuleRsc(filePathToFileURL(fileId));

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -127,7 +127,7 @@ export async function renderRsc(
   const renderWithContext = async (
     context: Record<string, unknown> | undefined,
     input: string,
-    params: unknown,
+    rscParams: unknown,
   ) => {
     const renderStore = {
       context: context || {},
@@ -136,7 +136,7 @@ export async function renderRsc(
       },
     };
     return runWithRenderStoreInternal(renderStore, async () => {
-      const elements = await renderEntries(input, { params });
+      const elements = await renderEntries(input, { rscParams });
       if (elements === null) {
         const err = new Error('No function component found');
         (err as any).statusCode = 404; // HACK our convention for NotFound
@@ -162,13 +162,13 @@ export async function renderRsc(
     let rendered = false;
     const renderStore = {
       context: context || {},
-      rerender: async (input: string, params?: unknown) => {
+      rerender: async (input: string, rscParams?: unknown) => {
         if (rendered) {
           throw new Error('already rendered');
         }
         elementsPromise = Promise.all([
           elementsPromise,
-          renderEntries(input, { params }),
+          renderEntries(input, { rscParams }),
         ]).then(([oldElements, newElements]) => ({
           ...oldElements,
           // FIXME we should actually check if newElements is null and send an error

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -1,29 +1,29 @@
 // This file should not include Node specific code.
 
-export const encodeInput = (input: string) => {
-  if (input === '') {
+export const encodeRscPath = (rscPath: string) => {
+  if (rscPath === '') {
     return 'index.txt';
   }
-  if (input === 'index') {
-    throw new Error('Input should not be `index`');
+  if (rscPath === 'index') {
+    throw new Error('rscPath should not be `index`');
   }
-  if (input.startsWith('/')) {
-    throw new Error('Input should not start with `/`');
+  if (rscPath.startsWith('/')) {
+    throw new Error('rscPath should not start with `/`');
   }
-  if (input.endsWith('/')) {
-    throw new Error('Input should not end with `/`');
+  if (rscPath.endsWith('/')) {
+    throw new Error('rscPath should not end with `/`');
   }
-  return input + '.txt';
+  return rscPath + '.txt';
 };
 
-export const decodeInput = (encodedInput: string) => {
-  if (encodedInput === 'index.txt') {
+export const decodeRscPath = (encodedRscPath: string) => {
+  if (encodedRscPath === 'index.txt') {
     return '';
   }
-  if (encodedInput?.endsWith('.txt')) {
-    return encodedInput.slice(0, -'.txt'.length);
+  if (encodedRscPath?.endsWith('.txt')) {
+    return encodedRscPath.slice(0, -'.txt'.length);
   }
-  const err = new Error('Invalid encoded input');
+  const err = new Error('Invalid encoded rscPath');
   (err as any).statusCode = 400;
   throw err;
 };
@@ -53,17 +53,17 @@ export const hasStatusCode = (x: unknown): x is { statusCode: number } =>
 
 export const generatePrefetchCode = (
   basePrefix: string,
-  inputs: Iterable<string>,
+  rscPaths: Iterable<string>,
   moduleIds: Iterable<string>,
 ) => {
-  const inputsArray = Array.from(inputs);
+  const rscPathArray = Array.from(rscPaths);
   let code = '';
-  if (inputsArray.length) {
+  if (rscPathArray.length) {
     code += `
 globalThis.__WAKU_PREFETCHED__ = {
-${inputsArray
-  .map((input) => {
-    const url = basePrefix + encodeInput(input);
+${rscPathArray
+  .map((rscPath) => {
+    const url = basePrefix + encodeRscPath(rscPath);
     return `  '${url}': fetch('${url}'),`;
   })
   .join('\n')}

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -28,23 +28,23 @@ export const decodeInput = (encodedInput: string) => {
   throw err;
 };
 
-const ACTION_PREFIX = 'ACTION_';
+const FUNC_PREFIX = 'FUNC_';
 
 export const encodeFuncId = (funcId: string) => {
   const [file, name] = funcId.split('#') as [string, string];
   if (name.includes('/')) {
     throw new Error('Unsupported function name');
   }
-  return ACTION_PREFIX + file + '/' + name;
+  return FUNC_PREFIX + file + '/' + name;
 };
 
 export const decodeFuncId = (encoded: string) => {
-  if (!encoded.startsWith(ACTION_PREFIX)) {
+  if (!encoded.startsWith(FUNC_PREFIX)) {
     return null;
   }
   const index = encoded.lastIndexOf('/');
   return (
-    encoded.slice(ACTION_PREFIX.length, index) + '#' + encoded.slice(index + 1)
+    encoded.slice(FUNC_PREFIX.length, index) + '#' + encoded.slice(index + 1)
   );
 };
 

--- a/packages/waku/src/lib/renderers/utils.ts
+++ b/packages/waku/src/lib/renderers/utils.ts
@@ -30,15 +30,15 @@ export const decodeInput = (encodedInput: string) => {
 
 const ACTION_PREFIX = 'ACTION_';
 
-export const encodeActionId = (actionId: string) => {
-  const [file, name] = actionId.split('#') as [string, string];
+export const encodeFuncId = (funcId: string) => {
+  const [file, name] = funcId.split('#') as [string, string];
   if (name.includes('/')) {
-    throw new Error('Unsupported action name');
+    throw new Error('Unsupported function name');
   }
   return ACTION_PREFIX + file + '/' + name;
 };
 
-export const decodeActionId = (encoded: string) => {
+export const decodeFuncId = (encoded: string) => {
   if (!encoded.startsWith(ACTION_PREFIX)) {
     return null;
   }

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -23,7 +23,7 @@ import type {
   MouseEvent,
 } from 'react';
 
-import { fetchRSC, prefetchRSC, Root, Slot, useRefetch } from '../client.js';
+import { fetchRsc, prefetchRsc, Root, Slot, useRefetch } from '../client.js';
 import {
   getComponentIds,
   getInputString,
@@ -407,7 +407,7 @@ const InnerRouter = ({ routerData }: { routerData: RouterData }) => {
         return; // everything is cached
       }
       const input = getInputString(route.path);
-      prefetchRSC(input, JSON.stringify({ query: route.query, skip }));
+      prefetchRsc(input, JSON.stringify({ query: route.query, skip }));
       (globalThis as any).__WAKU_ROUTER_PREFETCH__?.(route.path);
     },
     [routerData],
@@ -501,7 +501,7 @@ export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
       if (response.status === 404 && has404) {
         // HACK this is still an experimental logic. It's very fragile.
         // FIXME we should cache it if 404.txt is static.
-        return fetchRSC(getInputString('/404'));
+        return fetchRsc(getInputString('/404'));
       }
       const data = createData(responsePromise);
       Promise.resolve(data)

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -530,13 +530,13 @@ export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
         .catch(() => {});
       return data;
     };
-  const initialParams = JSON.stringify({ query: route.query });
+  const initialRscParams = JSON.stringify({ query: route.query });
   return createElement(
     ErrorBoundary,
     null,
     createElement(
       Root as FunctionComponent<Omit<ComponentProps<typeof Root>, 'children'>>,
-      { initialInput, initialParams, unstable_enhanceCreateData },
+      { initialInput, initialRscParams, unstable_enhanceCreateData },
       createElement(InnerRouter, { routerData }),
     ),
   );

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -26,7 +26,7 @@ import type {
 import { fetchRsc, prefetchRsc, Root, Slot, useRefetch } from '../client.js';
 import {
   getComponentIds,
-  getInputString,
+  getRscPath,
   SHOULD_SKIP_ID,
   ROUTE_ID,
   HAS404_ID,
@@ -375,9 +375,9 @@ const InnerRouter = ({ routerData }: { routerData: RouterData }) => {
       if (componentIds.every((id) => skip.includes(id))) {
         return; // everything is skipped
       }
-      const input = getInputString(route.path);
+      const rscPath = getRscPath(route.path);
       if (!skipRefetch) {
-        refetch(input, JSON.stringify({ query: route.query, skip }));
+        refetch(rscPath, JSON.stringify({ query: route.query, skip }));
       }
       startTransition(() => {
         setCached((prev) => ({
@@ -406,8 +406,8 @@ const InnerRouter = ({ routerData }: { routerData: RouterData }) => {
       if (componentIds.every((id) => skip.includes(id))) {
         return; // everything is cached
       }
-      const input = getInputString(route.path);
-      prefetchRsc(input, JSON.stringify({ query: route.query, skip }));
+      const rscPath = getRscPath(route.path);
+      prefetchRsc(rscPath, JSON.stringify({ query: route.query, skip }));
       (globalThis as any).__WAKU_ROUTER_PREFETCH__?.(route.path);
     },
     [routerData],
@@ -488,7 +488,7 @@ const DEFAULT_ROUTER_DATA: RouterData = [];
 
 export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
   const route = parseRouteFromLocation();
-  const initialInput = getInputString(route.path);
+  const initialRscPath = getRscPath(route.path);
   const unstable_enhanceCreateData =
     (
       createData: (
@@ -501,7 +501,7 @@ export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
       if (response.status === 404 && has404) {
         // HACK this is still an experimental logic. It's very fragile.
         // FIXME we should cache it if 404.txt is static.
-        return fetchRsc(getInputString('/404'));
+        return fetchRsc(getRscPath('/404'));
       }
       const data = createData(responsePromise);
       Promise.resolve(data)
@@ -536,7 +536,7 @@ export function Router({ routerData = DEFAULT_ROUTER_DATA }) {
     null,
     createElement(
       Root as FunctionComponent<Omit<ComponentProps<typeof Root>, 'children'>>,
-      { initialInput, initialRscParams, unstable_enhanceCreateData },
+      { initialRscPath, initialRscParams, unstable_enhanceCreateData },
       createElement(InnerRouter, { routerData }),
     ),
   );

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -15,18 +15,18 @@ export function getComponentIds(path: string): readonly string[] {
   return Array.from(idSet);
 }
 
-export function getInputString(path: string): string {
+export function getRscPath(path: string): string {
   if (!path.startsWith('/')) {
     throw new Error('Path should start with `/`');
   }
   return path.slice(1);
 }
 
-export function parseInputString(input: string): string {
-  if (input.startsWith('/')) {
-    throw new Error('Input should not start with `/`');
+export function parseRscPath(rscPath: string): string {
+  if (rscPath.startsWith('/')) {
+    throw new Error('rscPath should not start with `/`');
   }
-  return '/' + input;
+  return '/' + rscPath;
 }
 
 // It starts with "/" to avoid conflicting with normal component ids.

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -119,7 +119,7 @@ export function unstable_defineRouter(
           has404,
         };
   };
-  const renderEntries: RenderEntries = async (input, { params }) => {
+  const renderEntries: RenderEntries = async (input, { rscParams }) => {
     const pathname = parseInputString(input);
     const pathStatus = await existsPath(pathname);
     if (!pathStatus.found) {
@@ -129,7 +129,7 @@ export function unstable_defineRouter(
       [componentId: ShouldSkip[number][0]]: ShouldSkip[number][1];
     } = {};
 
-    const parsedParams = safeJsonParse(params);
+    const parsedParams = safeJsonParse(rscParams);
 
     const query =
       typeof parsedParams?.query === 'string' ? parsedParams.query : '';
@@ -253,7 +253,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
     );
     return {
       input,
-      params: JSON.stringify({ query: searchParams.toString() }),
+      rscParams: JSON.stringify({ query: searchParams.toString() }),
       html,
     };
   };

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -15,8 +15,8 @@ import type {
 import { Children, Slot } from '../client.js';
 import {
   getComponentIds,
-  getInputString,
-  parseInputString,
+  getRscPath,
+  parseRscPath,
   SHOULD_SKIP_ID,
   ROUTE_ID,
   HAS404_ID,
@@ -119,8 +119,8 @@ export function unstable_defineRouter(
           has404,
         };
   };
-  const renderEntries: RenderEntries = async (input, { rscParams }) => {
-    const pathname = parseInputString(input);
+  const renderEntries: RenderEntries = async (rscPath, { rscParams }) => {
+    const pathname = parseRscPath(rscPath);
     const pathStatus = await existsPath(pathname);
     if (!pathStatus.found) {
       return null;
@@ -190,8 +190,8 @@ export function unstable_defineRouter(
           return;
         }
         const pathname = '/' + pathSpec.map(({ name }) => name).join('/');
-        const input = getInputString(pathname);
-        path2moduleIds[pattern] = await unstable_collectClientModules(input);
+        const rscPath = getRscPath(pathname);
+        path2moduleIds[pattern] = await unstable_collectClientModules(rscPath);
       }),
     );
 
@@ -210,8 +210,8 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
       const entries: BuildConfig[number]['entries'] = [];
       if (pathSpec.every(({ type }) => type === 'literal')) {
         const pathname = '/' + pathSpec.map(({ name }) => name).join('/');
-        const input = getInputString(pathname);
-        entries.push({ input, isStatic });
+        const rscPath = getRscPath(pathname);
+        entries.push({ rscPath, isStatic });
       }
       buildConfig.push({
         pathname: pathSpec,
@@ -240,7 +240,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
       }
     }
     const componentIds = getComponentIds(pathname);
-    const input = getInputString(pathname);
+    const rscPath = getRscPath(pathname);
     const html = createElement(
       ServerRouter as FunctionComponent<
         Omit<ComponentProps<typeof ServerRouter>, 'children'>
@@ -252,7 +252,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
       ),
     );
     return {
-      input,
+      rscPath,
       rscParams: JSON.stringify({ query: searchParams.toString() }),
       html,
     };
@@ -266,6 +266,6 @@ export function unstable_rerenderRoute(
   query?: string,
   skip?: string[], // TODO this is too hard to use
 ) {
-  const input = getInputString(pathname);
-  rerender(input, { query, skip });
+  const rscPath = getRscPath(pathname);
+  rerender(rscPath, { query, skip });
 }

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -22,7 +22,7 @@ export type BuildConfig = {
 export type RenderEntries = (
   input: string,
   options: {
-    params: unknown | undefined;
+    rscParams: unknown | undefined;
   },
 ) => Promise<Elements | null>;
 
@@ -37,7 +37,7 @@ export type GetSsrConfig = (
   },
 ) => Promise<{
   input: string;
-  params?: unknown;
+  rscParams?: unknown;
   html: ReactNode;
 } | null>;
 
@@ -75,7 +75,7 @@ export function getEnv(key: string): string | undefined {
 }
 
 type RenderStore<> = {
-  rerender: (input: string, params?: unknown) => void;
+  rerender: (input: string, rscParams?: unknown) => void;
   context: Record<string, unknown>;
 };
 
@@ -122,12 +122,12 @@ export const runWithRenderStoreInternal = <T>(
   }
 };
 
-export function rerender(input: string, params?: unknown) {
+export function rerender(input: string, rscParams?: unknown) {
   const renderStore = renderStorage?.getStore() ?? currentRenderStore;
   if (!renderStore) {
     throw new Error('Render store is not available');
   }
-  renderStore.rerender(input, params);
+  renderStore.rerender(input, rscParams);
 }
 
 export function unstable_getCustomContext<

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -11,7 +11,7 @@ export type BuildConfig = {
   pathname: string | PathSpec; // TODO drop support for string?
   isStatic?: boolean | undefined;
   entries?: {
-    input: string;
+    rscPath: string;
     skipPrefetch?: boolean | undefined;
     isStatic?: boolean | undefined;
   }[];
@@ -20,14 +20,14 @@ export type BuildConfig = {
 }[];
 
 export type RenderEntries = (
-  input: string,
+  rscPath: string,
   options: {
     rscParams: unknown | undefined;
   },
 ) => Promise<Elements | null>;
 
 export type GetBuildConfig = (
-  unstable_collectClientModules: (input: string) => Promise<string[]>,
+  unstable_collectClientModules: (rscPath: string) => Promise<string[]>,
 ) => Promise<BuildConfig>;
 
 export type GetSsrConfig = (
@@ -36,7 +36,7 @@ export type GetSsrConfig = (
     searchParams: URLSearchParams;
   },
 ) => Promise<{
-  input: string;
+  rscPath: string;
   rscParams?: unknown;
   html: ReactNode;
 } | null>;
@@ -75,7 +75,7 @@ export function getEnv(key: string): string | undefined {
 }
 
 type RenderStore<> = {
-  rerender: (input: string, rscParams?: unknown) => void;
+  rerender: (rscPath: string, rscParams?: unknown) => void;
   context: Record<string, unknown>;
 };
 
@@ -122,12 +122,12 @@ export const runWithRenderStoreInternal = <T>(
   }
 };
 
-export function rerender(input: string, rscParams?: unknown) {
+export function rerender(rscPath: string, rscParams?: unknown) {
   const renderStore = renderStorage?.getStore() ?? currentRenderStore;
   if (!renderStore) {
     throw new Error('Render store is not available');
   }
-  renderStore.rerender(input, rscParams);
+  renderStore.rerender(rscPath, rscParams);
 }
 
 export function unstable_getCustomContext<

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -395,15 +395,15 @@ export default async function log4(mesg) {
     expect(await transform(code, '/src/func.ts')).toMatchInlineSnapshot(`
       "
       import { createServerReference } from 'react-server-dom-webpack/client';
-      import { callServerRSC } from 'waku/client';
+      import { callServerRsc } from 'waku/client';
 
-      export const log1 = createServerReference('/src/func.ts#log1', callServerRSC);
+      export const log1 = createServerReference('/src/func.ts#log1', callServerRsc);
 
-      export const log2 = createServerReference('/src/func.ts#log2', callServerRSC);
+      export const log2 = createServerReference('/src/func.ts#log2', callServerRsc);
 
-      export const log3 = createServerReference('/src/func.ts#log3', callServerRSC);
+      export const log3 = createServerReference('/src/func.ts#log3', callServerRsc);
 
-      export default createServerReference('/src/func.ts#default', callServerRSC);
+      export default createServerReference('/src/func.ts#default', callServerRsc);
       "
     `);
   });

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -116,12 +116,12 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         "import type { ReactNode } from 'react';
         import { createAI } from 'ai/rsc';
         import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        export const __waku_action1 = __waku_registerServerReference(async ()=>{
+        export const __waku_func1 = __waku_registerServerReference(async ()=>{
             return 0;
-        }, "/src/App.tsx", "__waku_action1");
+        }, "/src/App.tsx", "__waku_func1");
         const AI = createAI({
             actions: {
-                foo: __waku_action1.bind(null)
+                foo: __waku_func1.bind(null)
             }
         });
         export function ServerProvider({ children }: {
@@ -161,11 +161,11 @@ export default async () => null;
         "import { InternalProvider } from './shared.js';
         import { jsx } from 'react/jsx-runtime';
         import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        export async function __waku_action1({ action }, ...args) {
+        export async function __waku_func1({ action }, ...args) {
             return await action(...args);
         }
-        __waku_registerServerReference(__waku_action1, "/src/App.tsx", "__waku_action1");
-        const innerAction = __waku_action1.bind(null);
+        __waku_registerServerReference(__waku_func1, "/src/App.tsx", "__waku_func1");
+        const innerAction = __waku_func1.bind(null);
         function wrapAction(action) {
             return innerAction.bind(null, {
                 action
@@ -192,17 +192,17 @@ export default function App({ a }) {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-      "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-      export async function __waku_action1(a, mesg) {
-          console.log(mesg, a);
-      }
-      __waku_registerServerReference(__waku_action1, "/src/App.tsx", "__waku_action1");
-      export default function App({ a }) {
-          const log = __waku_action1.bind(null, a);
-          return <Hello log={log}/>;
-      }
-      "
-    `);
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export async function __waku_func1(a, mesg) {
+            console.log(mesg, a);
+        }
+        __waku_registerServerReference(__waku_func1, "/src/App.tsx", "__waku_func1");
+        export default function App({ a }) {
+            const log = __waku_func1.bind(null, a);
+            return <Hello log={log}/>;
+        }
+        "
+      `);
   });
 
   test('inline use server (const function expression)', async () => {
@@ -218,17 +218,17 @@ export default function App() {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-      "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-      export const __waku_action1 = __waku_registerServerReference(async function(rand, mesg, rand) {
-          console.log(mesg, rand);
-      }, "/src/App.tsx", "__waku_action1");
-      export default function App() {
-          const rand = Math.random();
-          const log = __waku_action1.bind(null, rand);
-          return <Hello log={log}/>;
-      }
-      "
-    `);
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export const __waku_func1 = __waku_registerServerReference(async function(rand, mesg, rand) {
+            console.log(mesg, rand);
+        }, "/src/App.tsx", "__waku_func1");
+        export default function App() {
+            const rand = Math.random();
+            const log = __waku_func1.bind(null, rand);
+            return <Hello log={log}/>;
+        }
+        "
+      `);
   });
 
   test('inline use server (const arrow function)', async () => {
@@ -244,17 +244,17 @@ export default function App() {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-      "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-      export const __waku_action1 = __waku_registerServerReference(async (mesg)=>{
-          console.log(mesg, now);
-      }, "/src/App.tsx", "__waku_action1");
-      const now = Date.now();
-      export default function App() {
-          const log = __waku_action1.bind(null);
-          return <Hello log={log}/>;
-      }
-      "
-    `);
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export const __waku_func1 = __waku_registerServerReference(async (mesg)=>{
+            console.log(mesg, now);
+        }, "/src/App.tsx", "__waku_func1");
+        const now = Date.now();
+        export default function App() {
+            const log = __waku_func1.bind(null);
+            return <Hello log={log}/>;
+        }
+        "
+      `);
   });
 
   test('inline use server (anonymous arrow function)', async () => {
@@ -269,16 +269,16 @@ export default function App() {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-      "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-      export const __waku_action1 = __waku_registerServerReference((mesg)=>{
-          console.log(mesg, now);
-      }, "/src/App.tsx", "__waku_action1");
-      const now = Date.now();
-      export default function App() {
-          return <Hello log={__waku_action1.bind(null)}/>;
-      }
-      "
-    `);
+        "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
+        export const __waku_func1 = __waku_registerServerReference((mesg)=>{
+            console.log(mesg, now);
+        }, "/src/App.tsx", "__waku_func1");
+        const now = Date.now();
+        export default function App() {
+            return <Hello log={__waku_func1.bind(null)}/>;
+        }
+        "
+      `);
   });
 
   test('inline use server (various patterns)', async () => {
@@ -317,29 +317,29 @@ export default async function(mesg) {
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
         "import { registerServerReference as __waku_registerServerReference } from 'react-server-dom-webpack/server.edge';
-        export const __waku_action1 = __waku_registerServerReference(async (mesg)=>{
+        export const __waku_func1 = __waku_registerServerReference(async (mesg)=>{
             console.log(mesg);
-        }, "/src/App.tsx", "__waku_action1");
-        export async function __waku_action2(mesg) {
+        }, "/src/App.tsx", "__waku_func1");
+        export async function __waku_func2(mesg) {
             console.log(mesg);
         }
-        __waku_registerServerReference(__waku_action2, "/src/App.tsx", "__waku_action2");
-        export const __waku_action3 = __waku_registerServerReference(async function(mesg) {
+        __waku_registerServerReference(__waku_func2, "/src/App.tsx", "__waku_func2");
+        export const __waku_func3 = __waku_registerServerReference(async function(mesg) {
             console.log(mesg);
-        }, "/src/App.tsx", "__waku_action3");
-        export const __waku_action4 = __waku_registerServerReference(async (mesg)=>{
+        }, "/src/App.tsx", "__waku_func3");
+        export const __waku_func4 = __waku_registerServerReference(async (mesg)=>{
             console.log(mesg);
-        }, "/src/App.tsx", "__waku_action4");
-        export const __waku_action5 = __waku_registerServerReference(async function(mesg) {
+        }, "/src/App.tsx", "__waku_func4");
+        export const __waku_func5 = __waku_registerServerReference(async function(mesg) {
             console.log(mesg);
-        }, "/src/App.tsx", "__waku_action5");
+        }, "/src/App.tsx", "__waku_func5");
         const actions = {
-            log: __waku_action1.bind(null)
+            log: __waku_func1.bind(null)
         };
-        const log2 = __waku_action2.bind(null);
-        const log3 = __waku_action3.bind(null);
-        const log4 = __waku_action4.bind(null);
-        export default __waku_action5.bind(null);
+        const log2 = __waku_func2.bind(null);
+        const log3 = __waku_func3.bind(null);
+        const log4 = __waku_func4.bind(null);
+        export default __waku_func5.bind(null);
         "
       `);
   });


### PR DESCRIPTION
Technically breaking, but hope nobody relies on it.

- [x] fetchRSC -> fetchRsc
- [x] server actions -> server functions
- [x] actionId -> funcId
- [x] rscPath -> rscBase
- [x] params -> rscParams
- [x] rsc input string -> rscPath
