### PR TITLE
fix(create-waku): remove tsbuildinfo files from template

### DIFF
--- a/packages/create-waku/package.json
+++ b/packages/create-waku/package.json
@@ -22,7 +22,7 @@
     "start": "node ./dist/index.js",
     "dev": "pnpm build --watch",
     "compile": "rm -rf template dist *.tsbuildinfo && pnpm run template && pnpm run build",
-    "template": "cp -r ../../examples template && rm -rf template/*/dist && rm -rf template/*/node_modules && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)",
+    "template": "cp -r ../../examples template && rm -rf template/*/dist && rm -rf template/*/node_modules && rm -rf template/*.tsbuildinfo && (for d in template/*; do mv $d/.gitignore $d/gitignore || true; done)",
     "build": "tsup"
   },
   "devDependencies": {


### PR DESCRIPTION
It's been there since v0.10.2.
https://unpkg.com/browse/create-waku@0.10.2/template/01_template/tsconfig.tsbuildinfo