### PR TITLE
chore(examples): server console.log

### DIFF
--- a/examples/38_cookies/src/components/App.tsx
+++ b/examples/38_cookies/src/components/App.tsx
@@ -14,7 +14,7 @@ const InternalAsyncComponent = async () => {
     throw new Error('Cache not working');
   }
   console.log('waku context', Object.keys(getContextData()));
-  console.log('hono context', Object.keys(getHonoContext()));
+  console.log('hono context', getHonoContext());
   return null;
 };
 


### PR DESCRIPTION
At some point, react throws an error with non serializable data. It seems that it's already fixed, so let's revert the example.

https://github.com/dai-shi/waku/pull/875/files#diff-741ff37ef190c7b4874d864c43f559ab1151ec213d97265317a83111bd6a33feR15-R16