### PR TITLE
chore: react version range in peerDeps

### DIFF
--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -102,8 +102,8 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-server-dom-webpack": "^19.0.0"
+    "react": "~19.0.0",
+    "react-dom": "~19.0.0",
+    "react-server-dom-webpack": "~19.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1118,13 +1118,13 @@ importers:
         specifier: 4.6.13
         version: 4.6.13
       react:
-        specifier: ^19.0.0
+        specifier: ~19.0.0
         version: 19.0.0
       react-dom:
-        specifier: ^19.0.0
+        specifier: ~19.0.0
         version: 19.0.0(react@19.0.0)
       react-server-dom-webpack:
-        specifier: ^19.0.0
+        specifier: ~19.0.0
         version: 19.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(webpack@5.97.1(@swc/core@1.10.0(@swc/helpers@0.5.15)))
       rsc-html-stream:
         specifier: 0.0.4


### PR DESCRIPTION
https://react.dev/reference/rsc/server-functions

> While Server Functions in React 19 are stable and will not break between major versions, the underlying APIs used to implement Server Functions in a React Server Components bundler or framework do not follow semver and may break between minors in React 19.x.