### PR TITLE
experimental: update e2e fixture for errors in ctx

### DIFF
--- a/e2e/fixtures/ssr-catch-error/src/components/server/throws-delayed.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/components/server/throws-delayed.tsx
@@ -1,0 +1,10 @@
+export const ThrowsDelayedComponent = async () => {
+  await new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error('Delayed unexpected error'));
+    }, 100);
+  });
+  return <div>Success</div>;
+};
+
+export default ThrowsDelayedComponent;

--- a/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
+++ b/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
@@ -25,8 +25,7 @@ const validateMiddleware: Middleware = () => {
     }
     const existingOnError = ctx.unstable_onError;
     ctx.unstable_onError = (err) => {
-
-      console.log("unstable_onError", err.message);
+      console.log('unstable_onError', err.message);
       existingOnError?.(err);
     };
     await next();

--- a/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
+++ b/e2e/fixtures/ssr-catch-error/src/middleware/validator.ts
@@ -23,7 +23,17 @@ const validateMiddleware: Middleware = () => {
     if (ctx.req.url.pathname.startsWith(`/${rscBase}/R/invalid`)) {
       ctx.data.unauthorized = true;
     }
+    const existingOnError = ctx.unstable_onError;
+    ctx.unstable_onError = (err) => {
+
+      console.log("unstable_onError", err.message);
+      existingOnError?.(err);
+    };
     await next();
+    console.log(
+      'ctx.unstable_errs',
+      ctx.unstable_errs?.map((e) => e.message),
+    );
   };
 };
 

--- a/e2e/fixtures/ssr-catch-error/src/pages/delayed.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/delayed.tsx
@@ -1,18 +1,18 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Link } from 'waku';
-import ThrowsComponent from '../components/server/throws.js';
+import ThrowsDelayedComponent from '../components/server/throws-delayed.js';
 
 export default async function HomePage() {
   return (
     <div>
-      <p>Home Page</p>
-      <Link to="/invalid">Invalid page</Link>
+      <p>Delayed Throws Page</p>
+      <Link to="/">Home page</Link>
       <br />
-      <Link to="/delayed">Delayed page</Link>
+      <Link to="/invalid">Invalid page</Link>
       <ErrorBoundary fallback={<div>Something went wrong</div>}>
         <Suspense fallback={<div>Loading...</div>}>
-          <ThrowsComponent />
+          <ThrowsDelayedComponent />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/e2e/fixtures/ssr-catch-error/src/pages/dynamic/delayed.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/dynamic/delayed.tsx
@@ -1,18 +1,16 @@
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Link } from 'waku';
-import ThrowsComponent from '../components/server/throws.js';
+import ThrowsDelayedComponent from '../../components/server/throws-delayed.js';
 
 export default async function HomePage() {
   return (
     <div>
-      <p>Home Page</p>
-      <Link to="/invalid">Invalid page</Link>
-      <br />
-      <Link to="/delayed">Delayed page</Link>
+      <p>Dynamic Delayed Page</p>
+      <Link to="/dynamic">Dynamic Home Page</Link>
       <ErrorBoundary fallback={<div>Something went wrong</div>}>
-        <Suspense fallback={<div>Loading...</div>}>
-          <ThrowsComponent />
+        <Suspense fallback={<div>Loading page...</div>}>
+          <ThrowsDelayedComponent />
         </Suspense>
       </ErrorBoundary>
     </div>
@@ -21,6 +19,6 @@ export default async function HomePage() {
 
 export const getConfig = async () => {
   return {
-    render: 'static',
+    render: 'dynamic',
   } as const;
 };

--- a/e2e/fixtures/ssr-catch-error/src/pages/dynamic/index.tsx
+++ b/e2e/fixtures/ssr-catch-error/src/pages/dynamic/index.tsx
@@ -2,12 +2,13 @@ import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Link } from 'waku';
 import ThrowsComponent from '../../components/server/throws.js';
+import ThrowsDelayedComponent from '../../components/server/throws-delayed.js';
 
 export default async function HomePage() {
   return (
     <div>
-      <p>Home Page</p>
-      <Link to="/invalid">Invalid page</Link>
+      <p>Dynamic Home Page</p>
+      <Link to="/dynamic/delayed">Dynamic delayed page</Link>
       <ErrorBoundary fallback={<div>Something went wrong</div>}>
         <Suspense fallback={<div>Loading page...</div>}>
           <ThrowsComponent />

--- a/packages/waku/src/lib/middleware/types.ts
+++ b/packages/waku/src/lib/middleware/types.ts
@@ -16,6 +16,7 @@ export type HandlerContext = {
   readonly context: Record<string, unknown>;
   readonly data: Record<string, unknown>;
   unstable_errs?: unknown[];
+  unstable_onError?: (err: unknown) => void;
   unstable_devServer?: {
     rootDir: string;
     resolveClientEntry: (id: string) => string;

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -165,7 +165,10 @@ export async function renderHtml(
   config: ConfigDev | ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
+    | 'unstable_modules'
+    | 'unstable_devServer'
+    | 'unstable_errs'
+    | 'unstable_onError'
   >,
   htmlHead: string,
   elements: Elements,
@@ -249,7 +252,7 @@ export async function renderHtml(
           if (typeof (err as any)?.digest === 'string') {
             return (err as { digest: string }).digest;
           }
-          console.log("renderHtml error");
+          console.log('renderHtml error');
           console.error(err);
         },
       },

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -165,7 +165,7 @@ export async function renderHtml(
   config: ConfigDev | ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs'
+    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
   >,
   htmlHead: string,
   elements: Elements,
@@ -244,10 +244,12 @@ export async function renderHtml(
           if (hackToIgnoreTheVeryFirstError) {
             return;
           }
+          ctx.unstable_onError?.(err);
           (ctx.unstable_errs ||= []).push(err);
           if (typeof (err as any)?.digest === 'string') {
             return (err as { digest: string }).digest;
           }
+          console.log("renderHtml error");
           console.error(err);
         },
       },

--- a/packages/waku/src/lib/renderers/rsc.ts
+++ b/packages/waku/src/lib/renderers/rsc.ts
@@ -16,7 +16,10 @@ export async function renderRsc(
   config: ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
+    | 'unstable_modules'
+    | 'unstable_devServer'
+    | 'unstable_errs'
+    | 'unstable_onError'
   >,
   elements: Record<string, unknown>,
   moduleIdCallback?: (id: string) => void,
@@ -50,7 +53,7 @@ export async function renderRsc(
         // This is not correct according to the type though.
         return (err as { digest: string }).digest;
       }
-      console.log("renderRsc error");
+      console.log('renderRsc error');
       console.error(err);
     },
   });
@@ -60,7 +63,10 @@ export function renderRscElement(
   config: ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
+    | 'unstable_modules'
+    | 'unstable_devServer'
+    | 'unstable_errs'
+    | 'unstable_onError'
   >,
   element: ReactNode,
 ): ReadableStream {
@@ -92,7 +98,7 @@ export function renderRscElement(
         // This is not correct according to the type though.
         return (err as { digest: string }).digest;
       }
-      console.log("renderRscElement onError");
+      console.log('renderRscElement onError');
       console.error(err);
     },
   });

--- a/packages/waku/src/lib/renderers/rsc.ts
+++ b/packages/waku/src/lib/renderers/rsc.ts
@@ -16,7 +16,7 @@ export async function renderRsc(
   config: ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs'
+    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
   >,
   elements: Record<string, unknown>,
   moduleIdCallback?: (id: string) => void,
@@ -44,11 +44,14 @@ export async function renderRsc(
   );
   return renderToReadableStream(elements, clientBundlerConfig, {
     onError: (err: unknown) => {
+      ctx.unstable_onError?.(err);
       (ctx.unstable_errs ||= []).push(err);
       if (typeof (err as any)?.digest === 'string') {
         // This is not correct according to the type though.
         return (err as { digest: string }).digest;
       }
+      console.log("renderRsc error");
+      console.error(err);
     },
   });
 }
@@ -57,7 +60,7 @@ export function renderRscElement(
   config: ConfigPrd,
   ctx: Pick<
     HandlerContext,
-    'unstable_modules' | 'unstable_devServer' | 'unstable_errs'
+    'unstable_modules' | 'unstable_devServer' | 'unstable_errs' | 'unstable_onError'
   >,
   element: ReactNode,
 ): ReadableStream {
@@ -83,11 +86,14 @@ export function renderRscElement(
   );
   return renderToReadableStream(element, clientBundlerConfig, {
     onError: (err: unknown) => {
+      ctx.unstable_onError?.(err);
       (ctx.unstable_errs ||= []).push(err);
       if (typeof (err as any)?.digest === 'string') {
         // This is not correct according to the type though.
         return (err as { digest: string }).digest;
       }
+      console.log("renderRscElement onError");
+      console.error(err);
     },
   });
 }


### PR DESCRIPTION
```sh
cd e2e/fixtures/ssr-catch-error
pnpm run dev
```

Open http://localhost:3000/

In the dev server logs, you should see the syncronously thrown error available to middleware in ctx.unstable_errs.

Click on "Delayed page" link. 

You should see in the log that ctx.unstable_errs is `undefined` in the middleware for that request. This is because the error is thrown after delay and there is a suspense boundary.

The unstable_onError does capture the error though. I do think it is correct to additionally add console.error into the rsc server onError so it is always printed to the console.

