### PR TITLE
fix(examples): nossr with fallback middleware

### DIFF
--- a/examples/12_nossr/waku.config.ts
+++ b/examples/12_nossr/waku.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'waku/config';
+
+export default defineConfig({
+  middleware: () => [
+    import('waku/middleware/context'),
+    import('waku/middleware/dev-server'),
+    import('waku/middleware/handler'),
+    import('waku/middleware/fallback'),
+  ],
+});


### PR DESCRIPTION
otherwise, reloading `http://localhost:3000/about` becomes 404.