### PR TITLE
fix(define-router): pass through url for api

### DIFF
--- a/packages/waku/src/router/define-router.ts
+++ b/packages/waku/src/router/define-router.ts
@@ -115,6 +115,7 @@ export function unstable_defineRouter(fns: {
   handleApi?: (
     path: string,
     options: {
+      url: URL;
       body: ReadableStream | null;
       headers: Readonly<Record<string, string>>;
       method: string;
@@ -306,6 +307,7 @@ export function unstable_defineRouter(fns: {
     const pathConfigItem = await getPathConfigItem(input.pathname);
     if (pathConfigItem?.specs?.isApi && fns.handleApi) {
       return fns.handleApi(input.pathname, {
+        url: input.req.url,
         body: input.req.body,
         headers: input.req.headers,
         method: input.req.method,
@@ -367,6 +369,7 @@ export function unstable_defineRouter(fns: {
             type: 'file',
             pathname,
             body: handleApi(pathname, {
+              url: new URL(pathname, 'http://localhost:3000'),
               body: null,
               headers: {},
               method: 'GET',

--- a/packages/waku/tests/create-pages.test.ts
+++ b/packages/waku/tests/create-pages.test.ts
@@ -573,6 +573,7 @@ describe('createPages pages and layouts', () => {
       },
     ]);
     const res = await handleApi('/test', {
+      url: new URL('http://localhost:3000/test'),
       method: 'GET',
       headers: {},
       body: null,
@@ -609,6 +610,7 @@ describe('createPages pages and layouts', () => {
       },
     ]);
     const res = await handleApi('/test/foo', {
+      url: new URL('http://localhost:3000/test/foo'),
       method: 'GET',
       headers: {},
       body: null,
@@ -1331,6 +1333,7 @@ describe('createPages api', () => {
       },
     ]);
     const res = await handleApi('/test', {
+      url: new URL('http://localhost:3000/test'),
       method: 'GET',
       headers: {},
       body: null,
@@ -1367,6 +1370,7 @@ describe('createPages api', () => {
       },
     ]);
     const res = await handleApi('/test/foo', {
+      url: new URL('http://localhost:3000/test/foo'),
       method: 'GET',
       headers: {},
       body: null,


### PR DESCRIPTION
for #1296 (not the entire fix).