### PR TITLE
fix: netlify relative fs path

### DIFF
--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
@@ -82,7 +82,7 @@ export function deployNetlifyPlugin(opts: {
       }
 
       if (deploy === 'netlify-functions') {
-        const functionsDir = path.join(rootDir, 'netlify/functions');
+        const functionsDir = path.join(rootDir, 'netlify-functions');
         mkdirSync(functionsDir, {
           recursive: true,
         });
@@ -99,7 +99,7 @@ export function deployNetlifyPlugin(opts: {
           path.join(functionsDir, 'serve.js'),
           `
 globalThis.__WAKU_NOT_FOUND_HTML__ = ${JSON.stringify(notFoundHtml)};
-export { default } from '../../${opts.distDir}/${SERVE_JS}';
+export { default } from '../${opts.distDir}/${SERVE_JS}';
 export const config = {
   preferStatic: true,
   path: ['/', '/*'],
@@ -117,6 +117,7 @@ export const config = {
   publish = "${opts.distDir}/${DIST_PUBLIC}"
 [functions]
   included_files = ["${opts.privateDir}/**"]
+  directory = "netlify-functions"
 `,
         );
       }


### PR DESCRIPTION
Changes the netlify functions output dir from netlify/functions to netlify-functions.

This is a breaking change for existing netlify projects using dynamic rendering. It requires updating the functions directory for existing projects from the default "netlify/functions" to "netlify-functions".

Edit the netlify.toml `[functions]` section and set

```
  directory = "netlify-functions"
```

In a monorepo, the directory value needs to also include the base path from the root of the monorepo.

Fixes #909