### PR TITLE
feat(core): new transform for client references

### DIFF
--- a/packages/waku/src/client.ts
+++ b/packages/waku/src/client.ts
@@ -1,2 +1,4 @@
-// empty for now
-export default {};
+/**
+ * Highly experimental, the name might change.
+ */
+export const allowServer = <T>(x: T) => x;

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -4,6 +4,7 @@ import * as swc from '@swc/core';
 import { EXTENSIONS } from '../constants.js';
 import { extname, joinPath } from '../utils/path.js';
 import { parseOpts } from '../utils/swc.js';
+import { treeshakeJs } from '../utils/treeshake.js';
 
 const collectExportNames = (mod: swc.Module) => {
   const exportNames = new Set<string>();
@@ -646,7 +647,7 @@ const transformServer = (
     transformExportedClientThings(mod, getClientId);
     mod.body.splice(findLastImportIndex(mod), 0, ...serverInitCode2);
     const newCode = swc.printSync(mod).code;
-    return newCode;
+    return treeshakeJs(newCode);
   }
   let transformed =
     hasUseServer && transformExportedServerFunctions(mod, getServerId);

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -638,9 +638,7 @@ import { registerClientReference as __waku_registerClientReference } from 'react
 `;
     for (const name of exportNames) {
       newCode += `
-export ${name === 'default' ? name : `const ${name} =`} __waku_registerClientReference
-(() => { throw new Error('It is not possible to invoke a client function from th
-e server: ${getClientId()}#${name}'); }, '${getClientId()}', '${name}');
+export ${name === 'default' ? name : `const ${name} =`} __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: ${getClientId()}#${name}'); }, '${getClientId()}', '${name}');
 `;
     }
     return newCode;

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-transform.ts
@@ -177,10 +177,11 @@ export ${name === 'default' ? name : `const ${name} =`} __waku_registerClientRef
 `;
       // FIXME this is probably not efficient
       const stmts = swc.parseSync(code).body;
-      mod.body.splice(i, 1, ...stmts);
-      i += stmts.length - 1;
+      mod.body.splice(i, 0, ...stmts);
+      i += stmts.length;
     };
     if (item.type === 'ExportDeclaration') {
+      mod.body.splice(i--, 1);
       if (item.declaration.type === 'FunctionDeclaration') {
         handleFunction(item.declaration.identifier.value);
       } else if (item.declaration.type === 'ClassDeclaration') {
@@ -197,10 +198,12 @@ export ${name === 'default' ? name : `const ${name} =`} __waku_registerClientRef
         }
       }
     } else if (item.type === 'ExportDefaultDeclaration') {
+      mod.body.splice(i--, 1);
       if (item.decl.type === 'FunctionExpression') {
         handleFunction('default');
       }
     } else if (item.type === 'ExportDefaultExpression') {
+      mod.body.splice(i--, 1);
       if (
         item.expression.type === 'FunctionExpression' ||
         item.expression.type === 'ArrowFunctionExpression'

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -32,6 +32,7 @@ export const treeshakeJs = async (jsCode: string): Promise<string> => {
     },
     treeshake: {
       moduleSideEffects: 'no-external',
+      propertyReadSideEffects: false,
     },
     plugins: [
       {

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -7,9 +7,7 @@ export const treeshake = async (
 ): Promise<string> => {
   const mod = swc.parseSync(code, { syntax: 'typescript' });
   modifyModule?.(mod);
-  code = swc.printSync(mod).code;
-  // FIXME can we avoid this and transform with printSync directly?
-  code = swc.transformSync(code, {
+  const transformedCode = swc.transformSync(mod, {
     jsc: { parser: { syntax: 'typescript' } },
   }).code;
 
@@ -35,7 +33,7 @@ export const treeshake = async (
         },
         load(id) {
           if (id === '\0code') {
-            return code;
+            return transformedCode;
           }
         },
         resolveDynamicImport(id) {

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -4,13 +4,17 @@ import * as swc from '@swc/core';
 export const treeshake = async (
   code: string,
   modifyModule?: (mod: swc.Module) => void,
+  tsx = false,
 ): Promise<string> => {
-  const mod = swc.parseSync(code, { syntax: 'typescript' });
+  const mod = swc.parseSync(code, { syntax: 'typescript', tsx });
   modifyModule?.(mod);
   const transformedCode = swc.transformSync(mod, {
-    jsc: { parser: { syntax: 'typescript' } },
+    jsc: { parser: { syntax: 'typescript', tsx } },
   }).code;
+  return treeshakeJs(transformedCode);
+};
 
+export const treeshakeJs = async (jsCode: string): Promise<string> => {
   const bundle = await rollup({
     input: '\0code',
     external: () => true,
@@ -33,7 +37,7 @@ export const treeshake = async (
         },
         load(id) {
           if (id === '\0code') {
-            return transformedCode;
+            return jsCode;
           }
         },
         resolveDynamicImport(id) {

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -8,16 +8,12 @@ export const treeshake = async (
 ): Promise<string> => {
   const mod = swc.parseSync(code, { syntax: 'typescript', tsx });
   modifyModule?.(mod);
-  const transformedCode = swc.transformSync(mod, {
+  const jsCode = swc.transformSync(mod, {
     jsc: {
       target: 'esnext',
       parser: { syntax: 'typescript', tsx },
     },
   }).code;
-  return treeshakeJs(transformedCode);
-};
-
-export const treeshakeJs = async (jsCode: string): Promise<string> => {
   const bundle = await rollup({
     input: '\0code',
     external: () => true,

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -9,7 +9,10 @@ export const treeshake = async (
   const mod = swc.parseSync(code, { syntax: 'typescript', tsx });
   modifyModule?.(mod);
   const transformedCode = swc.transformSync(mod, {
-    jsc: { parser: { syntax: 'typescript', tsx } },
+    jsc: {
+      target: 'esnext',
+      parser: { syntax: 'typescript', tsx },
+    },
   }).code;
   return treeshakeJs(transformedCode);
 };

--- a/packages/waku/src/lib/utils/treeshake.ts
+++ b/packages/waku/src/lib/utils/treeshake.ts
@@ -24,6 +24,9 @@ export const treeshakeJs = async (jsCode: string): Promise<string> => {
       }
       defaultHandler(warning);
     },
+    output: {
+      generatedCode: 'es2015',
+    },
     treeshake: {
       moduleSideEffects: 'no-external',
     },

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -54,18 +54,24 @@ export default function App() {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "
-        import { registerClientReference } from 'react-server-dom-webpack/server.edge';
+      "import { registerClientReference } from 'react-server-dom-webpack/server.edge';
 
-        export const Empty = registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty'); }, '/src/App.tsx', 'Empty');
+      const Empty = registerClientReference(()=>{
+          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty');
+      }, '/src/App.tsx', 'Empty');
+      const Greet = registerClientReference(()=>{
+          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet');
+      }, '/src/App.tsx', 'Greet');
+      const MyComponent = registerClientReference(()=>{
+          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent');
+      }, '/src/App.tsx', 'MyComponent');
+      var _code = registerClientReference(()=>{
+          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default');
+      }, '/src/App.tsx', 'default');
 
-        export const Greet = registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet'); }, '/src/App.tsx', 'Greet');
-
-        export const MyComponent = registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent'); }, '/src/App.tsx', 'MyComponent');
-
-        export default registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default'); }, '/src/App.tsx', 'default');
-        "
-      `);
+      export { Empty, Greet, MyComponent, _code as default };
+      "
+    `);
   });
 
   test('top-level use server', async () => {

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -68,25 +68,32 @@ export default function App() {
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-        "import { registerClientReference } from 'react-server-dom-webpack/server.edge';
+        "
+        import { registerClientReference as __waku_registerClientReference } from 'react-server-dom-webpack/server.edge';
 
-        const Empty = registerClientReference(()=>{
-            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty');
-        }, '/src/App.tsx', 'Empty');
-        const Greet = registerClientReference(()=>{
-            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet');
-        }, '/src/App.tsx', 'Greet');
-        const MyComponent = registerClientReference(()=>{
-            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent');
-        }, '/src/App.tsx', 'MyComponent');
-        const useMyContext = registerClientReference(()=>{
-            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#useMyContext');
-        }, '/src/App.tsx', 'useMyContext');
-        var _code = registerClientReference(()=>{
-            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default');
-        }, '/src/App.tsx', 'default');
+        export const Empty = __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#Empty'); }, '/src/App.tsx', 'Empty');
 
-        export { Empty, Greet, MyComponent, _code as default, useMyContext };
+        export const Greet = __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#Greet'); }, '/src/App.tsx', 'Greet');
+
+        export const MyComponent = __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#MyComponent'); }, '/src/App.tsx', 'MyComponent');
+
+        export const useMyContext = __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#useMyContext'); }, '/src/App.tsx', 'useMyContext');
+
+        export const NAME = __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#NAME'); }, '/src/App.tsx', 'NAME');
+
+        export default __waku_registerClientReference
+        (() => { throw new Error('It is not possible to invoke a client function from th
+        e server: /src/App.tsx#default'); }, '/src/App.tsx', 'default');
         "
       `);
   });

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -71,29 +71,17 @@ export default function App() {
         "
         import { registerClientReference as __waku_registerClientReference } from 'react-server-dom-webpack/server.edge';
 
-        export const Empty = __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#Empty'); }, '/src/App.tsx', 'Empty');
+        export const Empty = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty'); }, '/src/App.tsx', 'Empty');
 
-        export const Greet = __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#Greet'); }, '/src/App.tsx', 'Greet');
+        export const Greet = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet'); }, '/src/App.tsx', 'Greet');
 
-        export const MyComponent = __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#MyComponent'); }, '/src/App.tsx', 'MyComponent');
+        export const MyComponent = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent'); }, '/src/App.tsx', 'MyComponent');
 
-        export const useMyContext = __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#useMyContext'); }, '/src/App.tsx', 'useMyContext');
+        export const useMyContext = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#useMyContext'); }, '/src/App.tsx', 'useMyContext');
 
-        export const NAME = __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#NAME'); }, '/src/App.tsx', 'NAME');
+        export const NAME = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#NAME'); }, '/src/App.tsx', 'NAME');
 
-        export default __waku_registerClientReference
-        (() => { throw new Error('It is not possible to invoke a client function from th
-        e server: /src/App.tsx#default'); }, '/src/App.tsx', 'default');
+        export default __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default'); }, '/src/App.tsx', 'default');
         "
       `);
   });

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -35,8 +35,9 @@ import { atom } from 'jotai/vanilla';
 import { allowServer } from 'waku/client';
 
 const initialCount = 1;
+const TWO = 2;
 function double (x: number) {
-  return x * 2;
+  return x * TWO;
 }
 export const countAtom = allowServer(atom(double(initialCount)));
 
@@ -80,8 +81,9 @@ export default function App() {
         import { registerClientReference as __waku_registerClientReference } from 'react-server-dom-webpack/server.edge';
         import { atom } from 'jotai/vanilla';
         const initialCount = 1;
+        const TWO = 2;
         function double(x: number) {
-            return x * 2;
+            return x * TWO;
         }
         export const countAtom = __waku_registerClientReference(atom(double(initialCount)), "/src/App.tsx", "countAtom");
 

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -30,7 +30,7 @@ export default function App() {
     const code = `
 'use client';
 
-import { Component } from 'react';
+import { Component, createContext, useContext } from 'react';
 
 export const Empty = () => null;
 
@@ -50,8 +50,18 @@ export class MyComponent extends Component {
   }
 }
 
+const MyContext = createContext();
+
+// TODO export const useMyContext = () => useContext(MyContext);
+
+export const NAME = 'World';
+
 export default function App() {
-  return <div>Hello World</div>;
+  return (
+    <MyContext.Provider value="Hello">
+      <div>Hello World</div>
+    </MyContext.Provider>
+  );
 }
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -30,7 +30,7 @@ export default function App() {
     const code = `
 'use client';
 
-import { Component, createContext, useContext } from 'react';
+import { Component, createContext, useContext, memo } from 'react';
 
 export const Empty = () => null;
 
@@ -52,38 +52,43 @@ export class MyComponent extends Component {
 
 const MyContext = createContext();
 
-// TODO export const useMyContext = () => useContext(MyContext);
+export const useMyContext = () => useContext(MyContext);
+
+// TODO const MyProvider = memo(MyContext.Provider);
 
 export const NAME = 'World';
 
 export default function App() {
   return (
-    <MyContext.Provider value="Hello">
+    <MyProvider value="Hello">
       <div>Hello World</div>
-    </MyContext.Provider>
+    </MyProvider>
   );
 }
 `;
     expect(await transform(code, '/src/App.tsx', { ssr: true }))
       .toMatchInlineSnapshot(`
-      "import { registerClientReference } from 'react-server-dom-webpack/server.edge';
+        "import { registerClientReference } from 'react-server-dom-webpack/server.edge';
 
-      const Empty = registerClientReference(()=>{
-          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty');
-      }, '/src/App.tsx', 'Empty');
-      const Greet = registerClientReference(()=>{
-          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet');
-      }, '/src/App.tsx', 'Greet');
-      const MyComponent = registerClientReference(()=>{
-          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent');
-      }, '/src/App.tsx', 'MyComponent');
-      var _code = registerClientReference(()=>{
-          throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default');
-      }, '/src/App.tsx', 'default');
+        const Empty = registerClientReference(()=>{
+            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty');
+        }, '/src/App.tsx', 'Empty');
+        const Greet = registerClientReference(()=>{
+            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Greet');
+        }, '/src/App.tsx', 'Greet');
+        const MyComponent = registerClientReference(()=>{
+            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#MyComponent');
+        }, '/src/App.tsx', 'MyComponent');
+        const useMyContext = registerClientReference(()=>{
+            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#useMyContext');
+        }, '/src/App.tsx', 'useMyContext');
+        var _code = registerClientReference(()=>{
+            throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#default');
+        }, '/src/App.tsx', 'default');
 
-      export { Empty, Greet, MyComponent, _code as default };
-      "
-    `);
+        export { Empty, Greet, MyComponent, _code as default, useMyContext };
+        "
+      `);
   });
 
   test('top-level use server', async () => {

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -54,7 +54,7 @@ const MyContext = createContext();
 
 export const useMyContext = () => useContext(MyContext);
 
-// TODO const MyProvider = memo(MyContext.Provider);
+const MyProvider = memo(MyContext.Provider);
 
 export const NAME = 'World';
 

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -37,6 +37,8 @@ export const Empty = () => null;
 function Private() {
   return "Secret";
 }
+const SecretComponent = () => <p>Secret</p>;
+const SecretFunction = (n: number) => 'Secret' + n;
 
 export function Greet({ name }: { name: string }) {
   return <>Hello {name}</>;

--- a/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
+++ b/packages/waku/tests/vite-plugin-rsc-transform-internals.test.ts
@@ -31,6 +31,14 @@ export default function App() {
 'use client';
 
 import { Component, createContext, useContext, memo } from 'react';
+import { atom } from 'jotai/vanilla';
+import { allowServer } from 'waku/client';
+
+const initialCount = 1;
+function double (x: number) {
+  return x * 2;
+}
+export const countAtom = allowServer(atom(double(initialCount)));
 
 export const Empty = () => null;
 
@@ -70,6 +78,12 @@ export default function App() {
       .toMatchInlineSnapshot(`
         "
         import { registerClientReference as __waku_registerClientReference } from 'react-server-dom-webpack/server.edge';
+        import { atom } from 'jotai/vanilla';
+        const initialCount = 1;
+        function double(x: number) {
+            return x * 2;
+        }
+        export const countAtom = __waku_registerClientReference(atom(double(initialCount)), "/src/App.tsx", "countAtom");
 
         export const Empty = __waku_registerClientReference(() => { throw new Error('It is not possible to invoke a client function from the server: /src/App.tsx#Empty'); }, '/src/App.tsx', 'Empty');
 


### PR DESCRIPTION
This enables an experimental `allowServer`. I'm not sure if this is going to be finalized.