### PR TITLE
ci: split e2e test to a single file

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,34 +1,26 @@
-name: CI
+name: E2E
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'examples/**'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
   pull_request:
     types: [opened, synchronize]
+    paths:
+      - 'packages/**'
+      - 'examples/**'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test on (Node ${{ matrix.version }})
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [18.17.0, 20.8.0, 22.7.0]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.version }}
-          cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm test
-
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test on (Node ${{ matrix.version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [18.17.0, 20.8.0, 22.7.0]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.version }}
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test


### PR DESCRIPTION
only run E2E test when necessary to reduce unused CI check and cost