### PR TITLE
fix(create-waku): Fix detection of bun using npm_config_user_agent env var

### DIFF
--- a/packages/create-waku/src/index.ts
+++ b/packages/create-waku/src/index.ts
@@ -19,12 +19,7 @@ import {
 
 const userAgent = process.env.npm_config_user_agent || '';
 
-// Bun doesn't update `npm_config_user_agent`
-// so fallback to checking if the `Bun` global is present
-// https://github.com/oven-sh/bun/issues/2530
-const isBun = 'Bun' in globalThis;
-
-const packageManager = isBun
+const packageManager = /bun/.test(userAgent)
   ? 'bun'
   : /pnpm/.test(userAgent)
     ? 'pnpm'


### PR DESCRIPTION
I noticed that running `bun create waku@latest` and `bunx create-waku@latest` didn't seem to detect `bun` as the package manager as expected based on my changes in #1229.

However - I was able to verify that both formats should work when I tested with a new dummy package: `create-debug-create`

```sh
bun create debug-create@latest
# and
bunx create-debug-create@latest
```

will print some things to the console (e.g. `process.env`, `process`, etc).

Based on running both of those - it seems like the `npm_config_user_agent` env var _does_ get populated with `bun` as expected (not sure how I was testing before where it didn't work - maybe just with running the CLI directly via `bun ./cli.mjs`?)