### PR TITLE
chore(e2e): migrate to new_defineEntries

### DIFF
--- a/e2e/fixtures/rsc-basic/src/entries.tsx
+++ b/e2e/fixtures/rsc-basic/src/entries.tsx
@@ -2,7 +2,7 @@ import { new_defineEntries } from 'waku/minimal/server';
 
 import App from './components/App.js';
 
-export default new_defineEntries({
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
   unstable_handleRequest: async (input, { renderRsc }) => {
     if (input.type === 'component') {
       return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
@@ -16,3 +16,5 @@ export default new_defineEntries({
     { pathSpec: [], entries: [{ rscPath: '' }] },
   ],
 });
+
+export default entries;

--- a/e2e/fixtures/rsc-basic/src/entries.tsx
+++ b/e2e/fixtures/rsc-basic/src/entries.tsx
@@ -1,19 +1,18 @@
-import { lazy } from 'react';
-import { defineEntries } from 'waku/server';
+import { new_defineEntries } from 'waku/minimal/server';
 
-const App = lazy(() => import('./components/App.js'));
+import App from './components/App.js';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
+export default new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
   },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  () => {
-    throw new Error('SSR is should not be used in this test.');
-  },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});

--- a/e2e/fixtures/rsc-basic/waku.config.ts
+++ b/e2e/fixtures/rsc-basic/waku.config.ts
@@ -1,8 +1,10 @@
-/** @type {import('waku/config').Config} */
-export default {
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
   middleware: () => [
+    import('waku/middleware/context'),
     import('waku/middleware/dev-server'),
-    import('waku/middleware/rsc'),
+    import('waku/middleware/handler'),
     import('waku/middleware/fallback'),
   ],
-};
+});

--- a/e2e/fixtures/rsc-css-modules/src/entries.tsx
+++ b/e2e/fixtures/rsc-css-modules/src/entries.tsx
@@ -1,19 +1,20 @@
-import { lazy } from 'react';
-import { defineEntries } from 'waku/server';
+import { new_defineEntries } from 'waku/minimal/server';
 
-const App = lazy(() => import('./components/App.js'));
+import App from './components/App.js';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
   },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  () => {
-    throw new Error('SSR should not be used in this test.');
-  },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});
+
+export default entries;

--- a/e2e/fixtures/rsc-css-modules/waku.config.ts
+++ b/e2e/fixtures/rsc-css-modules/waku.config.ts
@@ -1,8 +1,10 @@
-/** @type {import('waku/config').Config} */
-export default {
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
   middleware: () => [
+    import('waku/middleware/context'),
     import('waku/middleware/dev-server'),
-    import('waku/middleware/rsc'),
+    import('waku/middleware/handler'),
     import('waku/middleware/fallback'),
   ],
-};
+});

--- a/e2e/fixtures/ssr-basic/src/entries.tsx
+++ b/e2e/fixtures/ssr-basic/src/entries.tsx
@@ -1,28 +1,24 @@
-import { lazy } from 'react';
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
-const App = lazy(() => import('./components/App.js'));
+import App from './components/App.js';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});
+
+export default entries;

--- a/e2e/fixtures/ssr-basic/tsconfig.json
+++ b/e2e/fixtures/ssr-basic/tsconfig.json
@@ -13,5 +13,5 @@
     "jsx": "react-jsx",
     "outDir": "./dist"
   },
-  "include": ["./src", "./vite.config.ts"]
+  "include": ["./src", "./waku.config.ts", "./vite.config.ts"]
 }

--- a/e2e/fixtures/ssr-basic/waku.config.ts
+++ b/e2e/fixtures/ssr-basic/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/e2e/fixtures/ssr-context-provider/src/components/context-consumer.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/components/context-consumer.tsx
@@ -13,7 +13,7 @@ export const ContextConsumer = () => {
   return (
     <>
       {mounted && <div data-testid="mounted">true</div>}
-      <div data-testid="value">{value}</div>;
+      <div data-testid="value">{value}</div>
     </>
   );
 };

--- a/e2e/fixtures/ssr-context-provider/src/entries.tsx
+++ b/e2e/fixtures/ssr-context-provider/src/entries.tsx
@@ -1,29 +1,24 @@
-/// <reference types="react/experimental" />
-
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
 import App from './components/app.js';
 
-export default defineEntries(
-  // renderEntries
-  async () => {
-    return {
-      App: <App />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});
+
+export default entries;

--- a/e2e/fixtures/ssr-context-provider/tsconfig.json
+++ b/e2e/fixtures/ssr-context-provider/tsconfig.json
@@ -11,7 +11,7 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
-  }
+  },
+  "include": ["./src", "./waku.config.ts"]
 }

--- a/e2e/fixtures/ssr-context-provider/waku.config.ts
+++ b/e2e/fixtures/ssr-context-provider/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/e2e/fixtures/ssr-swr/src/entries.tsx
+++ b/e2e/fixtures/ssr-swr/src/entries.tsx
@@ -1,28 +1,24 @@
-import { lazy } from 'react';
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
-const App = lazy(() => import('./components/App.js'));
+import App from './components/App.js';
 
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});
+
+export default entries;

--- a/e2e/fixtures/ssr-swr/tsconfig.json
+++ b/e2e/fixtures/ssr-swr/tsconfig.json
@@ -11,7 +11,7 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
-  }
+  },
+  "include": ["./src", "./waku.config.ts"]
 }

--- a/e2e/fixtures/ssr-swr/waku.config.ts
+++ b/e2e/fixtures/ssr-swr/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});

--- a/e2e/fixtures/ssr-target-bundle/src/components/App.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/components/App.tsx
@@ -1,6 +1,9 @@
 import { Textarea } from './Textarea.js';
+// @ts-expect-error no types
 import SampleImage from './image-not-inlined.jpg'; // build.assetsInlineLimit - default 4096 Bytes
+// @ts-expect-error no types
 import SampleJsonPrivate from './json-private-not-inlined.json'; // build.assetsInlineLimit - default 4096 Bytes
+// @ts-expect-error no types
 import SampleJsonPublic from './json-public-linked-not-inlined.json?url'; // build.assetsInlineLimit - default 4096 Bytes
 
 const App = async ({ name }: { name: string }) => {

--- a/e2e/fixtures/ssr-target-bundle/src/entries.tsx
+++ b/e2e/fixtures/ssr-target-bundle/src/entries.tsx
@@ -1,30 +1,24 @@
-/// <reference types="react/experimental" />
+import { new_defineEntries } from 'waku/minimal/server';
+import { Slot } from 'waku/minimal/client';
 
-import { lazy } from 'react';
-import { defineEntries } from 'waku/server';
-import { Slot } from 'waku/client';
+import App from './components/App.js';
 
-const App = lazy(() => import('./components/App.js'));
-
-export default defineEntries(
-  // renderEntries
-  async (rscPath) => {
-    return {
-      App: <App name={rscPath || 'Waku'} />,
-    };
-  },
-  // getBuildConfig
-  async () => [{ pathname: '/', entries: [{ rscPath: '' }] }],
-  // getSsrConfig
-  async (pathname) => {
-    switch (pathname) {
-      case '/':
-        return {
-          rscPath: '',
-          html: <Slot id="App" />,
-        };
-      default:
-        return null;
+const entries: ReturnType<typeof new_defineEntries> = new_defineEntries({
+  unstable_handleRequest: async (input, { renderRsc, renderHtml }) => {
+    if (input.type === 'component') {
+      return renderRsc({ App: <App name={input.rscPath || 'Waku'} /> });
+    }
+    if (input.type === 'function') {
+      const value = await input.fn(...input.args);
+      return renderRsc({ _value: value });
+    }
+    if (input.type === 'custom' && input.pathname === '/') {
+      return renderHtml({ App: <App name="Waku" /> }, <Slot id="App" />, '');
     }
   },
-);
+  unstable_getBuildConfig: async () => [
+    { pathSpec: [], entries: [{ rscPath: '' }] },
+  ],
+});
+
+export default entries;

--- a/e2e/fixtures/ssr-target-bundle/tsconfig.json
+++ b/e2e/fixtures/ssr-target-bundle/tsconfig.json
@@ -11,7 +11,7 @@
     "exactOptionalPropertyTypes": true,
     "types": ["react/experimental"],
     "jsx": "react-jsx",
-    "rootDir": "./src",
     "outDir": "./dist"
-  }
+  },
+  "include": ["./src", "./waku.config.ts"]
 }

--- a/e2e/fixtures/ssr-target-bundle/waku.config.ts
+++ b/e2e/fixtures/ssr-target-bundle/waku.config.ts
@@ -1,0 +1,11 @@
+// This is a temporary file while experimenting new_defineEntries
+
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+  ],
+});


### PR DESCRIPTION
- [x] rsc-basic
- [x] rsc-css-modules
- [x] ssr-basic
- [x] ssr-context-provider
- [x] ssr-swr
- [x] ssr-target-bundle