### PR TITLE
fix(router): improve function returning components with `skip`

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -124,8 +124,8 @@ export function rscHmrPlugin(): Plugin {
             `
 {
   const refetchRoute = () => {
-    cachedIdSet.clear();
     staticPathSet.clear();
+    routerData[2].clear(); // cacheIdSet
     const rscPath = encodeRoutePath(route.path);
     const rscParams = createRscParams(route.query, []);
     refetch(rscPath, rscParams);

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -34,6 +34,7 @@ import {
   ROUTE_ID,
   IS_STATIC_ID,
   HAS404_ID,
+  HEADER_SKIP,
 } from './common.js';
 import type { RouteProps } from './common.js';
 import type { RouteConfig } from './base-types.js';
@@ -75,21 +76,14 @@ const parseRouteFromLocation = (): RouteProps => {
   return parseRoute(new URL(window.location.href));
 };
 
-let savedRscParams:
-  | [query: string, skipStr: string, rscParams: URLSearchParams]
-  | undefined;
+let savedRscParams: [query: string, rscParams: URLSearchParams] | undefined;
 
-const createRscParams = (query: string, skip: string[]): URLSearchParams => {
-  const skipStr = JSON.stringify(skip);
-  if (
-    savedRscParams &&
-    savedRscParams[0] === query &&
-    savedRscParams[1] === skipStr
-  ) {
-    return savedRscParams[2];
+const createRscParams = (query: string): URLSearchParams => {
+  if (savedRscParams && savedRscParams[0] === query) {
+    return savedRscParams[1];
   }
-  const rscParams = new URLSearchParams({ query, skip: skipStr });
-  savedRscParams = [query, skipStr, rscParams];
+  const rscParams = new URLSearchParams({ query });
+  savedRscParams = [query, rscParams];
   return rscParams;
 };
 
@@ -326,7 +320,7 @@ const InnerRouter = ({
   routerData: Required<RouterData>;
   initialRoute: RouteProps;
 }) => {
-  const [cachedIdSet, staticPathSet, locationListeners] = routerData;
+  const [locationListeners, staticPathSet] = routerData;
   const refetch = useRefetch();
   const [route, setRoute] = useState(() => ({
     // This is the first initialization of the route, and it has
@@ -355,15 +349,14 @@ const InnerRouter = ({
       const { skipRefetch } = options || {};
       startTransition(() => {
         if (!staticPathSet.has(route.path) && !skipRefetch) {
-          const skip = Array.from(cachedIdSet);
           const rscPath = encodeRoutePath(route.path);
-          const rscParams = createRscParams(route.query, skip);
+          const rscParams = createRscParams(route.query);
           refetch(rscPath, rscParams);
         }
         setRoute(route);
       });
     },
-    [refetch, cachedIdSet, staticPathSet],
+    [refetch, staticPathSet],
   );
 
   const prefetchRoute: PrefetchRoute = useCallback(
@@ -371,13 +364,12 @@ const InnerRouter = ({
       if (staticPathSet.has(route.path)) {
         return;
       }
-      const skip = Array.from(cachedIdSet);
       const rscPath = encodeRoutePath(route.path);
-      const rscParams = createRscParams(route.query, skip);
+      const rscParams = createRscParams(route.query);
       prefetchRsc(rscPath, rscParams);
       (globalThis as any).__WAKU_ROUTER_PREFETCH__?.(route.path);
     },
-    [cachedIdSet, staticPathSet],
+    [staticPathSet],
   );
 
   useEffect(() => {
@@ -446,9 +438,9 @@ const InnerRouter = ({
 
 // Note: The router data must be a stable mutable object (array).
 type RouterData = [
-  cachedIdSet?: Set<string>,
-  staticPathSet?: Set<string>,
   locationListeners?: Set<(path: string, query: string) => void>,
+  staticPathSet?: Set<string>,
+  cachedIdSet?: Set<string>,
   has404?: boolean,
 ];
 
@@ -459,10 +451,22 @@ export function Router({
   initialRoute = parseRouteFromLocation(),
 }) {
   const initialRscPath = encodeRoutePath(initialRoute.path);
-  const cachedIdSet = (routerData[0] ||= new Set());
+  const locationListeners = (routerData[0] ||= new Set());
   const staticPathSet = (routerData[1] ||= new Set());
-  const locationListeners = (routerData[2] ||= new Set());
+  const cachedIdSet = (routerData[2] ||= new Set());
   const has404 = (routerData[3] ||= false);
+  const unstable_enhanceFetch =
+    (fetchFn: typeof fetch) =>
+    (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const skipStr = JSON.stringify(Array.from(cachedIdSet));
+      const headers = (init.headers ||= {});
+      if (Array.isArray(headers)) {
+        headers.push([HEADER_SKIP, skipStr]);
+      } else {
+        (headers as Record<string, string>)[HEADER_SKIP] = skipStr;
+      }
+      return fetchFn(input, init);
+    };
   const unstable_enhanceCreateData =
     (
       createData: (
@@ -511,13 +515,18 @@ export function Router({
         .catch(() => {});
       return data;
     };
-  const initialRscParams = createRscParams(initialRoute.query, []);
+  const initialRscParams = createRscParams(initialRoute.query);
   return createElement(
     ErrorBoundary,
     null,
     createElement(
       Root as FunctionComponent<Omit<ComponentProps<typeof Root>, 'children'>>,
-      { initialRscPath, initialRscParams, unstable_enhanceCreateData },
+      {
+        initialRscPath,
+        initialRscParams,
+        unstable_enhanceFetch,
+        unstable_enhanceCreateData,
+      },
       createElement(InnerRouter, {
         routerData: routerData as Required<RouterData>,
         initialRoute,

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -34,7 +34,7 @@ import {
   ROUTE_ID,
   IS_STATIC_ID,
   HAS404_ID,
-  HEADER_SKIP,
+  SKIP_HEADER,
 } from './common.js';
 import type { RouteProps } from './common.js';
 import type { RouteConfig } from './base-types.js';
@@ -461,9 +461,9 @@ export function Router({
       const skipStr = JSON.stringify(Array.from(cachedIdSet));
       const headers = (init.headers ||= {});
       if (Array.isArray(headers)) {
-        headers.push([HEADER_SKIP, skipStr]);
+        headers.push([SKIP_HEADER, skipStr]);
       } else {
-        (headers as Record<string, string>)[HEADER_SKIP] = skipStr;
+        (headers as Record<string, string>)[SKIP_HEADER] = skipStr;
       }
       return fetchFn(input, init);
     };

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -40,14 +40,9 @@ export function decodeRoutePath(rscPath: string): string {
   return rscPath.slice(ROUTE_PREFIX.length);
 }
 
-// It starts with "/" to avoid conflicting with normal component ids.
-export const ROUTE_ID = '/ROUTE';
-
-// It starts with "/" to avoid conflicting with normal component ids.
-export const IS_STATIC_ID = '/IS_STATIC';
-
-// It starts with "/" to avoid conflicting with normal component ids.
-export const HAS404_ID = '/HAS404';
+export const ROUTE_ID = 'ROUTE';
+export const IS_STATIC_ID = 'IS_STATIC';
+export const HAS404_ID = 'HAS404';
 
 // For HTTP header
-export const HEADER_SKIP = 'X-Waku-Router-Skip';
+export const SKIP_HEADER = 'X-Waku-Router-Skip';

--- a/packages/waku/src/router/common.ts
+++ b/packages/waku/src/router/common.ts
@@ -48,3 +48,6 @@ export const IS_STATIC_ID = '/IS_STATIC';
 
 // It starts with "/" to avoid conflicting with normal component ids.
 export const HAS404_ID = '/HAS404';
+
+// For HTTP header
+export const HEADER_SKIP = 'X-Waku-Router-Skip';

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -9,7 +9,7 @@ import {
   ROUTE_ID,
   IS_STATIC_ID,
   HAS404_ID,
-  HEADER_SKIP,
+  SKIP_HEADER,
 } from './common.js';
 import { getPathMapping } from '../lib/utils/path.js';
 import type { PathSpec } from '../lib/utils/path.js';
@@ -176,7 +176,7 @@ export function unstable_defineRouter(fns: {
     }
     let skipParam: unknown;
     try {
-      skipParam = JSON.parse(headers[HEADER_SKIP.toLowerCase()] || '');
+      skipParam = JSON.parse(headers[SKIP_HEADER.toLowerCase()] || '');
     } catch {
       // ignore
     }

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -9,6 +9,7 @@ import {
   ROUTE_ID,
   IS_STATIC_ID,
   HAS404_ID,
+  HEADER_SKIP,
 } from './common.js';
 import { getPathMapping } from '../lib/utils/path.js';
 import type { PathSpec } from '../lib/utils/path.js';
@@ -24,20 +25,12 @@ const parseRscParams = (
   rscParams: unknown,
 ): {
   query: string;
-  skip: string[];
 } => {
   if (!(rscParams instanceof URLSearchParams)) {
-    return { query: '', skip: [] };
+    return { query: '' };
   }
   const query = rscParams.get('query') || '';
-  let skipParam: unknown;
-  try {
-    skipParam = JSON.parse(rscParams.get('skip')!);
-  } catch {
-    // ignore
-  }
-  const skip = isStringArray(skipParam) ? skipParam : [];
-  return { query, skip };
+  return { query };
 };
 
 const RERENDER_SYMBOL = Symbol('RERENDER');
@@ -171,13 +164,24 @@ export function unstable_defineRouter(fns: {
       return !!found && found.staticElementIds.includes(slotId);
     });
   };
-  const getEntries = async (rscPath: string, rscParams: unknown) => {
+  const getEntries = async (
+    rscPath: string,
+    rscParams: unknown,
+    headers: Readonly<Record<string, string>>,
+  ) => {
     const pathname = decodeRoutePath(rscPath);
     const pathStatus = await existsPath(pathname);
     if (!pathStatus.found) {
       return null;
     }
-    const { query, skip } = parseRscParams(rscParams);
+    let skipParam: unknown;
+    try {
+      skipParam = JSON.parse(headers[HEADER_SKIP.toLowerCase()] || '');
+    } catch {
+      // ignore
+    }
+    const skip = isStringArray(skipParam) ? skipParam : [];
+    const { query } = parseRscParams(rscParams);
     const { routeElement, elements, fallbackElement } = await fns.renderRoute(
       pathname,
       pathStatus.isStatic ? {} : { query },
@@ -221,7 +225,7 @@ export function unstable_defineRouter(fns: {
         }
         const pathname = '/' + pathSpec.map(({ name }) => name).join('/');
         const rscPath = encodeRoutePath(pathname);
-        const entries = await getEntries(rscPath, undefined);
+        const entries = await getEntries(rscPath, undefined, {});
         if (entries) {
           path2moduleIds[pattern] =
             await unstable_collectClientModules(entries);
@@ -265,7 +269,11 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
   return defineEntries({
     handleRequest: async (input, { renderRsc, renderHtml }) => {
       if (input.type === 'component') {
-        const entries = await getEntries(input.rscPath, input.rscParams);
+        const entries = await getEntries(
+          input.rscPath,
+          input.rscParams,
+          input.req.headers,
+        );
         if (!entries) {
           return null;
         }
@@ -281,7 +289,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
           }
           elementsPromise = Promise.all([
             elementsPromise,
-            getEntries(rscPath, rscParams),
+            getEntries(rscPath, rscParams, input.req.headers),
           ]).then(([oldElements, newElements]) => {
             if (newElements === null) {
               console.warn('getEntries returned null');
@@ -313,7 +321,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         }
         const rscPath = encodeRoutePath(pathname);
         const rscParams = new URLSearchParams({ query });
-        const entries = await getEntries(rscPath, rscParams);
+        const entries = await getEntries(rscPath, rscParams, input.req.headers);
         if (!entries) {
           return null;
         }


### PR DESCRIPTION
Previously, we weren't able to pass `skip` to function invocation.
This moves `skip` from search params to http headers, and it's always available.