### PR TITLE
chore(.github/workflows): update 'node-version' to 20, simplify 'pnpm install', 'actions/setup-node'

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install
       - run: pnpm test
       - run: pnpm run compile

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - run: pnpm test
       - run: pnpm run compile
       - run: pnpm -r --filter='./packages/*' --no-git-checks publish

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install
       - run: pnpm run compile
       - uses: actions/upload-artifact@v4
@@ -77,7 +76,6 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,10 +28,10 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - run: pnpm run compile
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,7 @@ jobs:
           node-version: ${{ matrix.version }}
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - uses: actions/download-artifact@v4
         with:
           name: create-waku

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
           node-version: ${{ matrix.version }}
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,5 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
       - run: pnpm install
       - run: pnpm test


### PR DESCRIPTION
* In CI, `pnpm install` means `pnpm install --frozen-lockfile`
* Update `node-version` `18` to `20`
* We don't need to specify `cache-dependency-path` in `actions/setup-node`, monorepo only use `./pnpm-lock.yaml`, also we only use `./pnpm-lock.yaml`