### PR TITLE
test(define-router): handleApi and getApiConfig e2e tests

### DIFF
--- a/e2e/define-router.spec.ts
+++ b/e2e/define-router.spec.ts
@@ -26,5 +26,25 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await page.goto(`http://localhost:${port}/foo`);
       await expect(page.getByTestId('foo-title')).toHaveText('Foo');
     });
+
+    test('api hi', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/api/hi`);
+      await expect(page.getByText('hello world!')).toBeVisible();
+    });
+
+    test('api hi.txt', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/api/hi.txt`);
+      await expect(page.getByText('hello from a text file!')).toBeVisible();
+    });
+
+    test('api empty', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/api/empty`);
+      await expect(await page.innerHTML('body')).toBe('');
+    });
+
+    test('not found', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/does-not-exist.txt`);
+      await expect(page.getByText('Not Found')).toBeVisible();
+    });
   });
 }

--- a/e2e/fixtures/define-router/private/hi.txt
+++ b/e2e/fixtures/define-router/private/hi.txt
@@ -1,0 +1,1 @@
+hello from a text file!


### PR DESCRIPTION
add api handling support to define-router spec and test the result