### PR TITLE
fix(cloudflare): update default generated wrangler.toml

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -221,16 +221,14 @@ export function deployCloudflarePlugin(opts: {
 name = "waku-project"
 compatibility_date = "2024-09-23"
 compatibility_flags = [ "nodejs_als" ]
-pages_build_output_dir = "./dist"
 main = "./dist/worker/serve-cloudflare.js"
 
-assets = {
-  directory = "./dist/assets",
-  binding = "ASSETS",
-  html_handling = "drop-trailing-slash",
-  # "single-page-application" | "404-page" | "none"
-  not_found_handling = "404-page"
-}
+[assets]
+directory = "./dist/assets"
+binding = "ASSETS"
+html_handling = "drop-trailing-slash"
+# "single-page-application" | "404-page" | "none"
+not_found_handling = "404-page"
 `,
         );
       }


### PR DESCRIPTION
See #1053 - the generated `wrangler.toml` file does not match Waku's new Cloudflare Workers based deployment, and is invalid TOML.

I updated the plugin to generate the same file as in the example: https://github.com/dai-shi/waku/blob/main/examples/44_cloudflare/wrangler.toml

Fixes #1053