### PR TITLE
chore(e2e): add website to smoke tests & fix dev server error

### DIFF
--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -33,6 +33,8 @@ const examples = [
   ...(await readdir(examplesDir)).map((example) =>
     fileURLToPath(new URL(`../examples/${example}`, import.meta.url)),
   ),
+  // website isn't part of the examples but it is one of good examples to test here
+  fileURLToPath(new URL(`../packages/website`, import.meta.url)),
 ];
 
 for (const cwd of examples) {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "test": "prettier -c . && eslint . && tsc -b && tsc -b --noEmit `find examples -mindepth 1 -maxdepth 1 -type d ! -name '*_js'` && pnpm run --filter waku test",
     "test-vite-ecosystem-ci": "pnpm run --filter waku test && playwright test --project=chromium",
     "e2e": "playwright test",
-    "website:dev": "cd packages/website && pnpm run dev",
-    "website:build": "cd packages/website && pnpm run build",
+    "website:dev": "pnpm -F waku-website dev",
+    "website:build": "pnpm -F waku-website build",
     "website:vercel": "pnpm run compile && pnpm run website:build --with-vercel-static && mv packages/website/.vercel/output .vercel/",
-    "website:prd": "pnpm run website:build && (cd packages/website && pnpm start)"
+    "website:prd": "pnpm run website:build && (pnpm -F waku-website start)"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "website:dev": "pnpm -F waku-website dev",
     "website:build": "pnpm -F waku-website build",
     "website:vercel": "pnpm run compile && pnpm run website:build --with-vercel-static && mv packages/website/.vercel/output .vercel/",
-    "website:prd": "pnpm run website:build && (pnpm -F waku-website start)"
+    "website:prd": "pnpm run website:build && pnpm -F waku-website start"
   },
   "prettier": {
     "singleQuote": true,

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -111,11 +111,7 @@ const createMainViteServer = (
         fsRouterTypegenPlugin(config),
       ],
       optimizeDeps: {
-        include: [
-          'react-server-dom-webpack/client',
-          'react-server-dom-webpack/client.edge',
-          'react-dom/client',
-        ],
+        include: ['react-server-dom-webpack/client', 'react-dom/client'],
         exclude: ['waku', 'rsc-html-stream/server'],
         entries: [
           `${config.srcDir}/${SRC_ENTRIES}.*`,
@@ -125,6 +121,9 @@ const createMainViteServer = (
       },
       ssr: {
         external: ['waku'],
+        optimizeDeps: {
+          include: ['react-server-dom-webpack/client.edge'],
+        },
       },
       appType: 'mpa',
       server: { middlewareMode: true },
@@ -236,11 +235,7 @@ const createRscViteServer = (
         rscDelegatePlugin(hotUpdateCallback),
       ],
       optimizeDeps: {
-        include: [
-          'react-server-dom-webpack/client',
-          'react-server-dom-webpack/client.edge',
-          'react-dom/client',
-        ],
+        include: ['react-server-dom-webpack/client', 'react-dom/client'],
         exclude: ['waku'],
         entries: [
           `${config.srcDir}/${SRC_ENTRIES}.*`,
@@ -257,7 +252,6 @@ const createRscViteServer = (
         optimizeDeps: {
           include: [
             'react-server-dom-webpack/server.edge',
-            'react-server-dom-webpack/client.edge',
             'react',
             'react/jsx-runtime',
             'react/jsx-dev-runtime',

--- a/packages/waku/src/lib/middleware/dev-server-impl.ts
+++ b/packages/waku/src/lib/middleware/dev-server-impl.ts
@@ -111,7 +111,11 @@ const createMainViteServer = (
         fsRouterTypegenPlugin(config),
       ],
       optimizeDeps: {
-        include: ['react-server-dom-webpack/client', 'react-dom/client'],
+        include: [
+          'react-server-dom-webpack/client',
+          'react-server-dom-webpack/client.edge',
+          'react-dom/client',
+        ],
         exclude: ['waku', 'rsc-html-stream/server'],
         entries: [
           `${config.srcDir}/${SRC_ENTRIES}.*`,
@@ -232,7 +236,11 @@ const createRscViteServer = (
         rscDelegatePlugin(hotUpdateCallback),
       ],
       optimizeDeps: {
-        include: ['react-server-dom-webpack/client', 'react-dom/client'],
+        include: [
+          'react-server-dom-webpack/client',
+          'react-server-dom-webpack/client.edge',
+          'react-dom/client',
+        ],
         exclude: ['waku'],
         entries: [
           `${config.srcDir}/${SRC_ENTRIES}.*`,
@@ -249,6 +257,7 @@ const createRscViteServer = (
         optimizeDeps: {
           include: [
             'react-server-dom-webpack/server.edge',
+            'react-server-dom-webpack/client.edge',
             'react',
             'react/jsx-runtime',
             'react/jsx-dev-runtime',

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
@@ -55,6 +55,9 @@ export function rscRsdwPlugin(): Plugin {
     },
     transform(code, id) {
       const [file, opt] = id.split('?');
+      if (file?.includes('/cjs')) {
+        console.log('cjs', file);
+      }
       if (
         ['commonjs-exports', 'commonjs-proxy', 'commonjs-entry'].includes(opt!)
       ) {
@@ -76,6 +79,7 @@ export function rscRsdwPlugin(): Plugin {
           '/react-server-dom-webpack-client.browser.production.js',
           '/react-server-dom-webpack-client.browser.development.js',
           '/react-server-dom-webpack_client.js',
+          '/react-server-dom-webpack_client__edge.js',
         ].some((suffix) => file!.endsWith(suffix))
       ) {
         return patchRsdw(code, 'CLIENT');

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
@@ -55,9 +55,6 @@ export function rscRsdwPlugin(): Plugin {
     },
     transform(code, id) {
       const [file, opt] = id.split('?');
-      if (file?.includes('/cjs')) {
-        console.log('cjs', file);
-      }
       if (
         ['commonjs-exports', 'commonjs-proxy', 'commonjs-entry'].includes(opt!)
       ) {

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -7,10 +7,7 @@ export default ({ mode }: { mode: string }) => {
       },
       ssr: {
         optimizeDeps: {
-          include: [
-            'next-mdx-remote/rsc',
-            'react-server-dom-webpack/client.edge', // FIXME this should be managed by dev-server-impl.ts
-          ],
+          include: ['next-mdx-remote/rsc'],
         },
       },
     };

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -7,7 +7,10 @@ export default ({ mode }: { mode: string }) => {
       },
       ssr: {
         optimizeDeps: {
-          include: ['next-mdx-remote/rsc'],
+          include: [
+            'next-mdx-remote/rsc',
+            'react-server-dom-webpack/client.edge', // FIXME this should be managed by dev-server-impl.ts
+          ],
         },
       },
     };


### PR DESCRIPTION
- smoke test website in e2e tests
- fix runtime error for dev server related to client edge from react-server-dom-webpack

the error:

```
TypeError: globalThis.__WAKU_CLIENT_CHUNK_LOAD__ is not a function
    at Object.get (file:///~/gitspace/waku/packages/waku/dist/lib/renderers/html.js:162:36)
    at resolveClientReference (/~/gitspace/waku/node_modules/.pnpm/react-server-dom-webpack@19.0.0_react-dom@19.0.0_react@19.0.0__react@19.0.0_webpack@5.97.1/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js:28:60)
    at resolveModule (/~/gitspace/waku/node_modules/.pnpm/react-server-dom-webpack@19.0.0_react-dom@19.0.0_react@19.0.0__react@19.0.0_webpack@5.97.1/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js:1755:29)
    at processFullStringRow (/~/gitspace/waku/node_modules/.pnpm/react-server-dom-webpack@19.0.0_react-dom@19.0.0_react@19.0.0__react@19.0.0_webpack@5.97.1/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js:2273:11)
    at processFullBinaryRow (/~/gitspace/waku/node_modules/.pnpm/react-server-dom-webpack@19.0.0_react-dom@19.0.0_react@19.0.0__react@19.0.0_webpack@5.97.1/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js:2268:7)
    at progress (/~/gitspace/waku/node_modules/.pnpm/react-server-dom-webpack@19.0.0_react-dom@19.0.0_react@19.0.0__react@19.0.0_webpack@5.97.1/node_modules/react-server-dom-webpack/cjs/react-server-dom-webpack-client.edge.development.js:2476:17)
```