### PR TITLE
refactor: prefer platformData over platformObject

### DIFF
--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -10,7 +10,7 @@ import type { Config } from '../../config.js';
 import {
   setAllEnvInternal,
   iterateSerializablePlatformDataInternal,
-  unstable_getPlatformObject,
+  unstable_getBuildOptions,
 } from '../../server.js';
 import type { EntriesPrd } from '../types.js';
 import type { ResolvedConfig } from '../config.js';
@@ -705,14 +705,13 @@ export async function build(options: {
   ).root;
   const distEntriesFile = joinPath(rootDir, config.distDir, DIST_ENTRIES_JS);
 
-  const platformObject = unstable_getPlatformObject();
-  platformObject.buildOptions ||= {};
-  platformObject.buildOptions.deploy = options.deploy;
+  const buildOptions = unstable_getBuildOptions();
+  buildOptions.deploy = options.deploy;
 
-  platformObject.buildOptions.unstable_phase = 'analyzeEntries';
+  buildOptions.unstable_phase = 'analyzeEntries';
   const { clientEntryFiles, serverEntryFiles, serverModuleFiles } =
     await analyzeEntries(rootDir, config);
-  platformObject.buildOptions.unstable_phase = 'buildServerBundle';
+  buildOptions.unstable_phase = 'buildServerBundle';
   const serverBuildOutput = await buildServerBundle(
     rootDir,
     env,
@@ -722,7 +721,7 @@ export async function build(options: {
     serverModuleFiles,
     !!options.partial,
   );
-  platformObject.buildOptions.unstable_phase = 'buildSsrBundle';
+  buildOptions.unstable_phase = 'buildSsrBundle';
   await buildSsrBundle(
     rootDir,
     env,
@@ -732,7 +731,7 @@ export async function build(options: {
     serverBuildOutput,
     !!options.partial,
   );
-  platformObject.buildOptions.unstable_phase = 'buildClientBundle';
+  buildOptions.unstable_phase = 'buildClientBundle';
   const clientBuildOutput = await buildClientBundle(
     rootDir,
     env,
@@ -742,7 +741,7 @@ export async function build(options: {
     serverBuildOutput,
     !!options.partial,
   );
-  delete platformObject.buildOptions.unstable_phase;
+  delete buildOptions.unstable_phase;
 
   const distEntries: EntriesPrd = await import(
     filePathToFileURL(distEntriesFile)
@@ -752,7 +751,7 @@ export async function build(options: {
   const cssAssets = clientBuildOutput.output.flatMap(({ type, fileName }) =>
     type === 'asset' && fileName.endsWith('.css') ? [fileName] : [],
   );
-  platformObject.buildOptions.unstable_phase = 'emitStaticFiles';
+  buildOptions.unstable_phase = 'emitStaticFiles';
   await emitStaticFiles(
     rootDir,
     config,
@@ -761,9 +760,9 @@ export async function build(options: {
     cssAssets,
   );
 
-  platformObject.buildOptions.unstable_phase = 'buildDeploy';
+  buildOptions.unstable_phase = 'buildDeploy';
   await buildDeploy(rootDir, config);
-  delete platformObject.buildOptions.unstable_phase;
+  delete buildOptions.unstable_phase;
 
   if (existsSync(distEntriesFile)) {
     const DIST_PLATFORM_DATA = 'platform-data';

--- a/packages/waku/src/lib/builder/build.ts
+++ b/packages/waku/src/lib/builder/build.ts
@@ -9,7 +9,7 @@ import type { ReactNode } from 'react';
 import type { Config } from '../../config.js';
 import {
   setAllEnvInternal,
-  iterateAllPlatformDataInternal,
+  iterateSerializablePlatformDataInternal,
   unstable_getPlatformObject,
 } from '../../server.js';
 import type { EntriesPrd } from '../types.js';
@@ -771,7 +771,7 @@ export async function build(options: {
     await mkdir(joinPath(rootDir, config.distDir, DIST_PLATFORM_DATA), {
       recursive: true,
     });
-    for (const [key, data] of iterateAllPlatformDataInternal()) {
+    for (const [key, data] of iterateSerializablePlatformDataInternal()) {
       keys.add(key);
       const destFile = joinPath(
         rootDir,

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-aws-lambda.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { writeFileSync } from 'node:fs';
 import type { Plugin } from 'vite';
 
-import { unstable_getPlatformObject } from '../../server.js';
+import { unstable_getBuildOptions } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_PUBLIC } from '../builder/constants.js';
 
@@ -57,12 +57,12 @@ export function deployAwsLambdaPlugin(opts: {
   srcDir: string;
   distDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let entriesFile: string;
   return {
     name: 'deploy-aws-lambda-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildServerBundle' || deploy !== 'aws-lambda') {
         return;
       }
@@ -85,7 +85,7 @@ export function deployAwsLambdaPlugin(opts: {
       }
     },
     closeBundle() {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildDeploy' || deploy !== 'aws-lambda') {
         return;
       }

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -14,7 +14,7 @@ import { randomBytes } from 'node:crypto';
 import type { Plugin } from 'vite';
 
 import {
-  iterateAllPlatformDataInternal,
+  iterateSerializablePlatformDataInternal,
   unstable_getPlatformObject,
 } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
@@ -215,7 +215,7 @@ export function deployCloudflarePlugin(opts: {
       mkdirSync(path.join(workerDistDir, DIST_PLATFORM_DATA), {
         recursive: true,
       });
-      for (const [key, data] of iterateAllPlatformDataInternal()) {
+      for (const [key, data] of iterateSerializablePlatformDataInternal()) {
         keys.add(key);
         const destFile = path.join(
           workerDistDir,

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-cloudflare.ts
@@ -15,7 +15,7 @@ import type { Plugin } from 'vite';
 
 import {
   iterateSerializablePlatformDataInternal,
-  unstable_getPlatformObject,
+  unstable_getBuildOptions,
 } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_ENTRIES_JS, DIST_PUBLIC } from '../builder/constants.js';
@@ -150,13 +150,13 @@ export function deployCloudflarePlugin(opts: {
   distDir: string;
   privateDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let rootDir: string;
   let entriesFile: string;
   return {
     name: 'deploy-cloudflare-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildServerBundle' || deploy !== 'cloudflare') {
         return;
       }
@@ -168,7 +168,7 @@ export function deployCloudflarePlugin(opts: {
     configResolved(config) {
       rootDir = config.root;
       entriesFile = `${rootDir}/${opts.srcDir}/${SRC_ENTRIES}`;
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         (unstable_phase !== 'buildServerBundle' &&
           unstable_phase !== 'buildSsrBundle') ||
@@ -194,7 +194,7 @@ export function deployCloudflarePlugin(opts: {
       }
     },
     closeBundle() {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildDeploy' || deploy !== 'cloudflare') {
         return;
       }

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-deno.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite';
 
-import { unstable_getPlatformObject } from '../../server.js';
+import { unstable_getBuildOptions } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_PUBLIC } from '../builder/constants.js';
 
@@ -49,12 +49,12 @@ export function deployDenoPlugin(opts: {
   srcDir: string;
   distDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let entriesFile: string;
   return {
     name: 'deploy-deno-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildServerBundle' || deploy !== 'deno') {
         return;
       }
@@ -65,7 +65,7 @@ export function deployDenoPlugin(opts: {
     },
     configResolved(config) {
       entriesFile = `${config.root}/${opts.srcDir}/${SRC_ENTRIES}`;
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         (unstable_phase !== 'buildServerBundle' &&
           unstable_phase !== 'buildSsrBundle') ||

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-netlify.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import type { Plugin } from 'vite';
 
-import { unstable_getPlatformObject } from '../../server.js';
+import { unstable_getBuildOptions } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_PUBLIC } from '../builder/constants.js';
 
@@ -40,13 +40,13 @@ export function deployNetlifyPlugin(opts: {
   distDir: string;
   privateDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let rootDir: string;
   let entriesFile: string;
   return {
     name: 'deploy-netlify-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         unstable_phase !== 'buildServerBundle' ||
         (deploy !== 'netlify-functions' && deploy !== 'netlify-static')
@@ -73,7 +73,7 @@ export function deployNetlifyPlugin(opts: {
       }
     },
     closeBundle() {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         unstable_phase !== 'buildDeploy' ||
         (deploy !== 'netlify-functions' && deploy !== 'netlify-static')

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-partykit.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { existsSync, writeFileSync } from 'node:fs';
 import type { Plugin } from 'vite';
 
-import { unstable_getPlatformObject } from '../../server.js';
+import { unstable_getBuildOptions } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_PUBLIC } from '../builder/constants.js';
 
@@ -58,13 +58,13 @@ export function deployPartykitPlugin(opts: {
   srcDir: string;
   distDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let rootDir: string;
   let entriesFile: string;
   return {
     name: 'deploy-partykit-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildServerBundle' || deploy !== 'partykit') {
         return;
       }
@@ -76,7 +76,7 @@ export function deployPartykitPlugin(opts: {
     configResolved(config) {
       rootDir = config.root;
       entriesFile = `${rootDir}/${opts.srcDir}/${SRC_ENTRIES}`;
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         (unstable_phase !== 'buildServerBundle' &&
           unstable_phase !== 'buildSsrBundle') ||
@@ -102,7 +102,7 @@ export function deployPartykitPlugin(opts: {
       }
     },
     closeBundle() {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (unstable_phase !== 'buildDeploy' || deploy !== 'partykit') {
         return;
       }

--- a/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-deploy-vercel.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { cpSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import type { Plugin } from 'vite';
 
-import { unstable_getPlatformObject } from '../../server.js';
+import { unstable_getBuildOptions } from '../../server.js';
 import { SRC_ENTRIES } from '../constants.js';
 import { DIST_PUBLIC } from '../builder/constants.js';
 
@@ -52,13 +52,13 @@ export function deployVercelPlugin(opts: {
   rscBase: string;
   privateDir: string;
 }): Plugin {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   let rootDir: string;
   let entriesFile: string;
   return {
     name: 'deploy-vercel-plugin',
     config(viteConfig) {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         unstable_phase !== 'buildServerBundle' ||
         (deploy !== 'vercel-serverless' && deploy !== 'vercel-static')
@@ -85,7 +85,7 @@ export function deployVercelPlugin(opts: {
       }
     },
     closeBundle() {
-      const { deploy, unstable_phase } = platformObject.buildOptions || {};
+      const { deploy, unstable_phase } = buildOptions;
       if (
         unstable_phase !== 'buildDeploy' ||
         (deploy !== 'vercel-serverless' && deploy !== 'vercel-static')

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -437,7 +437,11 @@ globalThis.__WAKU_ROUTER_PREFETCH__ = (path) => {
         });
       }
 
-      await unstable_setPlatformData('defineRouterPathConfigs', pathConfig);
+      await unstable_setPlatformData(
+        'defineRouterPathConfigs',
+        pathConfig,
+        true,
+      );
       return tasks;
     });
 

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -1,7 +1,7 @@
 import {
   unstable_getPlatformData,
   unstable_setPlatformData,
-  unstable_getPlatformObject,
+  unstable_getBuildOptions,
 } from '../server.js';
 import { createPages, METHODS } from './create-pages.js';
 import type { Method } from './create-pages.js';
@@ -15,7 +15,7 @@ export function fsRouter(
   loadPage: (file: string) => Promise<any> | undefined,
   pages: string,
 ) {
-  const platformObject = unstable_getPlatformObject();
+  const buildOptions = unstable_getBuildOptions();
   return createPages(
     async ({ createPage, createLayout, createRoot, createApi }) => {
       let files = await unstable_getPlatformData<string[]>('fsRouterFiles');
@@ -58,7 +58,7 @@ export function fsRouter(
         });
       }
       // build only - skip in dev
-      if (platformObject.buildOptions?.unstable_phase) {
+      if (buildOptions.unstable_phase) {
         await unstable_setPlatformData('fsRouterFiles', files, true);
       }
       for (const file of files) {

--- a/packages/waku/src/router/fs-router.ts
+++ b/packages/waku/src/router/fs-router.ts
@@ -59,7 +59,7 @@ export function fsRouter(
       }
       // build only - skip in dev
       if (platformObject.buildOptions?.unstable_phase) {
-        await unstable_setPlatformData('fsRouterFiles', files);
+        await unstable_setPlatformData('fsRouterFiles', files, true);
       }
       for (const file of files) {
         const mod = await loadPage(file);

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -20,8 +20,9 @@ export function getEnv(key: string): string | undefined {
 export function iterateSerializablePlatformDataInternal(): Iterable<
   [string, unknown]
 > {
-  const platformData: Record<string, [unknown, boolean]> =
-    (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ || {};
+  const platformData: Record<string, [unknown, boolean]> = ((
+    globalThis as any
+  ).__WAKU_SERVER_PLATFORM_DATA__ ||= {});
   return Object.entries(platformData).flatMap(([key, [data, serializable]]) =>
     serializable ? [[key, data]] : [],
   );
@@ -41,16 +42,18 @@ export async function unstable_setPlatformData<T>(
   data: T,
   serializable: boolean,
 ): Promise<void> {
-  const platformData: Record<string, [unknown, boolean]> =
-    (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ || {};
+  const platformData: Record<string, [unknown, boolean]> = ((
+    globalThis as any
+  ).__WAKU_SERVER_PLATFORM_DATA__ ||= {});
   platformData[key] = [data, serializable];
 }
 
 export async function unstable_getPlatformData<T>(
   key: string,
 ): Promise<T | undefined> {
-  const platformData: Record<string, [unknown, boolean]> =
-    (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ || {};
+  const platformData: Record<string, [unknown, boolean]> = ((
+    globalThis as any
+  ).__WAKU_SERVER_PLATFORM_DATA__ ||= {});
   const item = platformData[key];
   if (item) {
     return item[0] as T;

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -22,7 +22,9 @@ export function iterateSerializablePlatformDataInternal(): Iterable<
 > {
   const platformData: Record<string, [unknown, boolean]> =
     (globalThis as any).__WAKU_SERVER_PLATFORM_DATA__ || {};
-  return Object.entries(platformData).map(([key, [data]]) => [key, data]);
+  return Object.entries(platformData).flatMap(([key, [data, serializable]]) =>
+    serializable ? [[key, data]] : [],
+  );
 }
 
 /**

--- a/packages/waku/src/server.ts
+++ b/packages/waku/src/server.ts
@@ -65,31 +65,29 @@ export function unstable_getHeaders(): Readonly<Record<string, string>> {
   return getContext().req.headers;
 }
 
-type PlatformObject = {
-  buildOptions?: {
-    deploy?:
-      | 'vercel-static'
-      | 'vercel-serverless'
-      | 'netlify-static'
-      | 'netlify-functions'
-      | 'cloudflare'
-      | 'partykit'
-      | 'deno'
-      | 'aws-lambda'
-      | undefined;
-    unstable_phase?:
-      | 'analyzeEntries'
-      | 'buildServerBundle'
-      | 'buildSsrBundle'
-      | 'buildClientBundle'
-      | 'buildDeploy'
-      | 'emitStaticFiles';
-  };
-} & Record<string, unknown>;
+type BuildOptions = {
+  deploy?:
+    | 'vercel-static'
+    | 'vercel-serverless'
+    | 'netlify-static'
+    | 'netlify-functions'
+    | 'cloudflare'
+    | 'partykit'
+    | 'deno'
+    | 'aws-lambda'
+    | undefined;
+  unstable_phase?:
+    | 'analyzeEntries'
+    | 'buildServerBundle'
+    | 'buildSsrBundle'
+    | 'buildClientBundle'
+    | 'buildDeploy'
+    | 'emitStaticFiles';
+};
 
 // TODO tentative name
-export function unstable_getPlatformObject(): PlatformObject {
-  return ((globalThis as any).__WAKU_PLATFORM_OBJECT__ ||= {});
+export function unstable_getBuildOptions(): BuildOptions {
+  return ((globalThis as any).__WAKU_BUILD_OPTIONS__ ||= {});
 }
 
 export function unstable_createAsyncIterable<T extends () => unknown>(


### PR DESCRIPTION
- support both serializable and non-serializable platform data
- simplify buildOptions

It's a refactor, but it's also kind of a breaking change, if people depend on the unstable features.