### PR TITLE
fix(style-dev): style css for dev with vite js module

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
@@ -225,28 +225,17 @@ async function generateInitialScripts(
   const scripts: HtmlTagDescriptor[] = [];
 
   for (const result of sources.values()) {
-    if (result.id.endsWith('.module.css')) {
-      // CSS modules do not support result.source (empty) since ssr-transforming them gives the css keys and client-transforming them gives the script tag for injecting them.
-      // Since we use the client-transformed script tag, we need to avoid FOUC by blocking render
-      scripts.push({
-        tag: 'script',
-        attrs: {
-          type: 'module',
-          async: true,
-          blocking: 'render',
-          'waku-module-id': result.id,
-        },
-        children: result.code,
-        injectTo: 'head',
-      });
-    } else {
-      scripts.push({
-        tag: 'style',
-        attrs: { type: 'text/css', 'waku-module-id': result.id },
-        children: result.source,
-        injectTo: 'head',
-      });
-    }
+    scripts.push({
+      tag: 'script',
+      attrs: {
+        type: 'module',
+        async: true,
+        blocking: 'render',
+        'waku-module-id': result.id,
+      },
+      children: result.code,
+      injectTo: 'head',
+    });
   }
   return scripts;
 }


### PR DESCRIPTION
This will fix the missing styles with vite 6 for #1012

It works by running js from the browser to create the styles with CSR in dev. Before we were extracting the source for plain css and passing those from the dev server in a <style> tag, but since that breaks in vite 6, this is an easy solution that will handle styles more consistently and without errors.