### PR TITLE
feat(create-pages): support for exactPath

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -143,5 +143,12 @@ for (const mode of ['DEV', 'PRD'] as const) {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe('POST to hello world! from the test!');
     });
+
+    test('exactPath', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/exact/[slug]/[...wild]`);
+      await expect(
+        page.getByRole('heading', { name: 'EXACTLY!!' }),
+      ).toBeVisible();
+    });
   });
 }

--- a/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/HomeLayout.tsx
@@ -61,6 +61,9 @@ const HomeLayout = ({ children }: { children: ReactNode }) => (
       <li>
         <Link to="/error">Error</Link>
       </li>
+      <li>
+        <Link to="/exact/[slug]/[...wild]">Exact Path</Link>
+      </li>
     </ul>
     {children}
   </div>

--- a/e2e/fixtures/create-pages/src/entries.tsx
+++ b/e2e/fixtures/create-pages/src/entries.tsx
@@ -133,6 +133,13 @@ const pages: ReturnType<typeof createPages> = createPages(
         return new Response(null);
       },
     }),
+
+    createPage({
+      render: 'static',
+      path: '/exact/[slug]/[...wild]',
+      exactPath: true,
+      component: () => <h1>EXACTLY!!</h1>,
+    }),
   ],
 );
 

--- a/packages/waku/src/lib/utils/path.ts
+++ b/packages/waku/src/lib/utils/path.ts
@@ -61,7 +61,13 @@ export const joinPath = (...paths: string[]) => {
 
 export const extname = (filePath: string) => {
   const index = filePath.lastIndexOf('.');
-  return index > 0 ? filePath.slice(index) : '';
+  if (index <= 0) {
+    return '';
+  }
+  if (['/', '.'].includes(filePath[index - 1]!)) {
+    return '';
+  }
+  return filePath.slice(index);
 };
 
 export type PathSpecItem =

--- a/packages/waku/src/lib/utils/path.ts
+++ b/packages/waku/src/lib/utils/path.ts
@@ -89,6 +89,12 @@ export const parsePathWithSlug = (path: string): PathSpec =>
       return { type, name };
     });
 
+export const parseExactPath = (path: string): PathSpec =>
+  path
+    .split('/')
+    .filter(Boolean)
+    .map((name) => ({ type: 'literal', name }));
+
 /**
  * Transform a path spec to a regular expression.
  */

--- a/packages/waku/src/router/create-pages.ts
+++ b/packages/waku/src/router/create-pages.ts
@@ -108,7 +108,7 @@ export type CreatePage = <
   WildSlugKey extends string,
   Render extends 'static' | 'dynamic',
   StaticPaths extends StaticSlugRoutePaths<Path>,
-  EP extends boolean | undefined = undefined,
+  ExactPath extends boolean | undefined = undefined,
 >(
   page: (
     | {
@@ -120,7 +120,7 @@ export type CreatePage = <
         render: Extract<Render, 'static'>;
         path: PathWithStaticSlugs<Path>;
         component: FunctionComponent<PropsForPages<Path>>;
-      } & (EP extends true ? {} : { staticPaths: StaticPaths }))
+      } & (ExactPath extends true ? {} : { staticPaths: StaticPaths }))
     | {
         render: Extract<Render, 'dynamic'>;
         path: PathWithoutSlug<Path>;
@@ -137,7 +137,7 @@ export type CreatePage = <
      * If true, the path will be matched exactly, without wildcards or slugs.
      * This is intended for extending support to create custom routers.
      */
-    exactPath?: EP;
+    exactPath?: ExactPath;
   },
 ) => Omit<
   Exclude<typeof page, { path: never } | { render: never }>,

--- a/packages/waku/src/router/create-pages.ts
+++ b/packages/waku/src/router/create-pages.ts
@@ -8,6 +8,7 @@ import {
   parsePathWithSlug,
   getPathMapping,
   pathSpecAsString,
+  parseExactPath,
 } from '../lib/utils/path.js';
 import type { PathSpec } from '../lib/utils/path.js';
 import type {
@@ -107,6 +108,7 @@ export type CreatePage = <
   WildSlugKey extends string,
   Render extends 'static' | 'dynamic',
   StaticPaths extends StaticSlugRoutePaths<Path>,
+  EP extends boolean | undefined = undefined,
 >(
   page: (
     | {
@@ -114,12 +116,11 @@ export type CreatePage = <
         path: PathWithoutSlug<Path>;
         component: FunctionComponent<PropsForPages<Path>>;
       }
-    | {
+    | ({
         render: Extract<Render, 'static'>;
         path: PathWithStaticSlugs<Path>;
-        staticPaths: StaticPaths;
         component: FunctionComponent<PropsForPages<Path>>;
-      }
+      } & (EP extends true ? {} : { staticPaths: StaticPaths }))
     | {
         render: Extract<Render, 'dynamic'>;
         path: PathWithoutSlug<Path>;
@@ -130,7 +131,14 @@ export type CreatePage = <
         path: PathWithWildcard<Path, SlugKey, WildSlugKey>;
         component: FunctionComponent<PropsForPages<Path>>;
       }
-  ) & { unstable_disableSSR?: boolean },
+  ) & {
+    unstable_disableSSR?: boolean;
+    /**
+     * If true, the path will be matched exactly, without wildcards or slugs.
+     * This is intended for extending support to create custom routers.
+     */
+    exactPath?: EP;
+  },
 ) => Omit<
   Exclude<typeof page, { path: never } | { render: never }>,
   'unstable_disableSSR'
@@ -337,7 +345,19 @@ export const createPages = <
       }
       return { numSlugs, numWildcards };
     })();
-    if (page.render === 'static' && numSlugs === 0) {
+
+    if (page.exactPath) {
+      const spec = parseExactPath(page.path);
+      if (page.render === 'static') {
+        staticPathMap.set(page.path, {
+          literalSpec: parseExactPath(page.path),
+        });
+        const id = joinPath(page.path, 'page').replace(/^\//, '');
+        registerStaticComponent(id, page.component);
+      } else {
+        dynamicPagePathMap.set(page.path, [spec, page.component]);
+      }
+    } else if (page.render === 'static' && numSlugs === 0) {
       staticPathMap.set(page.path, { literalSpec: pathSpec });
       const id = joinPath(page.path, 'page').replace(/^\//, '');
       registerStaticComponent(id, page.component);

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -291,16 +291,17 @@ export function unstable_defineRouter(fns: {
       rendered = true;
       return renderRsc({ ...(await elementsPromise), _value: value });
     }
-    const pathConfigItem = await getPathConfigItem(input.pathname);
+    const cleanPath = decodeURIComponent(input.pathname);
+    const pathConfigItem = await getPathConfigItem(cleanPath);
     if (pathConfigItem?.specs?.isApi && fns.handleApi) {
-      return fns.handleApi(input.pathname, {
+      return fns.handleApi(cleanPath, {
         body: input.req.body,
         headers: input.req.headers,
         method: input.req.method,
       });
     }
     if (input.type === 'action' || input.type === 'custom') {
-      let pathname = input.pathname;
+      let pathname = cleanPath;
       const query = input.req.url.searchParams.toString();
       if (pathConfigItem?.specs?.noSsr) {
         return null;

--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -291,17 +291,16 @@ export function unstable_defineRouter(fns: {
       rendered = true;
       return renderRsc({ ...(await elementsPromise), _value: value });
     }
-    const cleanPath = decodeURIComponent(input.pathname);
-    const pathConfigItem = await getPathConfigItem(cleanPath);
+    const pathConfigItem = await getPathConfigItem(input.pathname);
     if (pathConfigItem?.specs?.isApi && fns.handleApi) {
-      return fns.handleApi(cleanPath, {
+      return fns.handleApi(input.pathname, {
         body: input.req.body,
         headers: input.req.headers,
         method: input.req.method,
       });
     }
     if (input.type === 'action' || input.type === 'custom') {
-      let pathname = cleanPath;
+      let pathname = input.pathname;
       const query = input.req.url.searchParams.toString();
       if (pathConfigItem?.specs?.noSsr) {
         return null;

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -1385,3 +1385,204 @@ describe('createPages api', () => {
     expect(res.status).toEqual(200);
   });
 });
+
+describe('createPages - exactPath', () => {
+  it('creates a simple static page', async () => {
+    const TestPage = () => null;
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'static',
+        path: '/test',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test': { isStatic: true },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [{ name: 'test', type: 'literal' }],
+      },
+    ]);
+    const route = await handleRoute('/test', {
+      query: '?skip=[]',
+    });
+    expect(route).toBeDefined();
+    expect(route.rootElement).toBeDefined();
+    expect(route.routeElement).toBeDefined();
+    expect(Object.keys(route.elements)).toEqual(['page:/test']);
+  });
+
+  it('creates a simple dynamic page', async () => {
+    const TestPage = () => null;
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'dynamic',
+        path: '/test',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test': { isStatic: false },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [{ name: 'test', type: 'literal' }],
+      },
+    ]);
+    const route = await handleRoute('/test', {
+      query: '?skip=[]',
+    });
+    expect(route).toBeDefined();
+    expect(route.rootElement).toBeDefined();
+    expect(route.routeElement).toBeDefined();
+    expect(Object.keys(route.elements)).toEqual(['page:/test']);
+  });
+
+  it('works with a slug path', async () => {
+    const TestPage = vi.fn();
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'static',
+        path: '/test/[slug]',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test/[slug]': { isStatic: true },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [
+          { name: 'test', type: 'literal' },
+          { name: '[slug]', type: 'literal' },
+        ],
+      },
+    ]);
+    const route = await handleRoute('/test/[slug]', {
+      query: '?skip=[]',
+    });
+    expect(route).toBeDefined();
+    expect(route.rootElement).toBeDefined();
+    expect(route.routeElement).toBeDefined();
+    expect(Object.keys(route.elements)).toEqual(['page:/test/[slug]']);
+  });
+
+  it('works with a wildcard path', async () => {
+    const TestPage = vi.fn();
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'static',
+        path: '/test/[...wildcard]',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test/[...wildcard]': { isStatic: true },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [
+          { name: 'test', type: 'literal' },
+          { name: '[...wildcard]', type: 'literal' },
+        ],
+      },
+    ]);
+    const route = await handleRoute('/test/[...wildcard]', {
+      query: '?skip=[]',
+    });
+    expect(route).toBeDefined();
+    expect(route.rootElement).toBeDefined();
+    expect(route.routeElement).toBeDefined();
+    expect(Object.keys(route.elements)).toEqual(['page:/test/[...wildcard]']);
+  });
+
+  it('works with wildcard and slug path', async () => {
+    const TestPage = vi.fn();
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'static',
+        path: '/test/[...wildcard]/[slug]',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test/[...wildcard]/[slug]': { isStatic: true },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [
+          { name: 'test', type: 'literal' },
+          { name: '[...wildcard]', type: 'literal' },
+          { name: '[slug]', type: 'literal' },
+        ],
+      },
+    ]);
+    const route = await handleRoute('/test/[...wildcard]/[slug]', {
+      query: '?skip=[]',
+    });
+    expect(route).toBeDefined();
+    expect(route.rootElement).toBeDefined();
+    expect(route.routeElement).toBeDefined();
+    expect(Object.keys(route.elements)).toEqual([
+      'page:/test/[...wildcard]/[slug]',
+    ]);
+  });
+
+  it('does not work with slug match', async () => {
+    const TestPage = vi.fn();
+    createPages(async ({ createPage }) => [
+      createPage({
+        render: 'static',
+        path: '/test/[slug]',
+        exactPath: true,
+        component: TestPage,
+      }),
+    ]);
+    const { getRouteConfig, handleRoute } = injectedFunctions();
+    expect(await getRouteConfig()).toEqual([
+      {
+        elements: {
+          'page:/test/[slug]': { isStatic: true },
+        },
+        rootElement: { isStatic: true },
+        routeElement: { isStatic: true },
+        noSsr: false,
+        path: [
+          { name: 'test', type: 'literal' },
+          { name: '[slug]', type: 'literal' },
+        ],
+      },
+    ]);
+    await expect(async () => {
+      return handleRoute('/test/foo', {
+        query: '?skip=[]',
+      });
+    }).rejects.toThrowError();
+  });
+});

--- a/packages/waku/tests/path.test.ts
+++ b/packages/waku/tests/path.test.ts
@@ -1,9 +1,22 @@
 import { test, describe, expect } from 'vitest';
-import { parsePathWithSlug, path2regexp } from '../src/lib/utils/path.js';
+import {
+  extname,
+  parsePathWithSlug,
+  path2regexp,
+} from '../src/lib/utils/path.js';
 
 function matchPath(path: string, input: string) {
   return new RegExp(path2regexp(parsePathWithSlug(path))).test(input);
 }
+
+describe('extname', () => {
+  test('returns the extension of a path', () => {
+    expect(extname('foo/bar/baz.js')).toBe('.js');
+    expect(extname('foo/bar/baz')).toBe('');
+    expect(extname('foo/bar/.baz')).toBe('');
+    expect(extname('foo/bar/..baz')).toBe('');
+  });
+});
 
 describe('path2regexp', () => {
   test('handles paths without slugs', () => {


### PR DESCRIPTION
escape hatch for allowing any routing conventions at all