### PR TITLE
chore: react-server (dynamic ssr and rsc) error handling e2e tests

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -112,6 +112,7 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await page.click("a[href='/error']");
       // Default router client error boundary is reached
       await expect(
+        // TODO "Not Found" isn't appropriate for "unreachable error"
         page.getByRole('heading', { name: 'Not Found' }),
       ).toBeVisible();
       ({ port, stopApp } = await startApp(mode));

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -77,15 +77,11 @@ for (const mode of ['DEV', 'PRD'] as const) {
       );
       await page.getByTestId('server-throws').getByTestId('throws').click();
       await expect(
-        page.getByRole('heading', { name: 'Error: Internal Server Error' }),
+        page.getByRole('heading', { name: 'Error Page' }),
       ).toBeVisible();
-      // I think below is the expected behavior
-      // await expect(
-      //   page.getByRole('heading', { name: 'Error Page' }),
-      // ).toBeVisible();
-      // await expect(
-      //   page.getByTestId('server-throws').getByTestId('throws-error'),
-      // ).toHaveText('Something unexpected happened');
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-error'),
+      ).toHaveText('Something unexpected happened');
     });
 
     test('server function unreachable', async ({ page }) => {

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -65,5 +65,61 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await page.waitForTimeout(500); // need to wait not to error
       await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
     });
+
+    test('errors', async ({ page }) => {
+      await page.goto(`http://localhost:${port}`);
+      await page.click("a[href='/error']");
+      await expect(
+        page.getByRole('heading', { name: 'Error Page' }),
+      ).toBeVisible();
+      await expect(page.getByTestId('fallback-render')).toHaveText(
+        'Handling RSC render error',
+      );
+      await page.getByTestId('server-throws').getByTestId('throws').click();
+      await expect(
+        page.getByRole('heading', { name: 'Error: Internal Server Error' }),
+      ).toBeVisible();
+      // I think below is the expected behavior
+      // await expect(
+      //   page.getByRole('heading', { name: 'Error Page' }),
+      // ).toBeVisible();
+      // await expect(
+      //   page.getByTestId('server-throws').getByTestId('throws-error'),
+      // ).toHaveText('Something unexpected happened');
+    });
+
+    test('server function unreachable', async ({ page }) => {
+      await page.goto(`http://localhost:${port}`);
+      await page.click("a[href='/error']");
+      await expect(
+        page.getByRole('heading', { name: 'Error Page' }),
+      ).toBeVisible();
+      await page.getByTestId('server-throws').getByTestId('success').click();
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-success'),
+      ).toHaveText('It worked');
+      await page.getByTestId('server-throws').getByTestId('reset').click();
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-success'),
+      ).toHaveText('init');
+      await stopApp();
+      await page.getByTestId('server-throws').getByTestId('success').click();
+      // Default router client error boundary is reached
+      await expect(
+        page.getByRole('heading', { name: 'Not Found' }),
+      ).toBeVisible();
+      ({ port, stopApp } = await startApp(mode));
+    });
+
+    test('server page unreachable', async ({ page }) => {
+      await page.goto(`http://localhost:${port}`);
+      await stopApp();
+      await page.click("a[href='/error']");
+      // Default router client error boundary is reached
+      await expect(
+        page.getByRole('heading', { name: 'Not Found' }),
+      ).toBeVisible();
+      ({ port, stopApp } = await startApp(mode));
+    });
   });
 }

--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -100,10 +100,9 @@ for (const mode of ['DEV', 'PRD'] as const) {
       ).toHaveText('init');
       await stopApp();
       await page.getByTestId('server-throws').getByTestId('success').click();
-      // Default router client error boundary is reached
       await expect(
-        page.getByRole('heading', { name: 'Not Found' }),
-      ).toBeVisible();
+        page.getByTestId('server-throws').getByTestId('throws-error'),
+      ).toHaveText('Failed to fetch');
       ({ port, stopApp } = await startApp(mode));
     });
 

--- a/e2e/fixtures/create-pages/package.json
+++ b/e2e/fixtures/create-pages/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-error-boundary": "^5.0.0",
     "react-server-dom-webpack": "19.0.0",
     "waku": "workspace:*"
   },

--- a/e2e/fixtures/create-pages/src/components/ErrorBoundary.tsx
+++ b/e2e/fixtures/create-pages/src/components/ErrorBoundary.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import {
+  ErrorBoundary as ReactErrorBoundary,
+  type ErrorBoundaryProps,
+} from 'react-error-boundary';
+
+const ErrorBoundary: React.FC<ErrorBoundaryProps> = (props) => {
+  return <ReactErrorBoundary {...props} />;
+};
+
+export default ErrorBoundary;

--- a/e2e/fixtures/create-pages/src/components/ErrorPage.tsx
+++ b/e2e/fixtures/create-pages/src/components/ErrorPage.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react';
+import ErrorBoundary from './ErrorBoundary.js';
+import ErrorRender from './ErrorRender.js';
+import { ServerThrows } from './ServerThrows/index.js';
+
+const ErrorPage = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1));
+  return (
+    <ErrorBoundary
+      fallback={
+        <div data-testid="fallback-outer">This should not be reached</div>
+      }
+    >
+      <h2>Error Page</h2>
+      <ErrorBoundary
+        fallback={
+          <div data-testid="fallback-render">Handling RSC render error</div>
+        }
+      >
+        <Suspense>
+          <ErrorRender />
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary
+        fallback={
+          <div data-testid="fallback-function">Handling RSC function error</div>
+        }
+      >
+        <Suspense>
+          <ServerThrows />
+        </Suspense>
+      </ErrorBoundary>
+    </ErrorBoundary>
+  );
+};
+export default ErrorPage;

--- a/e2e/fixtures/create-pages/src/components/ErrorRender.tsx
+++ b/e2e/fixtures/create-pages/src/components/ErrorRender.tsx
@@ -1,0 +1,5 @@
+const ErrorRender = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1));
+  throw new Error('Something unexpected happened');
+};
+export default ErrorRender;

--- a/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
@@ -57,6 +57,9 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
       <li>
         <Link to="/nested/qux">Nested / Qux</Link>
       </li>
+      <li>
+        <Link to="/error">Error</Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/create-pages/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/create-pages/src/components/ServerThrows/Counter.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+export type CounterProps = {
+  throws: (input: string) => Promise<string>;
+};
+
+export function Counter({ throws }: CounterProps) {
+  const [error, setError] = useState('init');
+  const [success, setSuccess] = useState('init');
+  return (
+    <div>
+      <p data-testid="throws-error">{error}</p>
+      <p data-testid="throws-success">{success}</p>
+      <button
+        data-testid="throws"
+        onClick={() => {
+          throws('')
+            .then((value) => {
+              setSuccess(value);
+            })
+            .catch((e) => setError(e.message));
+        }}
+      >
+        throw
+      </button>
+      <button
+        data-testid="success"
+        onClick={() => {
+          throws('It worked')
+            .then((value) => {
+              setSuccess(value);
+            })
+            .catch((e) => {
+              console.error(e);
+              setError(e);
+            });
+        }}
+      >
+        success
+      </button>
+      <button
+        data-testid="reset"
+        onClick={() => {
+          setSuccess('init');
+          setError('init');
+        }}
+      >
+        reset
+      </button>
+    </div>
+  );
+}

--- a/e2e/fixtures/create-pages/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/create-pages/src/components/ServerThrows/Counter.tsx
@@ -34,7 +34,7 @@ export function Counter({ throws }: CounterProps) {
             })
             .catch((e) => {
               console.error(e);
-              setError(e);
+              setError(e.message);
             });
         }}
       >

--- a/e2e/fixtures/create-pages/src/components/ServerThrows/index.tsx
+++ b/e2e/fixtures/create-pages/src/components/ServerThrows/index.tsx
@@ -1,0 +1,10 @@
+import { Counter } from './Counter.js';
+import { throws } from '../funcs.js';
+
+export function ServerThrows() {
+  return (
+    <div data-testid="server-throws">
+      <Counter throws={throws} />
+    </div>
+  );
+}

--- a/e2e/fixtures/create-pages/src/components/funcs.ts
+++ b/e2e/fixtures/create-pages/src/components/funcs.ts
@@ -9,3 +9,10 @@ export const jump = async () => {
   console.log(`Jumping to ${page}`);
   unstable_rerenderRoute(page);
 };
+
+export const throws = async (input: string): Promise<string> => {
+  if (!input) {
+    throw new Error('Something unexpected happened');
+  }
+  return input;
+};

--- a/e2e/fixtures/create-pages/src/entries.tsx
+++ b/e2e/fixtures/create-pages/src/entries.tsx
@@ -8,6 +8,7 @@ import NestedBazPage from './components/NestedBazPage.js';
 import Root from './components/Root.js';
 import NestedLayout from './components/NestedLayout.js';
 import { DeeplyNestedLayout } from './components/DeeplyNestedLayout.js';
+import ErrorPage from './components/ErrorPage.js';
 
 const pages: ReturnType<typeof createPages> = createPages(
   async ({ createPage, createLayout, createRoot }) => [
@@ -84,6 +85,12 @@ const pages: ReturnType<typeof createPages> = createPages(
           <h3>Dynamic: {id}</h3>
         </>
       ),
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/error',
+      component: ErrorPage,
     }),
 
     createPage({

--- a/e2e/fixtures/rsc-basic/src/components/App.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/App.tsx
@@ -6,6 +6,7 @@ import { ServerPing } from './ServerPing/index.js';
 import { ServerBox } from './Box.js';
 import { ServerProvider } from './ServerAction/Server.js';
 import { ClientActionsConsumer } from './ServerAction/Client.js';
+import { ServerThrows } from './ServerThrows/index.js';
 
 const App = ({ name }: { name: string }) => {
   return (
@@ -21,6 +22,7 @@ const App = ({ name }: { name: string }) => {
           <ServerProvider>
             <ClientActionsConsumer />
           </ServerProvider>
+          <ServerThrows />
         </ServerBox>
       </body>
     </html>

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+
+export type CounterProps = {
+  throws: () => Promise<string>;
+};
+
+export function Counter({ throws }: CounterProps) {
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  return (
+    <div>
+      <p data-testid="throws-error">{error}</p>
+      <p data-testid="throws-success">{success}</p>
+      <button
+        data-testid="throws"
+        onClick={() => {
+          throws()
+            .then((value) => {
+              setSuccess(value);
+            })
+            .catch(setError);
+        }}
+      >
+        throw
+      </button>
+    </div>
+  );
+}

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
@@ -20,7 +20,7 @@ export function Counter({ throws }: CounterProps) {
             .then((value) => {
               setSuccess(value);
             })
-            .catch(setError);
+            .catch((e) => setError(e.message));
         }}
       >
         throw
@@ -43,8 +43,8 @@ export function Counter({ throws }: CounterProps) {
       <button
         data-testid="reset"
         onClick={() => {
-          setSuccess("init");
-          setError("init");
+          setSuccess('init');
+          setError('init');
         }}
       >
         reset

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
@@ -3,12 +3,12 @@
 import { useState } from 'react';
 
 export type CounterProps = {
-  throws: () => Promise<string>;
+  throws: (input: string) => Promise<string>;
 };
 
 export function Counter({ throws }: CounterProps) {
-  const [error, setError] = useState('');
-  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('init');
+  const [success, setSuccess] = useState('init');
   return (
     <div>
       <p data-testid="throws-error">{error}</p>
@@ -16,7 +16,7 @@ export function Counter({ throws }: CounterProps) {
       <button
         data-testid="throws"
         onClick={() => {
-          throws()
+          throws('')
             .then((value) => {
               setSuccess(value);
             })
@@ -24,6 +24,30 @@ export function Counter({ throws }: CounterProps) {
         }}
       >
         throw
+      </button>
+      <button
+        data-testid="success"
+        onClick={() => {
+          throws('It worked')
+            .then((value) => {
+              setSuccess(value);
+            })
+            .catch((e) => {
+              console.error(e);
+              setError(e);
+            });
+        }}
+      >
+        success
+      </button>
+      <button
+        data-testid="reset"
+        onClick={() => {
+          setSuccess("init");
+          setError("init");
+        }}
+      >
+        reset
       </button>
     </div>
   );

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/Counter.tsx
@@ -34,7 +34,7 @@ export function Counter({ throws }: CounterProps) {
             })
             .catch((e) => {
               console.error(e);
-              setError(e);
+              setError(e.message);
             });
         }}
       >

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/actions.ts
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/actions.ts
@@ -1,5 +1,8 @@
 'use server';
 
-export const throws = async (): Promise<string> => {
-  throw new Error('Something unexpected happened');
+export const throws = async (input: string): Promise<string> => {
+  if (!input) {
+    throw new Error('Something unexpected happened');
+  }
+  return input;
 };

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/actions.ts
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/actions.ts
@@ -1,0 +1,5 @@
+'use server';
+
+export const throws = async (): Promise<string> => {
+  throw new Error('Something unexpected happened');
+};

--- a/e2e/fixtures/rsc-basic/src/components/ServerThrows/index.tsx
+++ b/e2e/fixtures/rsc-basic/src/components/ServerThrows/index.tsx
@@ -1,0 +1,11 @@
+import { ServerBox } from '../Box.js';
+import { Counter } from './Counter.js';
+import { throws } from './actions.js';
+
+export function ServerThrows() {
+  return (
+    <ServerBox data-testid="server-throws">
+      <Counter throws={throws} />
+    </ServerBox>
+  );
+}

--- a/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
@@ -1,9 +1,15 @@
 'use client';
 
+import { useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import type { FallbackProps } from 'react-error-boundary';
 
-const FallbackComponent = ({ error }: { error: any }) => {
+const FallbackComponent = ({ error, resetErrorBoundary }: FallbackProps) => {
+  useEffect(() => {
+    window.addEventListener('popstate', resetErrorBoundary);
+    return () => window.removeEventListener('popstate', resetErrorBoundary);
+  },[resetErrorBoundary])
   return (
     <div role="alert">
       <p>Unexpected error in client fallback</p>

--- a/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
@@ -9,7 +9,7 @@ const FallbackComponent = ({ error, resetErrorBoundary }: FallbackProps) => {
   useEffect(() => {
     window.addEventListener('popstate', resetErrorBoundary);
     return () => window.removeEventListener('popstate', resetErrorBoundary);
-  },[resetErrorBoundary])
+  }, [resetErrorBoundary]);
   return (
     <div role="alert">
       <p>Unexpected error in client fallback</p>

--- a/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/client-layout.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 const FallbackComponent = ({ error }: { error: any }) => {
   return (
     <div role="alert">
-      <p>Something went wrong:</p>
+      <p>Unexpected error in client fallback</p>
       <pre style={{ color: 'red' }}>{error.message}</pre>
       {error.statusCode && (
         <pre style={{ color: 'red' }}>{error.statusCode}</pre>

--- a/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
@@ -1,5 +1,3 @@
-'use server';
-
 export const ThrowsComponent = async () => {
   await new Promise((_, reject) => {
     reject(new Error('Unexpected error'));

--- a/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
@@ -1,9 +1,9 @@
-"use server";
+'use server';
 
 export const ThrowsComponent = async () => {
   await new Promise((_, reject) => {
-    reject(new Error("Unexpected error"));
-  })
+    reject(new Error('Unexpected error'));
+  });
   return <div>Success</div>;
 };
 

--- a/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/server/throws.tsx
@@ -1,0 +1,10 @@
+"use server";
+
+export const ThrowsComponent = async () => {
+  await new Promise((_, reject) => {
+    reject(new Error("Unexpected error"));
+  })
+  return <div>Success</div>;
+};
+
+export default ThrowsComponent;

--- a/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
+++ b/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
@@ -15,13 +15,13 @@ const stringToStream = (str: string): ReadableStream => {
 
 const validateMiddleware: Middleware = () => {
   return async (ctx, next) => {
-    if (
-      ctx.req.url.pathname === '/invalid' ||
-      ctx.req.url.pathname.startsWith(`/${rscBase}/R/invalid`)
-    ) {
+    if (ctx.req.url.pathname === '/invalid') {
       ctx.res.status = 401;
       ctx.res.body = stringToStream('Unauthorized');
       return;
+    }
+    if (ctx.req.url.pathname.startsWith(`/${rscBase}/R/invalid`)) {
+      ctx.data.unauthorized = true;
     }
     await next();
   };

--- a/e2e/fixtures/ssr-catch-error/src/pages/_layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/_layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { ReactNode } from 'react';
 import { ClientLayout } from '../components/client-layout.js';
 
@@ -6,7 +7,11 @@ export default async function RootLayout({
 }: {
   children: ReactNode;
 }) {
-  return <ClientLayout>{children}</ClientLayout>;
+  return (
+    <ClientLayout>
+      <Suspense fallback="Loading...">{children}</Suspense>
+    </ClientLayout>
+  );
 }
 
 export const getConfig = async () => {

--- a/e2e/fixtures/ssr-catch-error/src/pages/_layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/_layout.tsx
@@ -1,6 +1,16 @@
 import { Suspense } from 'react';
 import type { ReactNode } from 'react';
+import { getContextData } from 'waku/middleware/context';
+
 import { ClientLayout } from '../components/client-layout.js';
+
+const CheckIfAccessDenied = ({ children }: { children: ReactNode }) => {
+  const data = getContextData();
+  if (data.unauthorized) {
+    throw new Error('401 Unauthorized');
+  }
+  return children;
+};
 
 export default async function RootLayout({
   children,
@@ -9,13 +19,15 @@ export default async function RootLayout({
 }) {
   return (
     <ClientLayout>
-      <Suspense fallback="Loading...">{children}</Suspense>
+      <Suspense fallback="Loading...">
+        <CheckIfAccessDenied>{children}</CheckIfAccessDenied>
+      </Suspense>
     </ClientLayout>
   );
 }
 
 export const getConfig = async () => {
   return {
-    render: 'static',
+    render: 'dynamic',
   } as const;
 };

--- a/e2e/fixtures/ssr-catch-error/src/pages/dynamic/_layout.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/dynamic/_layout.tsx
@@ -1,0 +1,27 @@
+import { Suspense, type ReactNode } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import ThrowsComponent from '../../components/server/throws.js';
+
+export default async function DynamicLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <>
+      {children}
+      <ErrorBoundary fallback={<div>Something is wrong</div>}>
+        <Suspense fallback={<div>Loading layout...</div>}>
+          OK
+          <ThrowsComponent />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  );
+}
+
+export const getConfig = async () => {
+  return {
+    render: 'dynamic',
+  } as const;
+};

--- a/e2e/fixtures/ssr-catch-error/src/pages/dynamic/index.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/dynamic/index.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Link } from 'waku';
-import ThrowsComponent from '../components/server/throws.js';
+import ThrowsComponent from '../../components/server/throws.js';
 
 export default async function HomePage() {
   return (
@@ -9,7 +9,7 @@ export default async function HomePage() {
       <p>Home Page</p>
       <Link to="/invalid">Invalid page</Link>
       <ErrorBoundary fallback={<div>Something went wrong</div>}>
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<div>Loading page...</div>}>
           <ThrowsComponent />
         </Suspense>
       </ErrorBoundary>
@@ -19,6 +19,6 @@ export default async function HomePage() {
 
 export const getConfig = async () => {
   return {
-    render: 'static',
+    render: 'dynamic',
   } as const;
 };

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -82,15 +82,13 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await expect(
         page.getByTestId('server-throws').getByTestId('throws-success'),
       ).toHaveText('init');
-      // This is intended to simulate the network or server being down
-      await page.route('http://localhost:${port}/**', (route) => {
-        return route.abort();
-      });
+      await stopApp();
       await page.getByTestId('server-throws').getByTestId('success').click();
       // Not sure what we should expect...
       await expect(
-        page.getByTestId('server-throws').getByTestId('throws-success'),
-      ).toHaveText('init');
+        page.getByTestId('server-throws').getByTestId('throws-error'),
+      ).toHaveText('Internal Server Error');
+      ({ port, stopApp } = await startApp(mode));
     });
   });
 }

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -61,5 +61,14 @@ for (const mode of ['DEV', 'PRD'] as const) {
       });
       expect(result).toBe(0);
     });
+
+    test('server throws', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await expect(page.getByTestId('app-name')).toHaveText('Waku');
+      await page.getByTestId('server-throws').getByTestId('throws').click();
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-error'),
+      ).toHaveText('Something unexpected happened');
+    });
   });
 }

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -70,5 +70,27 @@ for (const mode of ['DEV', 'PRD'] as const) {
         page.getByTestId('server-throws').getByTestId('throws-error'),
       ).toHaveText('Something unexpected happened');
     });
+
+    test('server handle network errors', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await expect(page.getByTestId('app-name')).toHaveText('Waku');
+      await page.getByTestId('server-throws').getByTestId('success').click();
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-success'),
+      ).toHaveText('It worked');
+      await page.getByTestId('server-throws').getByTestId('reset').click();
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-success'),
+      ).toHaveText('init');
+      // This is intended to simulate the network or server being down
+      await page.route('http://localhost:${port}/**', (route) => {
+        return route.abort();
+      });
+      await page.getByTestId('server-throws').getByTestId('success').click();
+      // Not sure what we should expect...
+      await expect(
+        page.getByTestId('server-throws').getByTestId('throws-success'),
+      ).toHaveText('init');
+    });
   });
 }

--- a/e2e/rsc-basic.spec.ts
+++ b/e2e/rsc-basic.spec.ts
@@ -84,10 +84,9 @@ for (const mode of ['DEV', 'PRD'] as const) {
       ).toHaveText('init');
       await stopApp();
       await page.getByTestId('server-throws').getByTestId('success').click();
-      // Not sure what we should expect...
       await expect(
         page.getByTestId('server-throws').getByTestId('throws-error'),
-      ).toHaveText('Internal Server Error');
+      ).toHaveText('Failed to fetch');
       ({ port, stopApp } = await startApp(mode));
     });
   });

--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -30,7 +30,9 @@ for (const mode of ['DEV', 'PRD'] as const) {
     test('access invalid page through client router', async ({ page }) => {
       await page.goto(`http://localhost:${port}/`);
       await page.getByText('Invalid page').click();
-      await expect(page.getByText('401')).toBeVisible();
+      await expect(
+        page.getByText('Unexpected error in client fallback'),
+      ).toBeVisible();
     });
 
     test('access invalid page directly', async ({ page }) => {
@@ -43,7 +45,9 @@ for (const mode of ['DEV', 'PRD'] as const) {
     }) => {
       await page.goto(`http://localhost:${port}/`);
       await page.getByText('Invalid page').click();
-      await expect(page.getByText('401')).toBeVisible();
+      await expect(
+        page.getByText('Unexpected error in client fallback'),
+      ).toBeVisible();
       await page.goBack();
       await expect(page.getByText('Home Page')).toBeVisible();
     });

--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -18,6 +18,13 @@ for (const mode of ['DEV', 'PRD'] as const) {
     test('access top page', async ({ page }) => {
       await page.goto(`http://localhost:${port}/`);
       await expect(page.getByText('Home Page')).toBeVisible();
+      await expect(page.getByText('Something went wrong')).toBeVisible();
+    });
+
+    test('access dynamic server page', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/dynamic`);
+      await expect(page.getByText('Home Page')).toBeVisible();
+      await expect(page.getByText('Something went wrong')).toBeVisible();
     });
 
     test('access invalid page through client router', async ({ page }) => {
@@ -29,6 +36,15 @@ for (const mode of ['DEV', 'PRD'] as const) {
     test('access invalid page directly', async ({ page }) => {
       await page.goto(`http://localhost:${port}/invalid`);
       await expect(page.getByText('Unauthorized')).toBeVisible();
+    });
+    test('navigate back after invalid page through client router', async ({
+      page,
+    }) => {
+      await page.goto(`http://localhost:${port}/`);
+      await page.getByText('Invalid page').click();
+      await expect(page.getByText('401')).toBeVisible();
+      await page.goBack();
+      await expect(page.getByText('Home Page')).toBeVisible();
     });
   });
 }

--- a/e2e/ssr-catch-error.spec.ts
+++ b/e2e/ssr-catch-error.spec.ts
@@ -37,6 +37,7 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await page.goto(`http://localhost:${port}/invalid`);
       await expect(page.getByText('Unauthorized')).toBeVisible();
     });
+
     test('navigate back after invalid page through client router', async ({
       page,
     }) => {

--- a/packages/waku/src/lib/middleware/handler.ts
+++ b/packages/waku/src/lib/middleware/handler.ts
@@ -3,12 +3,13 @@ import type { ReactNode } from 'react';
 import { resolveConfig, extractPureConfig } from '../config.js';
 import type { PureConfig } from '../config.js';
 import { setAllEnvInternal } from '../../server.js';
-import type { HandleRequest } from '../types.js';
+import type { HandleRequest, HandlerRes } from '../types.js';
 import type { Middleware, HandlerContext } from './types.js';
 import { renderRsc, decodeBody, decodePostAction } from '../renderers/rsc.js';
 import { renderHtml } from '../renderers/html.js';
 import { decodeRscPath, decodeFuncId } from '../renderers/utils.js';
 import { filePathToFileURL, getPathMapping } from '../utils/path.js';
+import { stringToStream } from '../utils/stream.js';
 
 export const SERVER_MODULE_MAP = {
   'rsdw-server': 'react-server-dom-webpack/server.edge',
@@ -150,7 +151,15 @@ export const handler: Middleware = (options) => {
     };
     const input = await getInput(config, ctx, loadServerModule);
     if (input) {
-      const res = await entries.default.handleRequest(input, utils);
+      let res: ReadableStream | HandlerRes | null | undefined;
+      try {
+        res = await entries.default.handleRequest(input, utils);
+      } catch (e) {
+        ctx.res.status = 500;
+        ctx.res.body = stringToStream(
+          (e as { message?: string } | undefined)?.message || String(e),
+        );
+      }
       if (res instanceof ReadableStream) {
         ctx.res.body = res;
       } else if (res) {

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -42,7 +42,7 @@ const checkStatus = async (
 ): Promise<Response> => {
   const response = await responsePromise;
   if (!response.ok) {
-    const err = new Error(response.statusText);
+    const err = new Error((await response.text()) || response.statusText);
     (err as any).statusCode = response.status;
     throw err;
   }
@@ -131,9 +131,10 @@ export const callServerRsc = async (
           enhanceFetch(fetch)(url, { method: 'POST', body }),
         );
   const data = enhanceCreateData(createData)(responsePromise);
+  const value = (await data)._value;
   // FIXME this causes rerenders even if data is empty
   fetchCache[SET_ELEMENTS]?.((prev) => mergeElements(prev, data));
-  return (await data)._value;
+  return value;
 };
 
 const prefetchedParams = new WeakMap<Promise<unknown>, unknown>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.0.0)
       react-server-dom-webpack:
         specifier: 19.0.0
         version: 19.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(webpack@5.97.1)


### PR DESCRIPTION
The additional ErrorFallback and Suspense examples seem to work well.

The tests I added for using the browser back button and for throwing an exception from a server function are failing though.

ref: #967