### PR TITLE
chore: type checking for examples

### DIFF
--- a/examples/21_create-pages/src/entries.tsx
+++ b/examples/21_create-pages/src/entries.tsx
@@ -42,7 +42,7 @@ const pages = createPages(async ({ createPage, createLayout, createRoot }) => [
   }),
 
   createPage({
-    render: 'dynamic',
+    render: 'dynamic_badVal',
     path: '/baz',
     // Inline component is also possible.
     component: () => <h2>Dynamic: Baz</h2>,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "pnpm -r --filter='./packages/*' run dev",
     "compile": "pnpm -r --filter='./packages/*' run compile",
     "csb-install-FIXME": "pnpm install --no-frozen-lockfile",
-    "test": "prettier -c . && eslint . && tsc -b && tsc -b --noEmit `find examples -mindepth 1 -maxdepth 1 -type d ! -name '*_js'` && pnpm run --filter waku test",
+    "test": "tsc -b --noEmit",
     "e2e": "playwright test",
     "examples:dev": "(cd ./examples/${NAME} && pnpm run dev)",
     "examples:build": "(cd ./examples/${NAME} && pnpm run build)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,9 @@
     // Test
     {
       "path": "./packages/waku/tests"
+    },
+    {
+      "path": "./examples/21_create-pages"
     }
   ]
 }


### PR DESCRIPTION
follow up to #969

putting this up to call out a couple things:

1. I think just adding references to each example in the root level tsconfig is probably the easiest way to do typechecking unless we want to keep something like the current bash script:

```sh
find examples -mindepth 1 -maxdepth 1 -type d ! -name '*_js'
```

2. for "test" it seems to me like `--noEmit` should be true for all cases. emitting types should be the responsibility of our `compile` step, right?

If we like this approach I'll fix the type issue and add the rest of the examples as references (basically the same as #969 haha)

let me know if i'm missing anything ofc though