### PR TITLE
fix(plugin/fs-router-typegen): use swc.parseSync instead of parseFileSync

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite';
 import { readdir, writeFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { SRC_ENTRIES, EXTENSIONS } from '../constants.js';
 import { joinPath } from '../utils/path.js';
 import * as swc from '@swc/core';
@@ -118,7 +118,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         if (!pagesDir) {
           return false;
         }
-        const file = swc.parseFileSync(pagesDir + filePath, {
+        const file = swc.parseSync(readFileSync(pagesDir + filePath, 'utf8'), {
           syntax: 'typescript',
           tsx: true,
         });

--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -3,7 +3,7 @@ import { readdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { SRC_ENTRIES, EXTENSIONS } from '../constants.js';
 import { joinPath } from '../utils/path.js';
-import { parseFileSync } from '@swc/core';
+import * as swc from '@swc/core';
 
 const SRC_PAGES = 'pages';
 
@@ -118,7 +118,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         if (!pagesDir) {
           return false;
         }
-        const file = parseFileSync(pagesDir + filePath, {
+        const file = swc.parseFileSync(pagesDir + filePath, {
           syntax: 'typescript',
           tsx: true,
         });


### PR DESCRIPTION
It fails in StackBlitz as `@swc/was` will be used.