### PR TITLE
fix(create-pages-eg): show example with simple response

### DIFF
--- a/examples/21_create-pages/src/entries.tsx
+++ b/examples/21_create-pages/src/entries.tsx
@@ -127,17 +127,7 @@ const pages = createPages(
       method: 'GET',
       handler: async () => {
         const hiTxt = await readFile('./private/hi.txt');
-        return new Response(
-          new ReadableStream({
-            start(controller) {
-              controller.enqueue(hiTxt);
-              controller.close();
-            },
-          }),
-          {
-            status: 200,
-          },
-        );
+        return new Response(hiTxt);
       },
     }),
 
@@ -146,17 +136,7 @@ const pages = createPages(
       mode: 'static',
       method: 'GET',
       handler: async () => {
-        return new Response(
-          new ReadableStream({
-            start(controller) {
-              controller.enqueue(new TextEncoder().encode('hello world!'));
-              controller.close();
-            },
-          }),
-          {
-            status: 200,
-          },
-        );
+        return new Response('hello world!');
       },
     }),
 


### PR DESCRIPTION
example can respond with simple response object that can accept anything the normal `Response` object would handle

https://developer.mozilla.org/en-US/docs/Web/API/Response/Response