### PR TITLE
fix(types): PageProps was missing type hints for paths

### DIFF
--- a/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
+++ b/packages/waku/src/router/create-pages-utils/inferred-path-types.ts
@@ -169,7 +169,7 @@ export type GetSlugs<Route extends string> = _GetSlugs<Route>;
 
 /** Paths with slugs as string literals */
 export type PagePath<Config> = Config extends {
-  pages: { DO_NOT_USE_pages: { path: infer Path } };
+  pages: { path: infer Path };
 }
   ? Path
   : never;


### PR DESCRIPTION
this fix brings back the autocomplete for `PageProps`:

<img width="638" alt="image" src="https://github.com/user-attachments/assets/e8f8633b-4fb7-4323-bc31-9d31c145282f" />

this was just missed in an earlier refactor of the types