### PR TITLE
feat: separate build data into files

### DIFF
--- a/packages/waku/src/lib/middleware/handler.ts
+++ b/packages/waku/src/lib/middleware/handler.ts
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 
 import { resolveConfig, extractPureConfig } from '../config.js';
 import type { PureConfig } from '../config.js';
-import { setAllEnvInternal, unstable_getPlatformObject } from '../../server.js';
+import {
+  setAllEnvInternal,
+  setPlatformDataLoaderInternal,
+} from '../../server.js';
 import type { HandleRequest, HandlerRes } from '../types.js';
 import type { Middleware, HandlerContext } from './types.js';
 import { renderRsc, decodeBody, decodePostAction } from '../renderers/rsc.js';
@@ -76,8 +79,8 @@ export const handler: Middleware = (options) => {
   const configPromise =
     options.cmd === 'start'
       ? entriesPromise.then(async (entries) => {
-          if (entries.buildData) {
-            unstable_getPlatformObject().buildData = entries.buildData;
+          if (entries.loadPlatformData) {
+            setPlatformDataLoaderInternal(entries.loadPlatformData);
           }
           return resolveConfig(await entries.loadConfig());
         })

--- a/packages/waku/src/lib/types.ts
+++ b/packages/waku/src/lib/types.ts
@@ -85,7 +85,7 @@ export type EntriesPrd = EntriesDev & {
   loadModule: (id: string) => Promise<unknown>;
   dynamicHtmlPaths: [pathSpec: PathSpec, htmlHead: string][];
   publicIndexHtml: string;
-  buildData?: Record<string, unknown>; // must be JSON serializable
+  loadPlatformData?: (key: string) => Promise<unknown>;
 };
 
 export type HandlerReq = {

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -2,7 +2,8 @@ import { createElement } from 'react';
 import type { ReactNode } from 'react';
 
 import {
-  unstable_getPlatformObject,
+  unstable_getPlatformData,
+  unstable_setPlatformData,
   unstable_createAsyncIterable as createAsyncIterable,
 } from '../server.js';
 import { unstable_defineEntries as defineEntries } from '../minimal/server.js';
@@ -112,7 +113,6 @@ export function unstable_defineRouter(fns: {
     status?: number;
   }>;
 }) {
-  const platformObject = unstable_getPlatformObject();
   type MyPathConfig = {
     pathSpec: PathSpec;
     pathname: string | undefined;
@@ -127,7 +127,9 @@ export function unstable_defineRouter(fns: {
   }[];
   let cachedPathConfig: MyPathConfig | undefined;
   const getMyPathConfig = async (): Promise<MyPathConfig> => {
-    const pathConfig = platformObject.buildData?.defineRouterPathConfigs;
+    const pathConfig = await unstable_getPlatformData(
+      'defineRouterPathConfigs',
+    );
     if (pathConfig) {
       return pathConfig as MyPathConfig;
     }
@@ -432,8 +434,7 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         });
       }
 
-      platformObject.buildData ||= {};
-      platformObject.buildData.defineRouterPathConfigs = pathConfig;
+      await unstable_setPlatformData('defineRouterPathConfigs', pathConfig);
       return tasks;
     });
 

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,4 +1,8 @@
-import { unstable_getPlatformObject } from '../server.js';
+import {
+  unstable_getPlatformData,
+  unstable_setPlatformData,
+  unstable_getPlatformObject,
+} from '../server.js';
 import { createPages, METHODS } from './create-pages.js';
 import type { Method } from './create-pages.js';
 
@@ -14,8 +18,7 @@ export function fsRouter(
   const platformObject = unstable_getPlatformObject();
   return createPages(
     async ({ createPage, createLayout, createRoot, createApi }) => {
-      let files: string[] | undefined = platformObject.buildData
-        ?.fsRouterFiles as string[] | undefined;
+      let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
       if (!files) {
         // dev and build only
         const [
@@ -56,8 +59,7 @@ export function fsRouter(
       }
       // build only - skip in dev
       if (platformObject.buildOptions?.unstable_phase) {
-        platformObject.buildData ||= {};
-        platformObject.buildData.fsRouterFiles = files;
+        await unstable_setPlatformData('fsRouterFiles', files);
       }
       for (const file of files) {
         const mod = await loadPage(file);

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -1,5 +1,8 @@
 import { getContext } from './middleware/context.js';
 
+// The use of `globalThis` in this file is more or less a hack.
+// It should be revisited with a better solution.
+
 /**
  * This is an internal function and not for public use.
  */
@@ -11,12 +14,49 @@ export function getEnv(key: string): string | undefined {
   return (globalThis as any).__WAKU_SERVER_ENV__?.[key];
 }
 
+/**
+ * This is an internal function and not for public use.
+ */
+export function iterateAllPlatformDataInternal(): Iterable<[string, unknown]> {
+  const platformData: Record<string, unknown> =
+    (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ || {};
+  return Object.entries(platformData);
+}
+
+/**
+ * This is an internal function and not for public use.
+ */
+export function setPlatformDataLoaderInternal(
+  loader: (key: string) => Promise<unknown>,
+): void {
+  (globalThis as any).__WAKU_SERVER_PLATFORM_DATA_LOADER__ = loader;
+}
+
+// data must be JSON serializable
+export async function unstable_setPlatformData<T>(
+  key: string,
+  data: T,
+): Promise<void> {
+  ((globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ ||= {})[key] = data;
+}
+
+export async function unstable_getPlatformData<T>(
+  key: string,
+): Promise<T | undefined> {
+  const loader: ((key: string) => Promise<unknown>) | undefined = (
+    globalThis as any
+  ).__WAKU_SERVER_PLATFORM_DATA_LOADER__;
+  if (loader) {
+    return loader(key) as T;
+  }
+  return (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__?.[key];
+}
+
 export function unstable_getHeaders(): Readonly<Record<string, string>> {
   return getContext().req.headers;
 }
 
 type PlatformObject = {
-  buildData?: Record<string, unknown>; // must be JSON serializable
   buildOptions?: {
     deploy?:
       | 'vercel-static'
@@ -38,11 +78,9 @@ type PlatformObject = {
   };
 } & Record<string, unknown>;
 
-(globalThis as any).__WAKU_PLATFORM_OBJECT__ ||= {};
-
 // TODO tentative name
 export function unstable_getPlatformObject(): PlatformObject {
-  return (globalThis as any).__WAKU_PLATFORM_OBJECT__;
+  return ((globalThis as any).__WAKU_PLATFORM_OBJECT__ ||= {});
 }
 
 export function unstable_createAsyncIterable<T extends () => unknown>(


### PR DESCRIPTION
Previously, it was a single JSON object. Separating it into multiple files theoretically enables lazy loading.