### PR TITLE
feat(create-waku): Add support for bun package manager

### DIFF
--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -21,6 +21,7 @@ const userAgent = process.env.npm_config_user_agent || '';
 
 // Bun doesn't update `npm_config_user_agent`
 // so fallback to checking if the `Bun` global is present
+// https://github.com/oven-sh/bun/issues/2530
 const isBun = 'Bun' in globalThis;
 
 const packageManager = isBun

--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -1,28 +1,36 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
-import { default as prompts } from 'prompts';
-import { red, green, bold } from 'kolorist';
 import fse from 'fs-extra/esm';
+import { bold, green, red } from 'kolorist';
+import { default as prompts } from 'prompts';
 import checkForUpdate from 'update-check';
+import {
+  downloadAndExtract,
+  parseExampleOption,
+} from './helpers/example-option.js';
 import {
   getTemplateNames,
   installTemplate,
 } from './helpers/install-template.js';
-import {
-  parseExampleOption,
-  downloadAndExtract,
-} from './helpers/example-option.js';
-import { spawn } from 'node:child_process';
 
 const userAgent = process.env.npm_config_user_agent || '';
-const packageManager = /pnpm/.test(userAgent)
-  ? 'pnpm'
-  : /yarn/.test(userAgent)
-    ? 'yarn'
-    : 'npm';
+
+// Bun doesn't update `npm_config_user_agent`
+// so fallback to checking if the `Bun` global is present
+const isBun = 'Bun' in globalThis;
+
+const packageManager = isBun
+  ? 'bun'
+  : /pnpm/.test(userAgent)
+    ? 'pnpm'
+    : /yarn/.test(userAgent)
+      ? 'yarn'
+      : 'npm';
+
 const commands = {
   pnpm: {
     install: 'pnpm install',
@@ -38,6 +46,11 @@ const commands = {
     install: 'npm install',
     dev: 'npm run dev',
     create: 'npm create waku',
+  },
+  bun: {
+    install: 'bun install',
+    dev: 'bun dev',
+    create: 'bun create waku',
   },
 }[packageManager];
 


### PR DESCRIPTION
Closes: #1228 

This change adds support for the `bun` package manager when running `create-waku`.

From some local testing, it seemed like bun didn't set the `process.env.npm_config_user_agent` variable correctly (it does so when running `bun repl` though...), so instead I opted to fallback to checking if the `Bun` global was defined, which seems to be present when running the package via `bun`.

I was also considering checking against `process.argv0` which I think would be `'bun'`, however I'm not 100% sure since I was running the cli manually via `bun ./path/to/cli.js` vs `bun create waku`.