### PR TITLE
fix(create-pages): Ensure dynamic layouts receive path prop

### DIFF
--- a/e2e/create-pages.spec.ts
+++ b/e2e/create-pages.spec.ts
@@ -35,6 +35,16 @@ for (const mode of ['DEV', 'PRD'] as const) {
       await expect(page.getByRole('heading', { name: 'Foo' })).toBeVisible();
     });
 
+    test('dynamic', async ({ page }) => {
+      await page.goto(`http://localhost:${port}/dynamic`);
+      await expect(page.getByRole('navigation')).toHaveText(
+        'Current path: /dynamic',
+      );
+      await expect(
+        page.getByRole('heading', { name: 'Dynamic Page' }),
+      ).toBeVisible();
+    });
+
     test('nested/foo', async ({ page }) => {
       // /nested/foo is defined as a staticPath of /nested/[id] which matches this layout
       await page.goto(`http://localhost:${port}/nested/foo`);

--- a/e2e/fixtures/create-pages/src/components/DynamicLayout.tsx
+++ b/e2e/fixtures/create-pages/src/components/DynamicLayout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export default function DynamicLayout({
+  children,
+  path,
+}: {
+  children: ReactNode;
+  path: string;
+}) {
+  return (
+    <>
+      <nav>Current path: {path}</nav>
+      {children}
+    </>
+  );
+}

--- a/e2e/fixtures/create-pages/src/entries.tsx
+++ b/e2e/fixtures/create-pages/src/entries.tsx
@@ -3,6 +3,7 @@ import type { PathsForPages } from 'waku/router';
 
 import FooPage from './components/FooPage.js';
 import HomeLayout from './components/HomeLayout.js';
+import DynamicLayout from './components/DynamicLayout.js';
 import HomePage from './components/HomePage.js';
 import NestedBazPage from './components/NestedBazPage.js';
 import NestedLayout from './components/NestedLayout.js';
@@ -139,6 +140,18 @@ const pages: ReturnType<typeof createPages> = createPages(
       path: '/exact/[slug]/[...wild]',
       exactPath: true,
       component: () => <h1>EXACTLY!!</h1>,
+    }),
+
+    createLayout({
+      render: 'dynamic',
+      path: '/dynamic',
+      component: DynamicLayout,
+    }),
+
+    createPage({
+      render: 'dynamic',
+      path: '/dynamic',
+      component: () => <h1>Dynamic Page</h1>,
     }),
   ],
 );

--- a/packages/waku/src/router/create-pages.ts
+++ b/packages/waku/src/router/create-pages.ts
@@ -624,7 +624,7 @@ export const createPages = <
           dynamicLayoutPathMap.get(segment)?.[1] ??
           staticComponentMap.get(joinPath(segment, 'layout').slice(1)); // feels like a hack
 
-        const isDynamic = !dynamicLayoutPathMap.has(segment);
+        const isDynamic = dynamicLayoutPathMap.has(segment);
 
         // always true
         if (layout) {


### PR DESCRIPTION
The logic seemed to be reversed when checking if the current layout segment is dynamic or static (see `!` in create-pages.ts), so the `path` prop was never provided.

Didn't run the E2E tests locally but verified by adding a temp test to `create-pages.test.ts` locally.