### PR TITLE
chore(types): obscure types for page props

### DIFF
--- a/packages/waku/src/router/base-types.ts
+++ b/packages/waku/src/router/base-types.ts
@@ -1,6 +1,6 @@
 import type {
   PagePath,
-  PropsForPages,
+  PropsForPagesComponent,
 } from './create-pages-utils/inferred-path-types.js';
 
 // PathsForPages collects the paths from the `createPages` result type
@@ -23,4 +23,4 @@ export interface CreatePagesConfig {
 /** Props for pages when using `createPages` */
 export type PageProps<
   Path extends PagePath<CreatePagesConfig> | (string & {}),
-> = PropsForPages<Path>;
+> = PropsForPagesComponent<Path>;

--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -194,6 +194,10 @@ export type PropsForPages<Path extends string> = Prettify<
     SlugTypes<Path>
 >;
 
+export interface PropsForPagesComponent<Path extends string> {
+  props: PropsForPages<Path>;
+}
+
 type GetResponseType<Response extends { render: string }> =
   string extends Response['render'] ? { render: 'dynamic' } : Response;
 


### PR DESCRIPTION
This is to hide the implementation details of `PropsForPages` in the exported `PageProps` type

re #1058