### PR TITLE
feat: regenerate fs-router types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ dist
 .cache
 .nvmrc
 .node-version
-entries.gen.tsx
+pages.gen.ts

--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -135,12 +135,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
           const hasGetConfig = fileExportsGetConfig(filePath);
 
           if (filePath.endsWith('/_layout.tsx')) {
-            fileInfo.push({
-              type: 'layout',
-              path: filePath.replace('_layout.tsx', ''),
-              src,
-              hasGetConfig,
-            });
+            continue;
           } else if (filePath.endsWith('/index.tsx')) {
             const path = filePath.slice(0, -'/index.tsx'.length);
             fileInfo.push({

--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -66,7 +66,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
       entriesFilePossibilities = EXTENSIONS.map((ext) =>
         joinPath(config.root, opts.srcDir, SRC_ENTRIES + ext),
       );
-      outputFile = joinPath(config.root, opts.srcDir, `${SRC_ENTRIES}.gen.tsx`);
+      outputFile = joinPath(config.root, opts.srcDir, 'pages.gen.ts');
 
       try {
         const prettier = await import('prettier');
@@ -120,13 +120,14 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         const file = readFileSync(pagesDir + filePath).toString();
 
         return (
-          file.includes('const getConfig') ||
-          file.includes('function getConfig')
+          file.includes('const getConfig =') ||
+          file.includes('function getConfig(')
         );
       };
 
       const generateFile = (filePaths: string[]): string => {
-        const fileInfo = [];
+        const fileInfo: { path: string; src: string; hasGetConfig: boolean }[] =
+          [];
         const moduleNames = getImportModuleNames(filePaths);
 
         for (const filePath of filePaths) {
@@ -139,14 +140,12 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
           } else if (filePath.endsWith('/index.tsx')) {
             const path = filePath.slice(0, -'/index.tsx'.length);
             fileInfo.push({
-              type: 'page',
               path: path || '/',
               src,
               hasGetConfig,
             });
           } else {
             fileInfo.push({
-              type: 'page',
               path: filePath.replace('.tsx', ''),
               src,
               hasGetConfig,

--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -195,6 +195,9 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
           return;
         }
         const files = await collectFiles(pagesDir);
+        if (!files.length) {
+          return;
+        }
         const formatted = await formatter(generateFile(files));
         await writeFile(outputFile, formatted, 'utf-8');
       };

--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -4,7 +4,11 @@ import type {
 } from './create-pages-utils/inferred-path-types.js';
 
 // PathsForPages collects the paths from the `createPages` result type
-export type { PathsForPages } from './create-pages-utils/inferred-path-types.js';
+// GetConfigResponse is a helper for generating types with fs-router
+export type {
+  PathsForPages,
+  GetConfigResponse,
+} from './create-pages-utils/inferred-path-types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RouteConfig {

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -190,9 +190,6 @@ export type PropsForPages<Path extends string> = Prettify<
 type GetResponseType<Response extends { render: string }> =
   string extends Response['render'] ? { render: 'dynamic' } : Response;
 
-type GetAsyncFnReturn<Fn extends () => Promise<{ render: string }>> =
-  GetResponseType<Awaited<ReturnType<Fn>>>;
-
 /**
  * Helper used for generation of types with fs-router for
  * collecting the type of the getConfig function response and
@@ -200,8 +197,7 @@ type GetAsyncFnReturn<Fn extends () => Promise<{ render: string }>> =
  */
 export type GetConfigResponse<
   Fn extends () => Promise<{ render: string }> | { render: string },
-> = Fn extends () => Promise<{ render: string }>
-  ? GetAsyncFnReturn<Fn>
-  : ReturnType<Fn> extends { render: string }
+> =
+  ReturnType<Fn> extends { render: string }
     ? GetResponseType<ReturnType<Fn>>
-    : never;
+    : GetResponseType<Awaited<ReturnType<Fn>>>;

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -186,3 +186,29 @@ export type PropsForPages<Path extends string> = Prettify<
   Omit<RouteProps<ReplaceAll<Path, `[${string}]`, string>>, 'hash'> &
     SlugTypes<Path>
 >;
+
+type AnyConfigResponse = {
+  render: string;
+  staticPaths: readonly string[] | readonly (readonly string[])[];
+};
+
+type GetResponseType<Response extends AnyConfigResponse> = Response extends {
+  render: 'static' | 'dynamic';
+}
+  ? Response
+  : { render: 'dynamic' };
+
+type GetAsyncFnReturn<Fn extends () => Promise<AnyConfigResponse>> =
+  GetResponseType<Awaited<ReturnType<Fn>>>;
+
+/**
+ * Helper used for generation of types with fs-router for
+ * collecting the type of the getConfig function response and
+ * falling back to {render: 'dynamic'} if inference fails.
+ */
+export type GetConfigResponse<Fn extends () => unknown> =
+  Fn extends () => Promise<AnyConfigResponse>
+    ? GetAsyncFnReturn<Fn>
+    : ReturnType<Fn> extends AnyConfigResponse
+      ? ReturnType<Fn>
+      : { render: 'dynamic' };

--- a/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
+++ b/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
@@ -87,15 +87,15 @@ describe('vite-plugin-fs-router-typegen', () => {
   test('creates the expected imports the generated entries file', async () => {
     await runTest(
       root,
-      `import CategoryTagsIndex, { getConfig as CategoryTagsIndex_getConfig } from './pages/[category]/[...tags]/index';
-import CategoryLayout, { getConfig as CategoryLayout_getConfig } from './pages/[category]/_layout';
-import Layout, { getConfig as Layout_getConfig } from './pages/_layout';
-import Root, { getConfig as Root_getConfig } from './pages/_root';
-import Index, { getConfig as Index_getConfig } from './pages/index';
-import OneTwoThree, { getConfig as OneTwoThree_getConfig } from './pages/one-two-three';
-import OneTwoThree_1, { getConfig as OneTwoThree_1_getConfig } from './pages/one__two_three';
-import OneTwoThree_2, { getConfig as OneTwoThree_2_getConfig } from './pages/one_two_three';
-import ØnéTwoThree, { getConfig as ØnéTwoThree_getConfig } from './pages/øné_two_three';`,
+      `import type { getConfig as CategoryTagsIndex_getConfig } from './pages/[category]/[...tags]/index';
+import type { getConfig as CategoryLayout_getConfig } from './pages/[category]/_layout';
+import type { getConfig as Layout_getConfig } from './pages/_layout';
+import type { getConfig as Root_getConfig } from './pages/_root';
+import type { getConfig as Index_getConfig } from './pages/index';
+import type { getConfig as OneTwoThree_getConfig } from './pages/one-two-three';
+import type { getConfig as OneTwoThree_1_getConfig } from './pages/one__two_three';
+import type { getConfig as OneTwoThree_2_getConfig } from './pages/one_two_three';
+import type { getConfig as ØnéTwoThree_getConfig } from './pages/øné_two_three';`,
     );
   });
 });

--- a/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
+++ b/packages/waku/tests/vite-plugin-fs-router-typegen.test.ts
@@ -88,8 +88,6 @@ describe('vite-plugin-fs-router-typegen', () => {
     await runTest(
       root,
       `import type { getConfig as CategoryTagsIndex_getConfig } from './pages/[category]/[...tags]/index';
-import type { getConfig as CategoryLayout_getConfig } from './pages/[category]/_layout';
-import type { getConfig as Layout_getConfig } from './pages/_layout';
 import type { getConfig as Root_getConfig } from './pages/_root';
 import type { getConfig as Index_getConfig } from './pages/index';
 import type { getConfig as OneTwoThree_getConfig } from './pages/one-two-three';


### PR DESCRIPTION
This moves the generation from fs-router types off of `createPages`

Happy to move things around or update examples as needed, but I think this solution simplifies our current uses nicely