### PR TITLE
feat(website): add rss feed

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "waku dev",
-    "build": "waku build",
+    "build": "VITE_EXPERIMENTAL_WAKU_ROUTER=true waku build",
     "start": "waku start"
   },
   "dependencies": {

--- a/packages/website/src/pages/api/rss.xml.ts
+++ b/packages/website/src/pages/api/rss.xml.ts
@@ -59,11 +59,16 @@ export const GET = async () => {
       date: string;
       author: string;
     };
+    const [year, month, day] = frontmatter.date.split('/').map(Number) as [
+      number,
+      number,
+      number,
+    ];
     items.push({
       title: frontmatter.title,
       link: `https://waku.gg/blog/${frontmatter.slug}`,
       description: frontmatter.description || '',
-      pubDate: new Date(frontmatter.date).toISOString(),
+      pubDate: new Date(Date.UTC(year, month - 1, day)).toUTCString(),
       author: frontmatter.author,
     });
   }

--- a/packages/website/src/pages/api/rss.xml.ts
+++ b/packages/website/src/pages/api/rss.xml.ts
@@ -75,3 +75,9 @@ export const GET = async () => {
     },
   });
 };
+
+export const getConfig = async () => {
+  return {
+    render: 'static',
+  } as const;
+};

--- a/packages/website/src/pages/api/rss.xml.ts
+++ b/packages/website/src/pages/api/rss.xml.ts
@@ -1,0 +1,77 @@
+import { compileMDX } from 'next-mdx-remote/rsc';
+import { readdirSync, readFileSync } from 'node:fs';
+
+type Item = {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: string;
+  author: string;
+};
+
+const generateRSSFeed = (items: Item[]) => {
+  const itemsXML = items
+    .map(
+      (item) => `
+   <item>
+     <title>${item.title}</title>
+     <link>${item.link}</link>
+     <pubDate>${item.pubDate}</pubDate>
+     <author>${item.author}</author>
+     <description>${item.description}</description>
+   </item>`,
+    )
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+ <channel>
+   <title>Waku</title>
+   <link>https://waku.gg</link>
+   <description>The minimal React framework</description>
+   ${itemsXML}
+ </channel>
+</rss>`;
+};
+
+export const GET = async () => {
+  const blogFileNames: Array<string> = [];
+  readdirSync('./private/contents').forEach((fileName) => {
+    if (fileName.endsWith('.mdx')) {
+      blogFileNames.push(fileName);
+    }
+  });
+
+  const items: Item[] = [];
+
+  for await (const fileName of blogFileNames) {
+    const path = `./private/contents/${fileName}`;
+    const source = readFileSync(path, 'utf8');
+    const mdx = await compileMDX({
+      source,
+      options: { parseFrontmatter: true },
+    });
+
+    const frontmatter = mdx.frontmatter as {
+      title: string;
+      description: string;
+      slug: string;
+      date: string;
+      author: string;
+    };
+    items.push({
+      title: frontmatter.title,
+      link: `https://waku.gg/blog/${frontmatter.slug}`,
+      description: frontmatter.description || '',
+      pubDate: new Date(frontmatter.date).toISOString(),
+      author: frontmatter.author,
+    });
+  }
+
+  const rssFeed = generateRSSFeed(items);
+  return new Response(rssFeed, {
+    headers: {
+      'Content-Type': 'application/rss+xml',
+    },
+  });
+};

--- a/packages/website/src/pages/api/rss.xml.ts
+++ b/packages/website/src/pages/api/rss.xml.ts
@@ -17,13 +17,15 @@ const generateRSSFeed = (items: Item[]) => {
      <link>${item.link}</link>
      <pubDate>${item.pubDate}</pubDate>
      <description>${item.description}</description>
+     <guid isPermaLink="true">${item.link}</guid>
    </item>`,
     )
     .join('');
 
   return `<?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
+   <atom:link href="https://waku.gg/api/rss.xml" rel="self" type="application/rss+xml" />
    <title>Waku</title>
    <link>https://waku.gg</link>
    <description>The minimal React framework</description>

--- a/packages/website/src/pages/api/rss.xml.ts
+++ b/packages/website/src/pages/api/rss.xml.ts
@@ -6,7 +6,6 @@ type Item = {
   link: string;
   description: string;
   pubDate: string;
-  author: string;
 };
 
 const generateRSSFeed = (items: Item[]) => {
@@ -17,7 +16,6 @@ const generateRSSFeed = (items: Item[]) => {
      <title>${item.title}</title>
      <link>${item.link}</link>
      <pubDate>${item.pubDate}</pubDate>
-     <author>${item.author}</author>
      <description>${item.description}</description>
    </item>`,
     )
@@ -57,7 +55,6 @@ export const GET = async () => {
       description: string;
       slug: string;
       date: string;
-      author: string;
     };
     const [year, month, day] = frontmatter.date.split('/').map(Number) as [
       number,
@@ -69,7 +66,6 @@ export const GET = async () => {
       link: `https://waku.gg/blog/${frontmatter.slug}`,
       description: frontmatter.description || '',
       pubDate: new Date(Date.UTC(year, month - 1, day)).toUTCString(),
-      author: frontmatter.author,
     });
   }
 


### PR DESCRIPTION
adds rss xml endpoint to the website.

should we add a button to link to the feed somewhere?

sample feed from time of PR:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 <channel>
   <atom:link href="https://waku.gg/api/rss.xml" rel="self" type="application/rss+xml" />
   <title>Waku</title>
   <link>https://waku.gg</link>
   <description>The minimal React framework</description>
   
   <item>
     <title>Introducing Waku</title>
     <link>https://waku.gg/blog/introducing-waku</link>
     <pubDate>Tue, 12 Dec 2023 00:00:00 GMT</pubDate>
     <description>Learn about the minimal React framework and how it enables RSC features.</description>
     <guid isPermaLink="true">https://waku.gg/blog/introducing-waku</guid>
   </item>
   <item>
     <title>Introducing createPages</title>
     <link>https://waku.gg/blog/introducing-create-pages</link>
     <pubDate>Tue, 16 Jan 2024 00:00:00 GMT</pubDate>
     <description>Learn about the new API for creating layouts and pages programmatically.</description>
     <guid isPermaLink="true">https://waku.gg/blog/introducing-create-pages</guid>
   </item>
   <item>
     <title>Introducing “pages router”</title>
     <link>https://waku.gg/blog/introducing-pages-router</link>
     <pubDate>Tue, 26 Mar 2024 00:00:00 GMT</pubDate>
     <description>Bringing a minimal API to the modern React server components era.</description>
     <guid isPermaLink="true">https://waku.gg/blog/introducing-pages-router</guid>
   </item>
   <item>
     <title>Server actions are here!</title>
     <link>https://waku.gg/blog/server-actions-are-here</link>
     <pubDate>Tue, 20 Aug 2024 00:00:00 GMT</pubDate>
     <description>Enjoy full support for React 19’s server actions API.</description>
     <guid isPermaLink="true">https://waku.gg/blog/server-actions-are-here</guid>
   </item>
   <item>
     <title>Root element API</title>
     <link>https://waku.gg/blog/root-element-api</link>
     <pubDate>Tue, 03 Dec 2024 00:00:00 GMT</pubDate>
     <description>Customize your Waku project’s root elements.</description>
     <guid isPermaLink="true">https://waku.gg/blog/root-element-api</guid>
   </item>
   <item>
     <title>Type-safe routing</title>
     <link>https://waku.gg/blog/type-safe-routing</link>
     <pubDate>Tue, 31 Dec 2024 00:00:00 GMT</pubDate>
     <description>Enjoy type safety for routing and navigation APIs in Waku projects.</description>
     <guid isPermaLink="true">https://waku.gg/blog/type-safe-routing</guid>
   </item>
 </channel>
</rss>
```