### PR TITLE
experimental GET support

### DIFF
--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -101,7 +101,7 @@ const defaultFetchCache: FetchCache = {};
  */
 export const callServerRsc = async (
   funcId: string,
-  args?: unknown[],
+  args: unknown[],
   fetchCache = defaultFetchCache,
 ) => {
   const enhanceCreateData = fetchCache[ENHANCE_CREATE_DATA] || ((d) => d);
@@ -112,8 +112,8 @@ export const callServerRsc = async (
     });
   const url = BASE_PATH + encodeRscPath(encodeFuncId(funcId));
   const responsePromise =
-    args === undefined
-      ? fetch(url)
+    args.length === 1 && args[0] instanceof URLSearchParams
+      ? fetch(url + '?' + args[0])
       : encodeReply(args).then((body) => fetch(url, { method: 'POST', body }));
   const data = enhanceCreateData(createData)(responsePromise);
   // FIXME this causes rerenders even if data is empty
@@ -126,8 +126,8 @@ const prefetchedParams = new WeakMap<Promise<unknown>, unknown>();
 const fetchRscInternal = (url: string, rscParams: unknown) =>
   rscParams === undefined
     ? fetch(url)
-    : typeof rscParams === 'string'
-      ? fetch(url, { headers: { 'X-Waku-Params': rscParams } })
+    : rscParams instanceof URLSearchParams
+      ? fetch(url + '?' + rscParams)
       : encodeReply(rscParams).then((body) =>
           fetch(url, { method: 'POST', body }),
         );

--- a/packages/waku/src/lib/middleware/rsc.ts
+++ b/packages/waku/src/lib/middleware/rsc.ts
@@ -35,7 +35,7 @@ export const rsc: Middleware = (options) => {
           config,
           rscPath,
           context: ctx.context,
-          decodedBody: headers['x-waku-params'],
+          decodedBody: ctx.req.url.searchParams,
           body: ctx.req.body,
           contentType: headers['content-type'] || '',
         };

--- a/packages/waku/src/lib/renderers/rsc-renderer.ts
+++ b/packages/waku/src/lib/renderers/rsc-renderer.ts
@@ -211,7 +211,11 @@ export async function renderRsc(
 
   const funcId = decodeFuncId(rscPath);
   if (funcId) {
-    const args = Array.isArray(decodedBody) ? decodedBody : [];
+    const args = Array.isArray(decodedBody)
+      ? decodedBody
+      : decodedBody instanceof URLSearchParams
+        ? [decodedBody]
+        : [];
     const [fileId, name] = funcId.split('#') as [string, string];
     let mod: any;
     if (isDev) {


### PR DESCRIPTION
Previously, we used GET with a header, because the header can accept larger string.
But, for larger string, we should use POST anyway, so introducing a new convention `URLSearchParams`. This is still experimental and should be revisited before v1. (Basically, review Next.js's API and re-consider.)