### PR TITLE
fix(typegen): abstract DO_NOT_USE_pages away from pages.gen.ts

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-fs-router-typegen.ts
@@ -186,8 +186,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
           }
         }
 
-        result += `\ntype Page = {
-  DO_NOT_USE_pages:`;
+        result += `\ntype Page =\n`;
 
         for (const file of fileInfo) {
           const moduleName = moduleNames[file.src];
@@ -198,7 +197,7 @@ export const fsRouterTypegenPlugin = (opts: { srcDir: string }): Plugin => {
           }
         }
 
-        result += `};
+        result += `;
 
   declare module 'waku/router' {
     interface RouteConfig {

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -141,10 +141,17 @@ export type AnyPage = {
  * type MyPaths = PathsForPages<typeof pages>;
  * // type MyPaths = '/foo' | '/bar';
  */
-export type PathsForPages<PagesResult extends { DO_NOT_USE_pages: AnyPage }> =
-  CollectPaths<PagesResult['DO_NOT_USE_pages']> extends never
+export type PathsForPages<
+  PagesResult extends { DO_NOT_USE_pages: AnyPage } | AnyPage,
+> = PagesResult extends { DO_NOT_USE_pages: AnyPage }
+  ? CollectPaths<PagesResult['DO_NOT_USE_pages']> extends never
     ? string
-    : CollectPaths<PagesResult['DO_NOT_USE_pages']>;
+    : CollectPaths<PagesResult['DO_NOT_USE_pages']>
+  : PagesResult extends AnyPage
+    ? CollectPaths<PagesResult> extends never
+      ? string
+      : CollectPaths<PagesResult>
+    : never;
 
 type _GetSlugs<
   Route extends string,


### PR DESCRIPTION
Simplified generated type output for waku website as example:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/3d5c161f-73ac-49f6-82bf-eb3de70dc0fe">
