### PR TITLE
chore(e2e): migrate to new_defineRouter

### DIFF
--- a/e2e/fixtures/rsc-router/src/entries.tsx
+++ b/e2e/fixtures/rsc-router/src/entries.tsx
@@ -1,29 +1,62 @@
-import { unstable_defineRouter } from 'waku/router/server';
+import type { ReactNode } from 'react';
+import { new_defineRouter } from 'waku/router/server';
+import { Slot, Children } from 'waku/minimal/client';
+
+import Layout from './routes/layout.js';
+import Page from './routes/page.js';
+import FooPage from './routes/foo/page.js';
 
 const STATIC_PATHS = ['/', '/foo'];
+const PATH_PAGE: Record<string, ReactNode> = {
+  '/': <Page />,
+  '/foo': <FooPage />,
+};
 
-export default unstable_defineRouter(
-  // getPathConfig
-  async () =>
+export default new_defineRouter({
+  getPathConfig: async () =>
     STATIC_PATHS.map((path) => ({
       pattern: `^${path}$`,
       path: path
         .split('/')
         .filter(Boolean)
         .map((name) => ({ type: 'literal', name })),
-      isStatic: true,
+      routeElement: { isStatic: true },
+      elements: {
+        root: { isStatic: true },
+        'layout:/': { isStatic: true },
+        [`page:${path}`]: { isStatic: true },
+      },
     })),
-  // getComponent (id is "**/layout" or "**/page")
-  async (id) => {
-    switch (id) {
-      case 'layout':
-        return (await import('./routes/layout.js')).default;
-      case 'page':
-        return (await import('./routes/page.js')).default;
-      case 'foo/page':
-        return (await import('./routes/foo/page.js')).default;
-      default:
-        return null;
+  renderRoute: async (path) => {
+    if (!STATIC_PATHS.includes(path)) {
+      throw new Error('renderRoute: No such path:' + path);
     }
+    return {
+      routeElement: (
+        <Slot id="root">
+          <Slot id="layout:/">
+            <Slot id={`page:${path}`} />
+          </Slot>
+        </Slot>
+      ),
+      elements: {
+        root: (
+          <html>
+            <head>
+              <title>Waku example</title>
+            </head>
+            <body>
+              <Children />
+            </body>
+          </html>
+        ),
+        'layout:/': (
+          <Layout>
+            <Children />
+          </Layout>
+        ),
+        [`page:${path}`]: PATH_PAGE[path],
+      },
+    };
   },
-);
+});

--- a/e2e/fixtures/rsc-router/src/main.tsx
+++ b/e2e/fixtures/rsc-router/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Router } from 'waku/router/client';
+import { NewRouter as Router } from 'waku/router/client';
 
 const rootElement = (
   <StrictMode>

--- a/e2e/fixtures/rsc-router/src/routes/layout.tsx
+++ b/e2e/fixtures/rsc-router/src/routes/layout.tsx
@@ -15,36 +15,29 @@ const Pending = ({ isPending }: { isPending: boolean }) => (
 );
 
 const HomeLayout = ({ children }: { children: ReactNode }) => (
-  <html>
-    <head>
-      <title>Waku example</title>
-    </head>
-    <body>
-      <div>
-        <ul>
-          <li>
-            <Link
-              to="/"
-              pending={<Pending isPending />}
-              notPending={<Pending isPending={false} />}
-            >
-              Home
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/foo"
-              pending={<Pending isPending />}
-              notPending={<Pending isPending={false} />}
-            >
-              Foo
-            </Link>
-          </li>
-        </ul>
-        {children}
-      </div>
-    </body>
-  </html>
+  <div>
+    <ul>
+      <li>
+        <Link
+          to="/"
+          pending={<Pending isPending />}
+          notPending={<Pending isPending={false} />}
+        >
+          Home
+        </Link>
+      </li>
+      <li>
+        <Link
+          to="/foo"
+          pending={<Pending isPending />}
+          notPending={<Pending isPending={false} />}
+        >
+          Foo
+        </Link>
+      </li>
+    </ul>
+    {children}
+  </div>
 );
 
 export default HomeLayout;


### PR DESCRIPTION
It's a leftover from #949.