### PR TITLE
Get config types w fn

### DIFF
--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -20,24 +20,7 @@ export interface CreatePagesConfig {
 export type PageProps<Path extends PagePath<CreatePagesConfig>> =
   PropsForPages<Path>;
 
-type StaticConfig = {
-  readonly render: 'static';
-  readonly staticPaths?: never;
+export type GetConfigResult = {
+  readonly render: 'static' | 'dynamic';
+  readonly staticPaths?: readonly string[];
 };
-
-type StaticWithSlugConfig = {
-  readonly render: 'static';
-  readonly staticPaths: readonly string[];
-};
-
-type DynamicConfig = {
-  readonly render: 'dynamic';
-};
-
-export type GetConfig =
-  | (() => Promise<StaticConfig>)
-  | (() => Promise<StaticWithSlugConfig>)
-  | (() => Promise<DynamicConfig>)
-  | (() => StaticWithSlugConfig)
-  | (() => StaticConfig)
-  | (() => DynamicConfig);

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -20,7 +20,11 @@ export interface CreatePagesConfig {
 export type PageProps<Path extends PagePath<CreatePagesConfig>> =
   PropsForPages<Path>;
 
-export type GetConfigResult = {
-  readonly render: 'static' | 'dynamic';
-  readonly staticPaths?: readonly string[];
-};
+export const config = <
+  SP extends string,
+  Fig extends
+    | { render: 'static'; staticPaths?: SP[] | [SP, ...SP[]][] }
+    | { render: 'dynamic' },
+>(
+  c: Fig,
+) => c;

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -19,3 +19,25 @@ export interface CreatePagesConfig {
 /** Props for pages when using `createPages` */
 export type PageProps<Path extends PagePath<CreatePagesConfig>> =
   PropsForPages<Path>;
+
+type StaticConfig = {
+  readonly render: 'static';
+  readonly staticPaths?: never;
+};
+
+type StaticWithSlugConfig = {
+  readonly render: 'static';
+  readonly staticPaths: readonly string[];
+};
+
+type DynamicConfig = {
+  readonly render: 'dynamic';
+};
+
+export type GetConfig =
+  | (() => Promise<StaticConfig>)
+  | (() => Promise<StaticWithSlugConfig>)
+  | (() => Promise<DynamicConfig>)
+  | (() => StaticWithSlugConfig)
+  | (() => StaticConfig)
+  | (() => DynamicConfig);

--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 
 import { Providers } from '../components/providers';
 import { Analytics } from '../components/analytics';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 type RootLayoutProps = { children: ReactNode };
 
@@ -46,8 +46,8 @@ const Meta = () => {
   );
 };
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   return {
     render: 'static',
-  };
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 
 import { Providers } from '../components/providers';
 import { Analytics } from '../components/analytics';
-import type { GetConfigResult } from 'waku/router';
+import { config } from 'waku/router';
 
 type RootLayoutProps = { children: ReactNode };
 
@@ -47,7 +47,7 @@ const Meta = () => {
 };
 
 export const getConfig = async () => {
-  return {
+  return config({
     render: 'static',
-  } satisfies GetConfigResult;
+  });
 };

--- a/packages/website/src/pages/_layout.tsx
+++ b/packages/website/src/pages/_layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 import { Providers } from '../components/providers';
 import { Analytics } from '../components/analytics';
+import type { GetConfig } from 'waku/router';
 
 type RootLayoutProps = { children: ReactNode };
 
@@ -45,8 +46,8 @@ const Meta = () => {
   );
 };
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  };
 };

--- a/packages/website/src/pages/blog/[slug].tsx
+++ b/packages/website/src/pages/blog/[slug].tsx
@@ -6,7 +6,7 @@ import { Meta } from '../../components/meta';
 import { components } from '../../components/mdx';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 type BlogArticlePageProps = {
   slug: string;
@@ -127,13 +127,13 @@ const getFileName = async (slug: string) => {
   return fileName;
 };
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   const blogPaths = await getBlogPaths();
 
   return {
     render: 'static',
     staticPaths: blogPaths,
-  };
+  } satisfies GetConfigResult;
 };
 
 const getBlogPaths = async () => {

--- a/packages/website/src/pages/blog/[slug].tsx
+++ b/packages/website/src/pages/blog/[slug].tsx
@@ -6,7 +6,7 @@ import { Meta } from '../../components/meta';
 import { components } from '../../components/mdx';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
-import type { GetConfigResult } from 'waku/router';
+import { config } from 'waku/router';
 
 type BlogArticlePageProps = {
   slug: string;
@@ -130,10 +130,10 @@ const getFileName = async (slug: string) => {
 export const getConfig = async () => {
   const blogPaths = await getBlogPaths();
 
-  return {
+  return config({
     render: 'static',
     staticPaths: blogPaths,
-  } satisfies GetConfigResult;
+  });
 };
 
 const getBlogPaths = async () => {

--- a/packages/website/src/pages/blog/[slug].tsx
+++ b/packages/website/src/pages/blog/[slug].tsx
@@ -6,6 +6,7 @@ import { Meta } from '../../components/meta';
 import { components } from '../../components/mdx';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
+import type { GetConfig } from 'waku/router';
 
 type BlogArticlePageProps = {
   slug: string;
@@ -126,13 +127,13 @@ const getFileName = async (slug: string) => {
   return fileName;
 };
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   const blogPaths = await getBlogPaths();
 
   return {
     render: 'static',
     staticPaths: blogPaths,
-  } as const;
+  };
 };
 
 const getBlogPaths = async () => {

--- a/packages/website/src/pages/blog/index.tsx
+++ b/packages/website/src/pages/blog/index.tsx
@@ -6,6 +6,7 @@ import { Page } from '../../components/page';
 import { Meta } from '../../components/meta';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
+import type { GetConfigResult } from 'waku/router';
 
 export default async function BlogIndexPage() {
   const articles = await getArticles();
@@ -99,5 +100,5 @@ const getArticles = async () => {
 export const getConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/blog/index.tsx
+++ b/packages/website/src/pages/blog/index.tsx
@@ -6,7 +6,7 @@ import { Page } from '../../components/page';
 import { Meta } from '../../components/meta';
 import { getAuthor } from '../../lib/get-author';
 import type { BlogFrontmatter } from '../../types';
-import type { GetConfigResult } from 'waku/router';
+import { config } from 'waku/router';
 
 export default async function BlogIndexPage() {
   const articles = await getArticles();
@@ -98,7 +98,7 @@ const getArticles = async () => {
 };
 
 export const getConfig = async () => {
-  return {
+  return config({
     render: 'static',
-  } satisfies GetConfigResult;
+  });
 };

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { Start } from '../components/start';
 import { AllSponsors } from '../components/all-sponsors';
 import { Destination } from '../components/destination';
 import { loadReadme } from '../lib/load-readme';
-import type { GetConfigResult } from 'waku/router';
+import { config } from 'waku/router';
 
 export default async function HomePage() {
   const file = loadReadme();
@@ -55,7 +55,7 @@ export default async function HomePage() {
 }
 
 export const getConfig = async () => {
-  return {
+  return config({
     render: 'static',
-  } satisfies GetConfigResult;
+  });
 };

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { Start } from '../components/start';
 import { AllSponsors } from '../components/all-sponsors';
 import { Destination } from '../components/destination';
 import { loadReadme } from '../lib/load-readme';
-import type { GetConfig } from 'waku/router';
+import type { GetConfigResult } from 'waku/router';
 
 export default async function HomePage() {
   const file = loadReadme();
@@ -54,8 +54,8 @@ export default async function HomePage() {
   );
 }
 
-export const getConfig: GetConfig = async () => {
+export const getConfig = async () => {
   return {
     render: 'static',
-  };
+  } satisfies GetConfigResult;
 };

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { Start } from '../components/start';
 import { AllSponsors } from '../components/all-sponsors';
 import { Destination } from '../components/destination';
 import { loadReadme } from '../lib/load-readme';
+import type { GetConfig } from 'waku/router';
 
 export default async function HomePage() {
   const file = loadReadme();
@@ -53,8 +54,8 @@ export default async function HomePage() {
   );
 }
 
-export const getConfig = async () => {
+export const getConfig: GetConfig = async () => {
   return {
     render: 'static',
-  } as const;
+  };
 };


### PR DESCRIPTION
This is just to show what I am talking about with using a function.

Hoping to highlight the power this brings both through the step of writing the config with type safety and inferring the result without the need for `as const` `satisfies`

These screenshots show a fake example I made up where I am using the functions inference capabilities to read in the type from a list of slug tuples.

![image](https://github.com/user-attachments/assets/80f9e028-7d15-4190-9cbc-040c8c2a2c5a)

![image](https://github.com/user-attachments/assets/7f71fee4-fda5-46e2-bdcd-9950631a0aed)

If we are continuing with generating `createPages` for the fs-router projects I think that something like this might be most ergonomic and type-safe.

If we are indeed 100% firm on not adding the function call still, I think `satisfies` will get us the most type safety, but have the gotcha of easily being forgotten. Because of this ease of forgetting, I think not including the `getConfig` in the generated types file at all would be most responsible.

This just means inferring `string` for any slug instead of having typed out staticPaths. So the final tradeoff to weigh for me is: do we want a function call that properly infers and type checks inside `getConfig` or do we want potentially looser slug types?

Happy to still discuss other options though of course

CC @dai-shi @sandren 