### PR TITLE
fix: github workflow for canary-ci, once again

### DIFF
--- a/.github/workflows/canary-ci.yml
+++ b/.github/workflows/canary-ci.yml
@@ -26,12 +26,12 @@ jobs:
     needs: parse-version
     uses: ./.github/workflows/e2e.yml
     with:
-      ref: ${{ github.event.pull_request.head.ref }}
+      ref: ${{ github.event.issue.pull_request.head.ref }}
       react_version: ${{ needs.parse-version.outputs.react_version }}
 
   canary-ci-test:
     needs: parse-version
     uses: ./.github/workflows/test.yml
     with:
-      ref: ${{ github.event.pull_request.head.ref }}
+      ref: ${{ github.event.issue.pull_request.head.ref }}
       react_version: ${{ needs.parse-version.outputs.react_version }}


### PR DESCRIPTION
continuing from #1154.