### PR TITLE
chore(examples): migrate to new_defineEntries

### DIFF
--- a/examples/32_minimal_js/src/entries.jsx
+++ b/examples/32_minimal_js/src/entries.jsx
@@ -1,27 +1,18 @@
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
 import App from './components/app';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/examples/32_minimal_js/waku.config.ts
+++ b/examples/32_minimal_js/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/examples/33_promise/src/entries.tsx
+++ b/examples/33_promise/src/entries.tsx
@@ -1,34 +1,36 @@
-import { defineEntries } from 'waku/server';
-import { Children, Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Children, Slot } from 'waku/minimal/client';
+
 import App from './components/App';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: (
-        <App name={rscPath || 'Waku'}>
-          <Children />
-        </App>
-      ),
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: (
-            <Slot id="App">
-              <h3>A client element</h3>
-            </Slot>
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({
+        App: (
+          <App name={input.rscPath || 'Waku'}>
+            <Children />
+          </App>
+        ),
+      });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml(
+        {
+          App: (
+            <App name="Waku">
+              <Children />
+            </App>
           ),
-        };
-      default:
-        return null;
+        },
+        <Slot id="App">
+          <h3>A client element</h3>
+        </Slot>,
+        '',
+      );
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/examples/33_promise/waku.config.ts
+++ b/examples/33_promise/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/examples/36_form/src/als.ts
+++ b/examples/36_form/src/als.ts
@@ -1,0 +1,16 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type Rerender = (rscPath: string) => void;
+
+const store = new AsyncLocalStorage<Rerender>();
+
+export const runWithRerender = <T>(rerender: Rerender, fn: () => T): T => {
+  return store.run(rerender, fn);
+};
+
+export const rerender = (rscPath: string) => {
+  const fn = store.getStore();
+  if (fn) {
+    fn(rscPath);
+  }
+};

--- a/examples/36_form/src/components/funcs.ts
+++ b/examples/36_form/src/components/funcs.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { rerender } from 'waku/server';
+import { rerender } from '../als';
 
 // module state on server
 let message = '';

--- a/examples/36_form/src/entries.tsx
+++ b/examples/36_form/src/entries.tsx
@@ -1,26 +1,29 @@
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
-import App from './components/App';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+import App from './components/App';
+import { runWithRerender } from './als';
+
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const elements: Record<string, unknown> = {};
+      const rerender = (rscPath: string) => {
+        elements.App = <App name={rscPath || 'Waku'} />;
+      };
+      const value = await runWithRerender(rerender, () =>
+        input.fn(...input.args),
+      );
+      return renderRsc({ ...elements, _value: value });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/examples/36_form/tsconfig.json
+++ b/examples/36_form/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "types": ["react/experimental"],
+    "types": ["node", "react/experimental"],
     "jsx": "react-jsx"
   }
 }

--- a/examples/36_form/waku.config.ts
+++ b/examples/36_form/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/examples/37_css/src/entries.tsx
+++ b/examples/37_css/src/entries.tsx
@@ -1,32 +1,35 @@
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
 import Layout from './components/layout';
 import App from './components/app';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: (
-        <Layout>
-          <App name={rscPath || 'Waku'} />
-        </Layout>
-      ),
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({
+        App: (
+          <Layout>
+            <App name={input.rscPath || 'Waku'} />
+          </Layout>
+        ),
+      });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml(
+        {
+          App: (
+            <Layout>
+              <App name={'Waku'} />
+            </Layout>
+          ),
+        },
+        <Slot id="App" />,
+        '',
+      );
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/examples/37_css/waku.config.ts
+++ b/examples/37_css/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/examples/41_path-alias/src/entries.tsx
+++ b/examples/41_path-alias/src/entries.tsx
@@ -1,26 +1,18 @@
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
+
 import App from '@/components/App';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/examples/41_path-alias/waku.config.ts
+++ b/examples/41_path-alias/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});


### PR DESCRIPTION
following up #993.

- [x] 32_minimal_js
- [x] 33_promise
- [x] 36_form
- [x] 37_css
- [x] 41_path-alias