### PR TITLE
chore(e2e): ignore known errors

### DIFF
--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -62,10 +62,15 @@ for (const cwd of examples) {
         cp.stderr?.on('data', (data) => {
           if (
             command === 'dev' &&
-            (/WebSocket server error: Port is already in use/.test(`${data}`) ||
-              /Error: The render was aborted by the server without a reason\..*\/examples\/53_islands\//s.test(
-                `${data}`,
-              ))
+            /WebSocket server error: Port is already in use/.test(`${data}`)
+          ) {
+            // ignore this error
+            return;
+          }
+          if (
+            /Error: The render was aborted by the server without a reason\..*\/examples\/53_islands\//s.test(
+              `${data}`,
+            )
           ) {
             // ignore this error
             return;

--- a/e2e/examples-smoke.spec.ts
+++ b/e2e/examples-smoke.spec.ts
@@ -62,7 +62,10 @@ for (const cwd of examples) {
         cp.stderr?.on('data', (data) => {
           if (
             command === 'dev' &&
-            /WebSocket server error: Port is already in use/.test(`${data}`)
+            (/WebSocket server error: Port is already in use/.test(`${data}`) ||
+              /Error: The render was aborted by the server without a reason\..*\/examples\/53_islands\//s.test(
+                `${data}`,
+              ))
           ) {
             // ignore this error
             return;


### PR DESCRIPTION
The error happens specific to 53_islands which keeps loading after the initial render. I'm not sure if there's a better way to fix this.