### PR TITLE
fix(create-waku): package.json not found

### DIFF
--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "template"
+    "template",
+    "package.json"
   ],
   "scripts": {
     "start": "node ./dist/index.js",


### PR DESCRIPTION
closes #983

I don't think this can be tested without being published, but I believe this is the fix to the problem.

@dai-shi would you be willing to publish some sort of pre-release version to test this if you agree that it should work?