### PR TITLE
feat(use-router): change default scroll restoration behavior

### DIFF
--- a/e2e/fixtures/use-router/src/TestRouter.tsx
+++ b/e2e/fixtures/use-router/src/TestRouter.tsx
@@ -13,16 +13,10 @@ export default function TestRouter() {
       <p data-testid="query">Query: {queryCount}</p>
       <p data-testid="hash">Hash: {hashCount}</p>
       <p>
-        <Link to={`?count=${queryCount + 1}`} preserveScroll={false}>
-          Increment query
-        </Link>
+        <Link to={`?count=${queryCount + 1}`}>Increment query</Link>
       </p>
       <p>
-        <button
-          onClick={() =>
-            router.push(`?count=${queryCount + 1}`, { preserveScroll: false })
-          }
-        >
+        <button onClick={() => router.push(`?count=${queryCount + 1}`)}>
           Increment query (push)
         </button>
       </p>
@@ -30,11 +24,7 @@ export default function TestRouter() {
         <Link to={`#${hashCount + 1}`}>Increment hash</Link>
       </p>
       <p>
-        <button
-          onClick={() =>
-            router.push(`#${hashCount + 1}`, { preserveScroll: false })
-          }
-        >
+        <button onClick={() => router.push(`#${hashCount + 1}`)}>
           Increment hash (push)
         </button>
       </p>

--- a/e2e/fixtures/use-router/src/TestRouter.tsx
+++ b/e2e/fixtures/use-router/src/TestRouter.tsx
@@ -13,10 +13,16 @@ export default function TestRouter() {
       <p data-testid="query">Query: {queryCount}</p>
       <p data-testid="hash">Hash: {hashCount}</p>
       <p>
-        <Link to={`?count=${queryCount + 1}`}>Increment query</Link>
+        <Link to={`?count=${queryCount + 1}`} preserveScroll={false}>
+          Increment query
+        </Link>
       </p>
       <p>
-        <button onClick={() => router.push(`?count=${queryCount + 1}`)}>
+        <button
+          onClick={() =>
+            router.push(`?count=${queryCount + 1}`, { preserveScroll: false })
+          }
+        >
           Increment query (push)
         </button>
       </p>
@@ -24,7 +30,11 @@ export default function TestRouter() {
         <Link to={`#${hashCount + 1}`}>Increment hash</Link>
       </p>
       <p>
-        <button onClick={() => router.push(`#${hashCount + 1}`)}>
+        <button
+          onClick={() =>
+            router.push(`#${hashCount + 1}`, { preserveScroll: false })
+          }
+        >
           Increment hash (push)
         </button>
       </p>

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -233,7 +233,7 @@ export function Link({
           '',
           url,
         );
-        changeRoute(route, { shouldScroll: !!route.hash });
+        changeRoute(route, { shouldScroll: true });
       });
     }
     props.onClick?.(event);

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -352,6 +352,20 @@ const InnerRouter = ({
     });
   }, [initialRoute]);
 
+  const handleScroll = useCallback((shouldScroll = true) => {
+    if (!shouldScroll) {
+      return;
+    }
+    const { hash } = window.location;
+    const { state } = window.history;
+    const element = hash && document.getElementById(hash.slice(1));
+    window.scrollTo({
+      left: 0,
+      top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
+      behavior: state?.waku_new_path ? 'instant' : 'auto',
+    });
+  }, []);
+
   const changeRoute: NewChangeRoute = useCallback(
     (route, options) => {
       const { skipRefetch } = options || {};
@@ -365,7 +379,7 @@ const InnerRouter = ({
         setRoute(route);
       });
     },
-    [refetch, staticPathSet],
+    [refetch, staticPathSet, handleScroll],
   );
 
   const prefetchRoute: PrefetchRoute = useCallback(
@@ -380,18 +394,6 @@ const InnerRouter = ({
     },
     [staticPathSet],
   );
-
-  const handleScroll = useCallback((shouldScroll = true) => {
-    if (!shouldScroll) return;
-    const { hash } = window.location;
-    const { state } = window.history;
-    const element = hash && document.getElementById(hash.slice(1));
-    window.scrollTo({
-      left: 0,
-      top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
-      behavior: state?.waku_new_path ? 'instant' : 'auto',
-    });
-  }, []);
 
   useEffect(() => {
     const callback = () => {

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -303,6 +303,17 @@ class ErrorBoundary extends Component<
 
 const getRouteSlotId = (path: string) => 'route:' + path;
 
+const handleScroll = () => {
+  const { hash } = window.location;
+  const { state } = window.history;
+  const element = hash && document.getElementById(hash.slice(1));
+  window.scrollTo({
+    left: 0,
+    top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
+    behavior: state?.waku_new_path ? 'instant' : 'auto',
+  });
+};
+
 const InnerRouter = ({
   routerData,
   initialRoute,
@@ -334,17 +345,6 @@ const InnerRouter = ({
     });
   }, [initialRoute]);
 
-  const handleScroll = useCallback(() => {
-    const { hash } = window.location;
-    const { state } = window.history;
-    const element = hash && document.getElementById(hash.slice(1));
-    window.scrollTo({
-      left: 0,
-      top: element ? element.getBoundingClientRect().top + window.scrollY : 0,
-      behavior: state?.waku_new_path ? 'instant' : 'auto',
-    });
-  }, []);
-
   const changeRoute: ChangeRoute = useCallback(
     (route, options) => {
       const { skipRefetch } = options || {};
@@ -360,7 +360,7 @@ const InnerRouter = ({
         setRoute(route);
       });
     },
-    [refetch, staticPathSet, handleScroll],
+    [refetch, staticPathSet],
   );
 
   const prefetchRoute: PrefetchRoute = useCallback(

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -112,23 +112,25 @@ export function useRouter_UNSTABLE() {
   const push = useCallback(
     (to: InferredPaths) => {
       const url = new URL(to, window.location.href);
+      const newPath = url.pathname !== window.location.pathname;
       window.history.pushState(
         {
           ...window.history.state,
-          waku_new_path: url.pathname !== window.location.pathname,
+          waku_new_path: newPath,
         },
         '',
         url,
       );
-      changeRoute(parseRoute(url), { shouldScroll: false });
+      changeRoute(parseRoute(url), { shouldScroll: newPath });
     },
     [changeRoute],
   );
   const replace = useCallback(
     (to: InferredPaths) => {
       const url = new URL(to, window.location.href);
+      const newPath = url.pathname !== window.location.pathname;
       window.history.replaceState(window.history.state, '', url);
-      changeRoute(parseRoute(url), { shouldScroll: false });
+      changeRoute(parseRoute(url), { shouldScroll: newPath });
     },
     [changeRoute],
   );

--- a/packages/waku/src/router/client.ts
+++ b/packages/waku/src/router/client.ts
@@ -89,8 +89,8 @@ const createRscParams = (query: string): URLSearchParams => {
 
 type ChangeRoute = (
   route: RouteProps,
-  options?: {
-    shouldScroll?: boolean;
+  options: {
+    shouldScroll: boolean;
     skipRefetch?: boolean;
   },
 ) => void;
@@ -332,10 +332,7 @@ const InnerRouter = ({
     });
   }, [initialRoute]);
 
-  const handleScroll = useCallback((shouldScroll = true) => {
-    if (!shouldScroll) {
-      return;
-    }
+  const handleScroll = useCallback(() => {
     const { hash } = window.location;
     const { state } = window.history;
     const element = hash && document.getElementById(hash.slice(1));
@@ -355,7 +352,9 @@ const InnerRouter = ({
           const rscParams = createRscParams(route.query);
           refetch(rscPath, rscParams);
         }
-        handleScroll(options?.shouldScroll);
+        if (options.shouldScroll) {
+          handleScroll();
+        }
         setRoute(route);
       });
     },
@@ -378,7 +377,7 @@ const InnerRouter = ({
   useEffect(() => {
     const callback = () => {
       const route = parseRoute(new URL(window.location.href));
-      changeRoute(route);
+      changeRoute(route, { shouldScroll: true });
     };
     window.addEventListener('popstate', callback);
     return () => {


### PR DESCRIPTION
fixes #791

## New scroll restoration defaults

### Will always scroll

- router.reload
- router.back
- `<Link to={foo} />`

### Scrolls when path changes

- router.replace 
- router.push
