### PR TITLE
chore: start GetConfig types

### DIFF
--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -20,24 +20,7 @@ export interface CreatePagesConfig {
 export type PageProps<Path extends PagePath<CreatePagesConfig>> =
   PropsForPages<Path>;
 
-type StaticConfig = {
-  readonly render: 'static';
-  readonly staticPaths?: never;
+export type GetConfigResult = {
+  readonly render: 'static' | 'dynamic';
+  readonly staticPaths?: readonly string[];
 };
-
-type StaticWithSlugConfig = {
-  readonly render: 'static';
-  readonly staticPaths: readonly string[];
-};
-
-type DynamicConfig = {
-  readonly render: 'dynamic';
-};
-
-export type GetConfig =
-  | (() => Promise<StaticConfig>)
-  | (() => Promise<StaticWithSlugConfig>)
-  | (() => Promise<DynamicConfig>)
-  | (() => StaticWithSlugConfig)
-  | (() => StaticConfig)
-  | (() => DynamicConfig);

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -19,3 +19,25 @@ export interface CreatePagesConfig {
 /** Props for pages when using `createPages` */
 export type PageProps<Path extends PagePath<CreatePagesConfig>> =
   PropsForPages<Path>;
+
+type StaticConfig = {
+  readonly render: 'static';
+  readonly staticPaths?: never;
+};
+
+type StaticWithSlugConfig = {
+  readonly render: 'static';
+  readonly staticPaths: readonly string[];
+};
+
+type DynamicConfig = {
+  readonly render: 'dynamic';
+};
+
+export type GetConfig =
+  | (() => Promise<StaticConfig>)
+  | (() => Promise<StaticWithSlugConfig>)
+  | (() => Promise<DynamicConfig>)
+  | (() => StaticWithSlugConfig)
+  | (() => StaticConfig)
+  | (() => DynamicConfig);

--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 
 import { Providers } from '../components/providers';
 import { Analytics } from '../components/analytics';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 type RootLayoutProps = { children: ReactNode };
 
@@ -46,8 +46,8 @@ const Meta = () => {
   );
 };
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   return {
     render: 'static',
-  };
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 import { Providers } from '../components/providers';
 import { Analytics } from '../components/analytics';
+import type { GetConfig } from 'waku/router';
 
 type RootLayoutProps = { children: ReactNode };
 
@@ -45,8 +46,8 @@ const Meta = () => {
   );
 };
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  };
 };

--- a/packages/website/src/pages/blog/[slug].tsx
+++ b/packages/website/src/pages/blog/[slug].tsx
@@ -6,7 +6,7 @@ import { Meta } from '../../components/meta';
 import { components } from '../../components/mdx';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 type BlogArticlePageProps = {
   slug: string;
@@ -127,13 +127,13 @@ const getFileName = async (slug: string) => {
   return fileName;
 };
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   const blogPaths = await getBlogPaths();
 
   return {
     render: 'static',
     staticPaths: blogPaths,
-  };
+  } satisfies GetConfigResult;
 };
 
 const getBlogPaths = async () => {

--- a/packages/website/src/pages/blog/[slug].tsx
+++ b/packages/website/src/pages/blog/[slug].tsx
@@ -6,6 +6,7 @@ import { Meta } from '../../components/meta';
 import { components } from '../../components/mdx';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
+import type { GetConfig } from 'waku/router';
 
 type BlogArticlePageProps = {
   slug: string;
@@ -126,13 +127,13 @@ const getFileName = async (slug: string) => {
   return fileName;
 };
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   const blogPaths = await getBlogPaths();
 
   return {
     render: 'static',
     staticPaths: blogPaths,
-  } as const;
+  };
 };
 
 const getBlogPaths = async () => {

--- a/packages/website/src/pages/blog/index.tsx
+++ b/packages/website/src/pages/blog/index.tsx
@@ -6,6 +6,7 @@ import { Page } from '../../components/page';
 import { Meta } from '../../components/meta';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
+import type { GetConfigResult } from 'waku/router';
 
 export default async function BlogIndexPage() {
   const articles = await getArticles();
@@ -99,5 +100,5 @@ const getArticles = async () => {
 export const getConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { Start } from '../components/start';
 import { AllSponsors } from '../components/all-sponsors';
 import { Destination } from '../components/destination';
 import { loadReadme } from '../lib/load-readme';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 export default async function HomePage() {
   const file = loadReadme();
@@ -54,8 +54,8 @@ export default async function HomePage() {
   );
 }
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   return {
     render: 'static',
-  };
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { Start } from '../components/start';
 import { AllSponsors } from '../components/all-sponsors';
 import { Destination } from '../components/destination';
 import { loadReadme } from '../lib/load-readme';
+import type { GetConfig } from 'waku/router';
 
 export default async function HomePage() {
   const file = loadReadme();
@@ -53,8 +54,8 @@ export default async function HomePage() {
   );
 }
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  };
 };


### PR DESCRIPTION
Using `satisfies` to help narrow response of `getConfig` with type checking and autocomplete on what is entered into the config.