### PR TITLE
chore: github workflow not to cancel for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Test on (Node ${{ matrix.version }})


### PR DESCRIPTION
#1104 split e2e and test, but it also copies `concurrency`. This isn't necessary for Test, and it caused a problem: https://github.com/dai-shi/waku/actions/runs/12760172620/job/35565189012

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/9c881fd1-a8cd-47b0-af21-b0d978ee01c4" />
