### PR TITLE
fix: watch pages dir for typegen updates

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -225,6 +225,8 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
         await writeFile(outputFile, formatted, 'utf-8');
       };
 
+      server.watcher.add(pagesDir);
+
       server.watcher.on('change', async (file) => {
         if (!outputFile || outputFile.endsWith(file)) {
           return;


### PR DESCRIPTION
Tested this locally and the hot reload still works when changing the components or the pages dir

the key about this is that pages.gen.ts is outside pagesDir so we avoid the issue we were seeing before.

but the upside of still watching this is that when we add/remove pages or update their getConfig, pages.gen.ts will hot update to reflect the changes